### PR TITLE
TESTS: fix bug with executable file names

### DIFF
--- a/red-system/tests/quick-test/quick-test.r
+++ b/red-system/tests/quick-test/quick-test.r
@@ -75,7 +75,7 @@ qt: make object! [
     
     ;; move the executable from /builds to /tests/runnable
     built: join %../builds/ [exe]
-    runner: join %runnable [exe]
+    runner: join %runnable/ [exe]
     if exists? built [
       write/binary runner read/binary built
       delete built


### PR DESCRIPTION
A single change so that executables are moved to the runnable directory rather than the test directory with runnable prefixed to their name.

The whole file is highlighted as changed as I have changed the line endings to newline.
