### PR TITLE
TESTS: Added alias tests

### DIFF
--- a/red-system/tests/source/compiler/alias-test.r
+++ b/red-system/tests/source/compiler/alias-test.r
@@ -1,0 +1,73 @@
+REBOL [
+	Title:   "Red/System cast test script"
+	Author:  "Nenad Rakocevic & Peter W A Wood"
+	File: 	 %alias-test.r
+	Rights:  "Copyright (C) 2011 Nenad Rakocevic & Peter W A Wood. All rights reserved."
+	License: "BSD-3 - https://github.com/dockimbel/Red/blob/origin/BSD-3-License.txt"
+]
+
+change-dir %../
+
+compiled?: func [
+  source [string!]
+][
+  write %runnable/alias.reds source 
+  exe: --compile src: %runnable/alias.reds
+  if exists? %runnable/alias.reds [delete %runnable/alias.reds]
+  if all [
+    exe
+    exists? exe
+  ][
+    delete exe
+  ]
+  qt/compile-ok?
+]
+  
+
+~~~start-file~~~ "alias-compile"
+
+===start-group=== "compiler checks"
+
+  --test-- "alias 1"
+      ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+      ;; I guess creating an alias from an existing struc! alllowed? :-)
+      ;; perhaps it will be in Red ?? ;-)
+      ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  --assert compiled? {
+    a3-struct: struct [a [integer!] b [integer!]]
+    a3-struct/a: 1
+    a3-struct/b: 2
+    a3-alias!: alias a3-struct
+    a3-struct-1: struct a3-alias!
+    a3-struct-1/a: 3
+    a3-struct-1/b: 4
+  }
+  
+  --test-- "alias 2"
+  ;; I'm not sure if this use of alias is supported, it would be good if it was
+  --assert compiled? {
+      a5-alias!: alias struct! [a [integer!] b [integer!]]
+      a5-struc: struct a5-alias!
+      a5-pointer: pointer [integer!]
+      a5-struc/a: 1
+      a5-struc/b: 2
+      a5-pointer: as pointer! a5-struc
+      a5-struc: as [struct! [a5-alias-1]] a5-pointer
+    }
+    
+  --test-- "alias 2"
+      ;; This is bascially the book/gift example from the spec
+  --assert compiled? {
+    a5-alias!: alias struct! [a [byte!] b [byte!]]
+    a5-struc: struct [
+      s1 [a5-alias!]
+      s2 [a5-alias!]
+    ]
+    a5-struct/s1: struct a5-alias!
+  }
+  
+===end-group=== 
+       
+~~~end-file~~~
+
+

--- a/red-system/tests/source/compiler/cast-test.r
+++ b/red-system/tests/source/compiler/cast-test.r
@@ -101,13 +101,28 @@ compiled?: func [
          0 = as integer! i
     }
 
