### PR TITLE
TESTS: added test for integer literal FFFFFFFFh

### DIFF
--- a/red-system/tests/source/compiler/int-literals-test.r
+++ b/red-system/tests/source/compiler/int-literals-test.r
@@ -1,0 +1,21 @@
+REBOL [
+  Title: "Red/System compilation error test"
+  File:  %int-literals-test.r
+  License: "BSD-3 - https://github.com/dockimbel/Red/blob/master/BSD-3-License.txt"
+]
+
+change-dir %../                   ;; revert to tests/ dir (from runnable)
+  
+qt/start-file "int-literals-err"
+
+;; int-literals-1
+write %runnable/int-literals.reds {
+  Red/System []
+  i: FFFFFFFFh
+}
+qt/compile %runnable/int-literals.reds
+if exists? %runnable/int-literals.reds [delete %runnable/int-literals.reds]
+qt/assert "int-literals-l" qt/compile-ok?
+
+qt/end-file
+

--- a/red-system/tests/source/rs-test-suite.r
+++ b/red-system/tests/source/rs-test-suite.r
@@ -11,6 +11,7 @@ qt/start-test-run "Red/System Test Suite - Part II"
 
 qt/run-script %source/compiler/comp-err-test.r
 qt/run-script %source/compiler/exit-test.r
+qt/run-script %source/compiler/int-literals-test.r
 qt/run-script %source/compiler/output-test.r
 qt/run-script %source/compiler/return-test.r
 


### PR DESCRIPTION
I came across this compile problem.

Code:

```
Red/System []
i: FFFFFFFFh
```

Result:

```
>> do/args %rsc.r "%/c/code/red-system/test.reds"
Script: "Red/System compiler wrapper" (none)
Script: "Red/System compiler" (none)
Script: "Red/System linker" (none)
Script: "Red/System PE/COFF format emitter" (none)
Script: "Red/System ELF format emitter" (none)
Script: "Red/System code emitter" (none)
Script: "Red/System code emitter base object" (none)

-= Red/System Compiler =-
Compiling /c/code/red-system/test.reds ...
Script: "Red/System IA32 code emitter" (none)
*** undefined symbol
at:  [FFFFFFFFh]
```

I've added a test for this in `tests/source/compiler/int-literals-test.r` which fails at the moment.
