### PR TITLE
TESTS: exit and return tests - converted to quick-test

### DIFF
--- a/red-system/tests/source/compiler/exit-test.r
+++ b/red-system/tests/source/compiler/exit-test.r
@@ -1,0 +1,47 @@
+REBOL [
+	Title:   "Red/System EXIT keyword test script"
+	Author:  "Nenad Rakocevic"
+	File: 	 %exit-test.reds
+	Rights:  "Copyright (C) 2011 Nenad Rakocevic. All rights reserved."
+	License: "BSD-3 - https://github.com/dockimbel/Red/blob/origin/BSD-3-License.txt"
+]
+
+change-dir %../
+
+qt/start-file "exit-compile"
+
+;; simple test of complie and run
+write %runnable/exit.reds "Red/System[]^/test: does [exit]^/test" 
+either exe: qt/compile src: %runnable/exit.reds [
+  qt/run exe
+  qt/assert "exit-compile-1" qt/output = ""
+][
+  qt/compile-error src 
+]
+if exists? %runnable/exit.reds [delete %runnable/exit.reds]
+if all [
+  exe
+  exists? exe
+][
+  delete exe
+]
+
+;; test of exit as last statement in until block
+write %runnable/exit.reds 
+  {Red/System[]
+    until [exit]
+  }
+exe: qt/compile src: %runnable/exit.reds
+qt/assert "exit-compile-2" none <> find qt/comp-output "*** datatype not allowed"
+if exists? %runnable/exit.reds [delete %runnable/exit.reds]
+if all
+[
+  exe
+  exists? exe
+][
+  delete exe
+]
+
+qt/end-file
+
+

--- a/red-system/tests/source/compiler/return-test.r
+++ b/red-system/tests/source/compiler/return-test.r
@@ -1,0 +1,30 @@
+REBOL [
+	Title:   "Red/System RETURN keyword test script"
+	Author:  "Nenad Rakocevic"
+	File: 	 %return-test.reds
+	Rights:  "Copyright (C) 2011 Nenad Rakocevic. All rights reserved."
+	License: "BSD-3 - https://github.com/dockimbel/Red/blob/origin/BSD-3-License.txt"
+]
+
+change-dir %../
+
+qt/start-file "return-compile"
+
+;; test of return as last statement in until block
+write %runnable/return.reds 
+  {Red/System[]
+    until [return]
+  }
+exe: qt/compile src: %runnable/return.reds
+qt/assert "return-compile-2" none <> find qt/comp-output "*** datatype not allowed"
+if exists? %runnable/return.reds [delete %runnable/return.reds]
+if all [
+  exe
+  exists? exe
+][
+  delete exe
+]
+
+qt/end-file
+
+

--- a/red-system/tests/source/rs-test-suite.r
+++ b/red-system/tests/source/rs-test-suite.r
@@ -9,7 +9,9 @@ if not value? 'qt [do %quick-test-quick-test.r]
        
 qt/start-test-run "Red/System Test Suite - Part II"
 
-qt/run-script %source/compiler/output-test.r
 qt/run-script %source/compiler/comp-err-test.r
+qt/run-script %source/compiler/exit-test.r
+qt/run-script %source/compiler/output-test.r
+qt/run-script %source/compiler/return-test.r
 
 qt/end-test-run