-comment {    
-    warning-test "logic!" {				;; does not produce a Warning message
-        Red/System []					;; because the [true =] part of the expression is
-         l: true						;; removed during compilation (part of literal logic! value
-         true = as logic! l				;; internal reduction strategy)
-    }									
-}    
+  --test-- "logic! warning special case"
+    result: false
+    result: compiled? {         ;; does not produce a Warning message because 
+      Red/System []					    ;; the [true =] part of the expression is
+      l: true						        ;; removed during compilation 
+      true = as logic! l				;; (part of literal logic! value
+    }                           ;; internal reduction strategy)
+    warning: "*** Warning: type casting"
+    either result [
+  --assert none = find qt/comp-output warning 
+    ][
+      --assert result                       ;; signify failing test
+      print qt/comp-output
+    ]
+  
+    warning-test "logic!" {
+        Red/System []
+         l: 1 = 1
+         l2: as logic! l
+    }
+
+
     warning-test "c-string!" {
         Red/System []
          cs: "hello"

--- a/red-system/tests/source/rs-test-suite.r
+++ b/red-system/tests/source/rs-test-suite.r
@@ -9,6 +9,7 @@ if not value? 'qt [do %quick-test-quick-test.r]
        
 ***start-run*** "Red/System Test Suite - Part II"
 
+  --run-script %source/compiler/alias-test.r
   --run-script %source/compiler/cast-test.r
   --run-script %source/compiler/comp-err-test.r
   --run-script %source/compiler/exit-test.r

--- a/red-system/tests/source/rs-test-suite.reds
+++ b/red-system/tests/source/rs-test-suite.reds
@@ -16,6 +16,7 @@ Red/System [
 #include %units/struct-test.reds
 #include %units/pointer-test.reds
 #include %units/cast-test.reds
+#include #units/alias-test.reds
 
 ;-- Native functions tests
 #include %units/not-test.reds

--- a/red-system/tests/source/units/alias-test.reds
+++ b/red-system/tests/source/units/alias-test.reds
@@ -1,0 +1,78 @@
+Red/System [
+	Title:   "Red/System alias test script"
+	Author:  "Nenad Rakocevic & Peter W A Wood"
+	File: 	 %alias-test.reds
+	Rights:  "Copyright (C) 2011 Nenad Rakocevic & Peter W A Wood. All rights reserved."
+	License: "BSD-3 - https://github.com/dockimbel/Red/blob/origin/BSD-3-License.txt"
+]
+
+#include %../../quick-test/quick-test.reds
+
+~~~start-file~~~ "alias"
+
+  --test-- "alias-1"
+    a1-str!: alias struct! [i [integer!]]
+    a1-s: struct a1-str!
+    a1-s/i: 123
+  --assert a1-s/i = 123
+  
+  --test-- "alias-2"
+    a2-str!: alias struct! [i [integer!]]
+    a2-s: struct a2-str!
+    a2-s/i: 123
+    a2-str2!: alias struct! [a [a2-str!] b [a2-str!]]
+    a2-s2: struct a2-str2!
+    a2-s2/b: a2-s
+    a2-s2/b/i: 987
+  --assert a2-S/i = 987
+
+  --test-- "alias-3"
+    a3-alias!: alias struct! [s [c-string!]]
+    a3-struct: struct a3-alias!
+    a3-struct/s: "abcde"
+    a3-struct-1: struct a3-alias!
+    a3-struct-1/s: "fghij"
+  --assert a3-struct/s/1 = #"a"
+  --assert a3-struct/s/2 = #"b"
+  --assert a3-struct/s/3 = #"c"
+  --assert a3-struct/s/4 = #"d"
+  --assert a3-struct/s/5 = #"e"
+  --assert a3-struct-1/s/1 = #"f"
+  --assert a3-struct-1/s/2 = #"g"
+  --assert a3-struct-1/s/3 = #"h"
+  --assert a3-struct-1/s/4 = #"i"
+  --assert a3-struct-1/s/5 = #"j"
+
+  --test-- "alias-4"
+    a4-alias!: alias struct! [a [integer!] b [integer!]]
+    a4-struct: struct a4-alias!
+    a4-struct/a: 1
+    a4-struct/b: 2
+    a4-struct-1: struct a4-alias!
+    a4-struct-1/a: 3
+    a4-struct-1/b: 4
+  --assert a4-struct/a = 1
+  --assert a4-struct/b = 2
+  --assert a4-struct-1/a = 3
+  --assert a4-struct-1/b = 4
+
+comment {
+  --test-- "alias-5"
+    a5-alias!: alias struct! [a [byte!] b [byte!]]
+    a5-struc: struct [
+      s1 [a5-alias!]
+      s2 [a5-alias!]
+    ]
+    a5-struct/s1: struct a5-alias!
+    a5-struct/s1/a: #"a"
+    a5-struct/s1/b: #"b"
+    a5-struct/s2: struct a5-alias!    
+    a5-struct/s2/a: #"c"
+    a5-struct/s2/b: #"d"
+  --assert a5-struct/s1/a = #"a"
+  --assert a5-struct/s1/b = #"b"
+  --assert a5-struct/s2/a = #"c"
+  --assert a5-struct/s2/b = #"d"
+}    
+~~~end-file~~~
+

--- a/red-system/tests/source/units/cast-test.reds
+++ b/red-system/tests/source/units/cast-test.reds
@@ -143,18 +143,18 @@ comment {
 ===end-group===
 
 ===start-group=== "cast from logic!"
-comment {  
+  
   --test-- "logic-cast-1"
   --assert #"^(01)" = as byte! true 
-}
+  
   --test-- "logic-cast-2"
     cast-test-b: #"^(01)"
     l: true
   --assert cast-test-b = as byte! l
-comment {  
+ 
   --test-- "logic-cast-3"
   --assert #"^(00)" = as byte! false
-}
+
   --test-- "logic-cast-4"
     cast-test-b: #"^(00)"
     l: false


### PR DESCRIPTION
Only five tests but they cover the basics.
The fifth one is commented out as it doesn't compile, it is a copy of the book/gift example from the spec.
There are also three compiler tests which all fail - one is the book/gift case, the others are not in the spec - one is very wishful thinking that cannot be implemented, the other would be very useful.

I'll remove these additional tests once you've had chance to look at them.

I've also added the additional tests to cast-test.reds that we discussed yesterday.
