### PR TITLE
TESTS: Additional tests in byte.reds

### DIFF
--- a/red-system/tests/source/units/byte-test.reds
+++ b/red-system/tests/source/units/byte-test.reds
@@ -19,6 +19,37 @@ Red/System [
 	
 	--test-- "byte-type-3"
 	--assert #"A" < #"B"
+	
+	--test-- "byte-operator-1"
+	  bo1-c: #"^(10)"
+	  either 17  < bo1-c [bo1-res: 1][bo!-res: 0]
+	--assert bo1-res = 0    
+	
+	--test-- "byte-operator-2"
+	  bo1-c: #"^(10)"
+	  either 17  < as integer! bo1-c [bo1-res: 1][bo!-res: 0]
+	--assert bo1-res = 0    
+	
+	--test-- "byte-operator-3"
+	  bo1-c: #"^(10)"
+	  bol-res: 0
+	  if 17  < bo1-c [bo1-res: 1]
+	--assert bo1-res = 0    
+	
+	--test-- "byte-operator-4"
+	  bo1-c: #"^(10)"
+	  bol-res: 0
+	  if 17  < as integer! bo1-c [bo1-res: 1]
+	--assert bo1-res = 0  
+	
+	--test-- "byte-operator-5"
+	  bo1-c: #"^(10)"
+	--assert 17  < bo1-c     
+	
+	--test-- "byte-operator-6"
+	  bo1-c: #"^(10)"
+	--assert 17  < as integer! bo1-c
+	  
 ===end-group===
 
 ===start-group=== "Byte literals assignment"


### PR DESCRIPTION
I came across a possible bug using the < operator with an integer! and a byte!. I'm not sure if it's a casting problem or a operator problem so I added the tests to byte-test.reds.

They are byte-operator-1 to -6. Five of them fail at the moment.