--- a/red-system/tests/source/rs-test-suite.reds
+++ b/red-system/tests/source/rs-test-suite.reds
@@ -8,13 +8,15 @@ Red/System [
 
 qt-start-run "Red/System Test Suite - Part I"
 
+#include %units/exit-test.reds
+qt-update-totals
 #include %units/logic-test.reds
 qt-update-totals
-
 #include %units/modulo-test.reds
 qt-update-totals
-
 #include %units/not-test.reds
+qt-update-totals
+#include %units/return-test.reds
 qt-update-totals
 
 qt-end-run

--- a/red-system/tests/source/units/exit-test.reds
+++ b/red-system/tests/source/units/exit-test.reds
@@ -1,0 +1,107 @@
+Red/System [
+	Title:   "Red/System EXIT keyword test script"
+	Author:  "Nenad Rakocevic"
+	File: 	 %exit-test.reds
+	Rights:  "Copyright (C) 2011 Nenad Rakocevic. All rights reserved."
+	License: "BSD-3 - https://github.com/dockimbel/Red/blob/origin/BSD-3-License.txt"
+]
+
+#include %../../quick-test/quick-test.reds
+
+qt-start-file "exit"
+
+i: 0
+test99: func [] [
+	exit
+	i: 1
+]
+test99
+qt-assert "exit-1" i = 0
+
+i: 0
+test2: func [] [
+	i: 1
+	exit
+	i: 2
+]
+test2
+qt-assert "exit-2" i = 1
+
+
+i: 0
+test3: func [] [
+	i: 1
+	if true [exit]
+	i: 2
+]
+test3
+qt-assert "exit-3" i = 1
+
+i: 0
+test4: func [] [
+	i: 1
+	if false [exit]
+	i: 2
+]
+test4
+qt-assert "exit-4" i = 2
+
+i: 0
+test5: func [] [
+	i: 1
+	either true [exit][i: 2]
+	i: 3
+]
+test5
+qt-assert "exit-5" i = 1
+
+i: 0
+test6: func [] [
+	i: 0
+	either false [exit][i: 1 exit]
+	i: 2
+]
+test6
+qt-assert "exit-6" i = 1
+
+i: 0
+test7: func [] [
+	i: 1
+	either 1 < 2 [
+		exit
+	][
+		i: 2
+	]
+	i: 3
+]
+test7
+qt-assert "exit-7" i = 1
+
+;; test "exit-8" moved to exit-test.r
+
+i: 0
+test9: func [] [
+	i: 1
+	until [
+		exit
+		true
+	]
+	i: 2
+]
+test9
+qt-assert "exit-9" i = 1
+
+i: 0
+test10: func [] [
+	i: 1
+	until [
+		if true [exit]
+		i: 2
+		true
+	]
+	i: 3
+]
+test10
+qt-assert "exit-10" i = 1
+
+qt-end-file

--- a/red-system/tests/source/units/return-test.reds
+++ b/red-system/tests/source/units/return-test.reds
@@ -1,0 +1,133 @@
+Red/System [
+	Title:   "Red/System RETURN keyword test script"
+	Author:  "Nenad Rakocevic"
+	File: 	 %test-return.reds
+	Rights:  "Copyright (C) 2011 Nenad Rakocevic. All rights reserved."
+	License: "BSD-3 - https://github.com/dockimbel/Red/blob/origin/BSD-3-License.txt"
+]
+
+#include %../../quick-test/quick-test.reds
+
+qt-start-file "return"
+
+test: func [return: [integer!]][return 1]
+qt-assert "return-1" test = 1
+
+i: 0
+test98: func [return: [logic!]][
+	return true
+	i: 1
+]
+qt-assert "return-2" test98
+qt-assert "return-3" i = 0
+
+i: 0
+test99: func [return: [logic!]][
+	return false
+	i: 1
+]
+qt-assert "return-4" not test99
+qt-assert "return-5" i = 0
+
+i: 0
+test2: func [return: [logic!]][
+	i: 1
+	return true
+	i: 2
+]
+qt-assert "return-6" test2
+qt-assert "return-7" i = 1
+
+i: 0
+test3: func [return: [logic!]][
+	i: 1
+	if true [return true i: 2]
+	i: 3
+]
+qt-assert "return-8" test3
+qt-assert "return-9" i = 1
+
+i: 0
+test97: func [a [logic!] return: [logic!]][
+	i: 1
+	if true [return a i: 2]
+	i: 3
+]
+qt-assert "return-10" test97 true
+qt-assert "return-11" i = 1
+
+i: 0
+test4: func [return: [logic!]][
+	i: 1
+	if false [return false i: 2]
+	i: 1
+	true
+]
+qt-assert "return-12" test4
+qt-assert "return-13" i = 1
+
+i: 0
+test5: func [return: [logic!]][
+	i: 1
+	either true [return 1 < 2 i: 2][i: 3]
+	i: 4
+]
+qt-assert "return-14" test5
+qt-assert "return-15" i = 1
+
+i: 0
+test6: func [return: [logic!]][
+	i: 1
+	either false [return false][i: 1 return true i: 2]
+	i: 3
+]
+qt-assert "return-16" test6
+qt-assert "return-17" i = 1
+
+i: 0
+test7: func [return: [logic!]][
+	i: 1
+	either 1 < 2 [
+		either 3 < 4 [
+			return true
+			i: 2
+		][
+			i: 3
+		]
+	][
+		i: 4
+	]
+	i: 5
+]
+qt-assert "return-18" test7
+qt-assert "return-19" i = 1
+
+;; test8 moved to return-test.r
+
+i: 0
+test9: func [return: [logic!]][
+	i: 1
+	until [
+		return false
+		true
+	]
+	i: 2
+]
+qt-assert "return-20" not test9
+qt-assert "return-21" i = 1
+
+i: 0
+test10: func [return: [integer!]][
+	i: 1
+	until [
+		if true [return 42]
+		i: 2
+		true
+	]
+	i: 3
+]
+qt-assert "return-22" test10 = 42
+qt-assert "return-23" i = 1
+
+qt-end-file
+


### PR DESCRIPTION
I've converted `test-exit.reds` to `source/units/exit-test.reds` and `source/compiler/exit-test.r`
and `test-return.reds` to `source/units/return-test.reds` and `source/complier/return-test.r`

`rs-test-suite.r` and `rs-test-suite.reds` have been updated to include them.

There is one failure in `exit-test.r` - `until [exit]` crashes the compiler - `return [exit]` correctly gives compilation error.

There is something odd with test "exit-4" in `exit-test.reds` - all exit tests pass when run from `run-test.r`, test "exit-4" fails when run from `run-all.r`. I'd appreciate if you could take a quick look.
