### PR TITLE
Build binary compatible hello.red in R2 and R3 for Elf

### DIFF
--- a/quick-test/quick-unit-test.r
+++ b/quick-test/quick-unit-test.r
@@ -8,6 +8,8 @@ REBOL [
 	License: "BSD-3 - https://github.com/dockimbel/Red/blob/master/BSD-3-License.txt"
 ]
 
+do %../red-system/utils/r2-forward.r
+
 qut: make object! [
   
   test-print: :print

--- a/red-system/linker.r
+++ b/red-system/linker.r
@@ -132,11 +132,9 @@ linker: context [
 
 		file: make-filename job
 		if verbose >= 1 [print ["output file:" file]]
-		write/binary/direct file job/buffer
+		write-binary/direct file job/buffer
 		
-		if find get-modes file 'file-modes 'owner-execute [
-			set-modes file [owner-execute: true]
-		]
+		make-owner-executable file
 	]
 
 ]

--- a/red-system/rsc.r
+++ b/red-system/rsc.r
@@ -24,17 +24,15 @@ rsc: context [
 	fail-try: func [component body /local err] [
 		if error? set/any 'err try body [
 			err: disarm err
+			probe err
 			foreach w [arg1 arg2 arg3][
 				set w either unset? get/any in err w [none][
 					get/any in err w
 				]
 			]
-			fail [
+			fail compose [
 				"***" component "Internal Error:"
-				system/error/(err/type)/type #":"
-				reduce system/error/(err/type)/(err/id) newline
-				"*** Where:" mold/flat err/where newline
-				"*** Near: " mold/flat err/near newline
+				(readable-error-block err)
 			]
 		]
 	]
@@ -155,3 +153,6 @@ rsc: context [
 
 	fail-try "Driver" [main]
 ]
+
+;-- script will evaluate to whatever is at the end here, literal of type unset!
+#[unset!]

--- a/red-system/targets/target-class.r
+++ b/red-system/targets/target-class.r
@@ -35,22 +35,25 @@ target-class: context [
 	bitwise-op:	   [and or xor]
 	bitshift-op:   [>> << -**]
 	
-	opp-conditions: [
+	;-- compose is necessary to bypass tag parsing bug in Rebol 2 in order
+	;-- to format the data for use by Rebol 3 select
+	;-- http://stackoverflow.com/questions/14368508/
+	opp-conditions: compose/deep [
 	;-- condition ------ opposite condition --
-		overflow?		 not-overflow?
-		not-overflow?	 overflow?			
-		=				 <>
-		<>				 =
-		even?			 odd?
-		odd?			 even?
-		<				 >=
-		>=				 <
-		<=				 >
-		>				 <=
+		overflow?		 [not-overflow?]
+		not-overflow?	 [overflow?]	
+		=				 [<>]
+		<>				 [=]
+		even?			 [odd?]
+		odd?			 [even?]
+		(to-word "<")	 [(to-word ">=")]
+		(to-word ">=")	 [(to-word "<")]
+		(to-word "<=")	 [(to-word ">")]
+		(to-word ">")	 [(to-word "<=")]
 	]
 	
 	opposite?: func [cond [word!]][
-		first select/skip opp-conditions cond 2
+		first select opp-conditions cond
 	]
 	
 	power-of-2?: func [n [integer! char!]][
@@ -70,7 +73,7 @@ target-class: context [
 		][
 			compiler/throw-error "#code generation error: overflow in emit-variable"
 		]
-		skip debase/base to-hex offset 16 3		; @@ just to-char ??
+		integer-to-bytes/width offset 1		; @@ just to-char ??
 	]
 
 	emit: func [bin [binary! char! block!]][

--- a/red-system/utils/IEEE-754.r
+++ b/red-system/utils/IEEE-754.r
@@ -48,11 +48,11 @@ IEEE-754: context [
 		set [sign exp frac] split64 n
 		out: make binary! 8
 		loop 6 [
-			insert out to char! byte: frac // 256
+			insert out integer-to-bytes/width byte: to integer! (frac // 256) 1
 			frac: frac - byte / 256
 		]
-		insert out to char! exp // 16 * 16  + frac
-		insert out to char! exp / 16 + (128 * sign)
+		insert out integer-to-bytes/width to integer! (exp // 16 * 16  + frac) 1
+		insert out integer-to-bytes/width to integer! (exp / 16 + (128 * sign)) 1
 		either rev [copy reverse out][out]
 	]
 
@@ -92,11 +92,11 @@ IEEE-754: context [
 		set [sign exp frac] split32 n
 		out: make binary! 4
 		loop 2 [
-			insert out to char! byte: frac // 256
+			insert out integer-to-bytes/width to integer! (byte: frac // 256) 1
 			frac: frac - byte / 256
 		]
-	    insert out to char! exp * 128 // 256  + frac
-	    insert out to char! exp / 2 + (128 * sign)
+	    insert out integer-to-bytes/width to integer! (exp * 128 // 256  + frac) 1
+	    insert out integer-to-bytes/width to integer! (exp / 2 + (128 * sign)) 1
 		either rev [copy reverse out][out]
 	]
-]
+]

--- a/red-system/utils/int-to-bin.r
+++ b/red-system/utils/int-to-bin.r
@@ -10,16 +10,21 @@ REBOL [
 
 int-to-bin: context [
 	little-endian?: yes
+
+	set 'to-bin func [v [integer!] size [integer!] /local bytes] [
+		bytes: integer-to-bytes/width v size
+		either little-endian? [reverse bytes] [bytes]
+	]
 	
-	set 'to-bin8 func [v [integer! char!]][
-		to binary! to char! 256 + v and 255
+	set 'to-bin8 func [v [integer!]] [
+		to-bin v 1
 	]
 
-	set 'to-bin16 func [v [integer! char!]][			;TBD: add big-endian support
-		reverse skip debase/base to-hex to integer! v 16 2
+	set 'to-bin16 func [v [integer!]] [
+		to-bin v 2
 	]
 
-	set 'to-bin32 func [v [integer! char!]][			;TBD: add big-endian support
-		reverse debase/base to-hex to integer! v 16
+	set 'to-bin32 func [v [integer!]] [
+		to-bin v 4
 	]
 ]

--- a/red-system/utils/r2-forward.r
+++ b/red-system/utils/r2-forward.r
@@ -17,6 +17,33 @@ REBOL [
 	Exports: [
 		map-each
 		collect
+		
+		; tentative additions from HostileFork
+		r3?
+		hash!
+		to-hash
+		disarm
+		read-binary
+		write-binary
+		read-string
+		clear-map
+		remove-map
+		bin-pos
+		bin-capture
+		readable-error-block
+		clean-path
+		shift-left
+		shift-right
+		make-owner-executable
+		unique-extended
+		some-parsefix
+		any-parsefix
+		binary-to-int32
+		integer-to-bytes
+		r2-utf8-checked
+		r2-string-to-binary
+		r2-escape-string
+		to-hex-string
 	] ; No Globals to limit any potential damage.
 	License: {
 		Copyright (c) 2008-2009 Brian Hawley
@@ -40,6 +67,18 @@ REBOL [
 		THE SOFTWARE.
 	} ; MIT
 ]
+
+r3?: does [system/version > 2.99.0]
+
+;-- Interim solution for preliminary r3 build...define hash! simply as block!
+;-- Performance suffers vs. re-coding to use map!-safe functions on R2 hash!
+;-- But at least this won't degrade the R2 version, and gets the ball rolling
+if r3? [
+	hash!: block! 
+	to-hash: func [b [block!]] [b]
+]
+
+if not r3? [
 
 ; MAP-EACH with set-words, best datatype! support and /into (ideal full version)
 map-each: func [
@@ -102,3 +141,296 @@ collect: func [
 	either into [output] [head output]
 ]
 ; R3 version based on a discussion with Gregg and Gabriele in AltME.
+
+]
+
+;;
+;; Tentative additions by HostileFork to support features that differ in R3
+;; which are used by the Red codebase
+;;
+
+if r3? [disarm: func [e [error!]] [e]]
+; Note: Errors are disarmed by default in R3
+
+remove-map: func [m [map!] key /local pos /exists] [
+	either r3? [
+		; we're in Rebol 3, in which unfulfilled refinements are none?
+		if (true? exists) and (none = m/key) [
+				print "key was not in map for remove-map/exists"
+				halt
+		]
+
+		m/key: none
+	] [
+		; we're in Rebol 2, this is the only way I know of to remove a key/val
+		either pos: find m key [
+			remove/part pos 2
+		] [
+			if exists [
+				print "key was not in map for remove-map/exists"
+				halt
+			]
+		]
+
+	]
+]
+; Note: R3 does not support FIND on MAP!
+
+read-binary: func [source [file! url! block!]] [
+	either r3? [
+		read source									;-- R3 defaults binary!
+	] [
+		read/binary source							;-- R2 defaults string!
+	]
+]
+
+write-binary: func [destination [file! url! block!] data /direct] [
+	either r3? [
+		;-- no direct refinement in R3, ignore it
+		write destination data						;-- R3 defaults binary!
+	] [
+		;-- R2 defaults string!
+		
+		either direct [
+			write/binary/direct destination data
+		] [
+			write/binary destination data
+		]
+	]
+]
+
+read-string: func [source /local result] [
+	either r3? [
+		read/string source							;-- R3 defaults binary!
+	] [
+		read source									;-- R2 defaults string!
+	]
+]
+
+clear-map: func [m [map!]] [
+	either r3? [
+		m: make map! [] 							;-- loses size hint
+	] [
+		clear m
+	]
+]
+; Note: This shouldn't be needed, it's a temporary workaround for a bug in R3
+; http://curecode.org/rebol3/ticket.rsp?id=1930&cursor=4
+
+bin-pos: bin-capture: func [pos [binary! string!]] [
+    either string? pos [
+ 	    as-binary pos
+    ] [
+        pos											;-- no-op in R3
+    ]
+]
+; Note: these are for bridging incompatibility between R2/R3 on binary PARSE
+; http://stackoverflow.com/questions/14203426/
+
+readable-error-block: func [err [error! object!]] [
+	either object? err [							;-- disarmed errors in R2
+		system/error/(err/type)/type #":"
+		reduce system/error/(err/type)/(err/id) newline
+		"*** Where:" mold/flat err/where newline
+		"*** Near: " mold/flat err/near newline
+	] [
+		mold err 									;-- need to write this
+	]
+]
+
+if not r3? [clean-path: func [f [file!]] [get-modes f 'full-path]]
+; http://stackoverflow.com/questions/14352039/
+
+shift-left: func [data [integer! binary!] bits [integer!]] [
+	either r3? [
+		;-- R3 changes the default direction of shift to left :-/
+		shift data bits
+	] [
+		shift/left data bits
+	]
+]
+
+shift-right: func [data [integer! binary!] bits [integer!]] [
+	either r3? [
+		;-- R3 changes the default direction of shift to left :-/
+		shift data negate bits
+	] [
+		shift data bits
+	]
+]
+
+make-owner-executable: func [target [file!]] [
+	either r3? [
+		;-- just unix for now...
+		call/wait rejoin [{chmod +x "} to-string target {"}]
+	] [
+		if find get-modes target 'file-modes 'owner-execute [
+			set-modes target [owner-execute: true]
+		]
+	]
+]
+
+unique-extended: func [series [series!] /local s e] [
+	either r3? [
+		s: series
+		while [s <> e: tail series] [
+			while [e <> s] [
+				if s/1 = e/1 [
+					take e
+				]
+				e: back e
+			]
+			s: next s
+		]
+		series
+	] [
+		unique series
+	]
+]
+
+some-parsefix: func [rule [block!] /local r] [
+	if r3? [parse rule r: [any [ 
+		change 'some 'while | and block! into r | skip 
+	]]]
+	rule
+]
+any-parsefix: func [rule [block!] /local r] [
+	if r3? [parse rule r: [any [ 
+		change 'any 'while | and block! into r | skip 
+	]]]
+	rule
+]
+;-- R3 has different behavior w.r.t. SOME and CHANGE
+;-- Replacing with WHILE works, but that is not available in R2 PARSE
+;--     http://stackoverflow.com/questions/14352264/ 
+
+binary-to-int32: func [bin [binary!] /local padded] [
+	assert [find [1 2 4] length? bin]
+	padded: head insert/dup bin #{00} (4 - length? bin)
+	if r3? [
+		insert/dup padded (either 127 < first padded [#{FF}] [#{00}]) 4
+	]
+	to integer! padded
+]
+
+integer-to-bytes: func [v [integer!] /width bytes [integer!] /local bin high-byte s][
+	unless width [
+		if zero? v [return #{00}] ;-- special case or could fix parse rule
+		bytes: 4
+	]
+	assert [find [1 2 4] bytes] ;-- code is generalized, just sanity check
+	
+	;-- This reformulation of [debase/base to-hex v 16] seems to
+	;-- be able to work in both R2 and R3, but we need to recognize
+	;-- that to-hex produces 8 byte long issues, not 4 byte ones		
+	bin: debase/base next mold to-hex v 16
+
+	high-byte: either v < 0 [
+		;-- For now, if you don't specify a width we trim all leading
+		;-- zeroes...if we did this with the FFs you might not know your
+		;-- number was negative.  Revisit this design.
+		assert [width]
+		#{FF}
+	] [
+		#{00}
+	]
+	
+	assert [
+		parse/all bin compose [
+			((length? bin) - bytes) high-byte 
+			(unless width [[any #{00}]]) s: to end  
+		]
+	]
+	copy bin-pos s
+]
+
+safe-r2-char: charset [#"^(00)" - #"^(7F)"]
+unsafe-r2-char: charset [#"^(80)" - #"^(FF)"]
+
+hex-digit: charset [#"0" - #"9" #"A" - #"F" #"a" - #"f"]
+
+r2-utf8-checked: func [codepoints [char! string!]] [
+	either char! = type? codepoints [
+		if find safe-r2-char codepoints [return codepoints]
+	] [
+		if parse/all codepoints [any safe-r2-char] [return codepoints]
+	]
+	print "Unsafe codepoints for R2 found in string! by r2-utf8-checked"
+	print "See http://stackoverflow.com/questions/15077974/"
+	print mold codepoints
+	throw "Bad codepoint found by r2-utf8-checked"
+]
+
+r2-string-to-binary: func [str [string!] /string /unescape /unsafe /local result s e escape-rule unsafe-rule safe-rule rule] [
+	;-- Utility function originally from here:
+	;--     http://stackoverflow.com/questions/15077974/
+	
+	result: copy either string [{}] [#{}]
+	escape-rule: [
+		"^^(" s: 2 hex-digit e: ")" (
+			append result debase/base copy/part s e 16
+		)
+	]
+	unsafe-rule: [
+		s: unsafe-r2-char (
+			append result to integer! first s
+		)
+	]
+	safe-rule: [
+		s: safe-r2-char (append result first s)
+	]
+	rule: compose/deep [
+		any [
+			(either unescape [[escape-rule |]] [])
+			safe-rule
+			(either unsafe [[| unsafe-rule]] [])
+		]
+	]
+	unless parse/all str rule [
+		print "Unsafe codepoints for R2 found in string! by r2-string-to-binary"
+		print "See http://stackoverflow.com/questions/15077974/"
+		print mold str
+		throw "Bad codepoint found by r2-string-to-binary"
+	]
+	result
+]
+
+r2-escape-string: func [str [string!] /count var /local result num temp] [
+	result: copy {}
+	num: 0
+	foreach codepoint str [
+		either 127 >= to integer! codepoint [
+			append result codepoint
+			++ num
+		] [
+			codepoint: to binary! codepoint
+			;-- only R3 will have > 1 byte cases
+			assert [4 >= length? codepoint] 
+			foreach byte codepoint [
+				append result rejoin ["^^(" to-hex-string/size byte 2 ")"]
+				++ num
+			]
+		]	
+	]
+	if count [
+		set var num
+	]
+	result
+]
+
+to-hex-string: func [value [integer!] /size len /local result] [
+	either size [
+		either r3? [
+			remove to string! to-hex/size value len
+		] [
+			;-- No size refinement in R2, string conversion drops # sign
+			result: to string! to-hex value
+			while ["00" = copy/part result 2] [
+				remove/part result 2
+			]
+			result
+		] 
+	] [
+		remove to string! to-hex value
+	] 
+]

--- a/red-system/utils/secure-clean-path.r
+++ b/red-system/utils/secure-clean-path.r
@@ -19,7 +19,8 @@ REBOL [
 ;-- script trimmed down to the function only
 ;-- most of comments and unit tests removed
 ;-- minor changes in the function body ("/" factorized, index? replaced by offset?)
-;--
+;-- Changed to use the word "constraint" instead of R3 parse keyword LIMIT
+
 ;-- Full script can be found here: http://www.rebol.org/view-script.r?script=secure-clean-path.r
 
 
@@ -28,7 +29,7 @@ secure-clean-path: func [
     /limit               {Limit paths relative to this root}
     root   [any-string!] {The root path (Default "", not applied if "")}
     /nocopy              {Modify target instead of copy}
-    /local root-rule a b c slash dot
+    /local root-rule a b c slash dot constraint
 ] [
 	dot: "."
 	slash: "/"
@@ -41,7 +42,7 @@ secure-clean-path: func [
     ]
     
     if parse/all target [
-        root-rule limit:
+        root-rule constraint:
         any [
             a: dot [slash | end] (remove/part a 2) :a |
             a: some slash b: (remove/part a b) :a |
@@ -49,8 +50,8 @@ secure-clean-path: func [
                 loop (offset? a b) - 1 [
                     either all [
                         b: find/reverse back a slash
-                        -1 <= offset? limit b
-                    ] [a: next b] [a: limit  break]
+                        -1 <= offset? constraint b
+                    ] [a: next b] [a: constraint break]
                 ]
             ) :a (
                 remove/part a c

--- a/red-system/utils/virtual-struct.r
+++ b/red-system/utils/virtual-struct.r
@@ -32,7 +32,7 @@ virtual-struct!: context [
 		__vs-spec: none
 	]
 
-	pad: func [buf [any-string!] n [integer!] /local mod][
+	pad: func [buf [binary!] n [integer!] /local mod][
 		unless any [
 			empty? buf
 			zero? mod: (length? buf) // n
@@ -69,7 +69,7 @@ virtual-struct!: context [
 		]
 		
 		if data [
-			specs: skip first obj 3					;-- skip over: self, __vs-type, __vs-spec
+			specs: skip words-of obj 2					;-- skip over: __vs-type, __vs-spec
 			until [
 				set in obj specs/1 data/1
 				data: next data
@@ -92,7 +92,7 @@ virtual-struct!: context [
 		][
 			make error! "invalid virtual struct! value"
 		]
-		out: make binary! 4 * length? members: skip first obj 3		;-- raw guess
+		out: make binary! 4 * length? members: skip words-of obj 2		;-- raw guess
 		n: any [n alignment]
 		
 		foreach name members [
@@ -100,10 +100,18 @@ virtual-struct!: context [
 			value: get in obj name
 			
 			append out switch/default type/1 [
-				char 	 [to-bin8   any [value 0]]
+				char 	 [to-bin8   any [
+							if not none? value [to integer! value] 
+							0
+					]
+				]
 				short	 [pad out 2 to-bin16  any [value 0]]
 				int		 [pad out 4 to-bin32  any [value 0]]
-				char!	 [to-bin8   any [value 0]]
+				char!	 [to-bin8   any [
+							if not none? value [to integer! value]
+							0
+					]
+				]
 				integer! [pad out 4 to-bin32  any [value 0]]
 				decimal! [pad out 4 #{0000000000000000}]	;-- placeholder
 			][

--- a/red.r
+++ b/red.r
@@ -24,17 +24,15 @@ redc: context [
 	fail-try: func [component body /local err] [
 		if error? set/any 'err try body [
 			err: disarm err
+			probe err
 			foreach w [arg1 arg2 arg3][
 				set w either unset? get/any in err w [none][
 					get/any in err w
 				]
 			]
-			fail [
+			fail compose [
 				"***" component "Internal Error:"
-				system/error/(err/type)/type #":"
-				reduce system/error/(err/type)/(err/id) newline
-				"*** Where:" mold/flat err/where newline
-				"*** Near: " mold/flat err/near newline
+				(readable-error-block err)
 			]
 		]
 	]
@@ -96,7 +94,7 @@ redc: context [
 		unless config: select load-targets config-name: to word! trim target [
 			fail ["Unknown target:" target]
 		]
-		base-path: system/script/parent/path
+		base-path: system/script/path 						;-- was system/script/parent/path but r3 returns none
 		opts: make opts config
 		opts/config-name: config-name
 		opts/build-prefix: base-path
@@ -177,3 +175,6 @@ redc: context [
 
 	fail-try "Driver" [main]
 ]
+
+;-- script will evaluate to whatever is at the end here, literal of type unset!
+#[unset!]

--- a/red/runtime/tokenizer.reds
+++ b/red/runtime/tokenizer.reds
@@ -204,7 +204,7 @@ tokenizer: context [
 				c = #":"  [src: scan-word src + 1 blk TYPE_GET_WORD]
 				c = #"'"  [src: scan-word src + 1 blk TYPE_LIT_WORD]
 				all [#"0" <= c c <= #"9"][src: scan-integer src blk]
-				all [#" " <= c c <= #"ÿ"][src: scan-word src blk TYPE_WORD]
+				all [#" " <= c c <= #"^(FF)"][src: scan-word src blk TYPE_WORD]
 			]
 		]	
 		if null? parent [

--- a/red/tests/source/compiler/print-test.r
+++ b/red/tests/source/compiler/print-test.r
@@ -11,11 +11,11 @@ REBOL [
 
  --test-- "Red print 1"
    --compile-and-run-red %source/compiler/print-test.red 
-  --assert-red-printed? 1
+  --assert-red-printed? "1"
   
   --test-- "Red print 2"
     --compile-and-run-this-red {print 2}
-  --assert-red-printed? 2
+  --assert-red-printed? "2"
   
   --test-- "Red print 3"
     --compile-and-run-this-red {

--- a/red/tests/source/compiler/regression-tests.r
+++ b/red/tests/source/compiler/regression-tests.r
@@ -8,7 +8,23 @@ REBOL [
 
 ~~~start-file~~~ "Old Regression tests"
 
-    --compile-and-run-this-red {
+	alpha-utf8: #{CEB1}
+  beta-utf8: #{CEB2}
+  sigma-utf8: #{CF83}
+  iota-utf8: #{E1BF96}
+  rho-utf8: #{CF81}
+  epsilon-utf8: #{CEB5}
+  kappa-utf8: #{CEB5}
+  omicron-utf8: #{CF8C}
+  mu-utf8: #{CEBC}  
+	
+    ;; Hell capital sigma o, then cat in russian      
+    hello-cat-utf8: #{48656C6CC6A96F20D0BAD0BED188D0BAD0B0}
+      
+    ;; Hello, World! in Greek
+	hello-greek-utf8: #{CEA7CEB1E1BF96CF81CEB52C20CEBACF8CCF83CEBCCEB521}
+	
+    --compile-and-run-this-red rejoin [#{} {
       ;================ BASIC =================
       prin "or1"
       print 789
@@ -124,7 +140,7 @@ REBOL [
       
       ;================ STRING =================
       
-      s: {^(48)^(65)^(6C)^(6C)^(C6)^(A9)^(6F)^(20)^(D0)^(BA)^(D0)^(BE)^(D1)^(88)^(D0)^(BA)^(D0)^(B0)}              ;;"HellƩo кошка"
+      s: "} hello-cat-utf8 to binary! {"
       
       prin "or33"
       print s
@@ -133,24 +149,24 @@ REBOL [
       print 123
       
       
-      α: 1
-      β: 2
+      } alpha-utf8 {: 1
+      } beta-utf8 {: 2
       prin "or35"
-      print α + β
+      print } to binary! { + } beta-utf8 {
       
       prin "or36"
-      print {^(CE)^(A7)^(CE)^(B1)^(E1)^(BF)^(96)^(CF)^(81)^(CE)^(B5)^(2C)^(20)^(CE)^(BA)^(CF)^(8C)^(CF)^(83)^(CE)^(BC)^(CE)^(B5)^(21)}    ;"Χαῖρε, κόσμε!"
+      print "} hello-greek-utf8 to binary! {"
       
       prin "or37"
       print #"a"
       
       prin "or38"
-      print #"α"
+      print #"} alpha-utf8 to binary! {"
       
       prin "or39"
       print #"a" + 1
       
-      z: {^(CE)^(A7)^(CE)^(B1)^(E1)^(BF)^(96)^(CF)^(81)^(CE)^(B5)^(2C)^(20)^(CE)^(BA)^(CF)^(8C)^(CF)^(83)^(CE)^(BC)^(CE)^(B5)^(21)}        ;;"Χαῖρε, κόσμε!"
+      z: "} hello-greek-utf8 to binary! {"
       
       prin "or40"
       print head? z
@@ -166,11 +182,16 @@ REBOL [
       
       ;--invalid UTF-8
       prin "or44"
-      ;print "^(D801)^(DC81)"            
-      
+      print "^^(D801)^^(DC81)"
+} 
+;-- This codepoint is simply too high to be represented currently by R3
+;-- in a string! ... hence would have to be a binary in the Red/System
+;-- dialect output.  R2 cheats by having fake strings that are really
+;-- just binaries under the hood, though it knows nothing of Unicode
+comment {      
       prin "or45"
-      ;print "^(10481)"              
-      
+      print "^^(10481)"          
+} {
       s: "toto"
       
       prin "or46"
@@ -268,7 +289,7 @@ REBOL [
       print s
       
       poke at s 5 -1 #"O"
-      append s #"α"
+      append s #"} alpha-utf8 {"
       
       prin "or76"
       print s
@@ -354,10 +375,12 @@ REBOL [
       
       prin "or100"
       print all [1 < 5 true 1 + 2 <= 3]
-      
-      c: "^(10FFFF)"
-      ;c: #"^(10FFFF)"
-      
+}
+;-- Another codepoint simply too high to be MOLDed and LOADed as R3 string!
+comment {       
+      c: "^^(10FFFF)"
+      ;c: #"^^(10FFFF)"
+} {      
       print "---APPEND"
       
       prin "or101"
@@ -367,10 +390,10 @@ REBOL [
       print append "tαst" "hello"
       
       prin "or103"
-      print append "test" "hαllo"
+      print append "test" "h} alpha-utf8 {llo"
       
       prin "or104"
-      print append "test" ["h" #"σ" "llo"]
+      print append "test" ["h" #"} sigma-utf8 {" "llo"]
       
       print "---Symbols"
       list: [test5 /test2 'test3 test6:]
@@ -436,7 +459,7 @@ REBOL [
       prin "or118"
       repeat c 5 [prin "x"]
       
-      z: {^(CE)^(A7)^(CE)^(B1)^(E1)^(BF)^(96)^(CF)^(81)^(CE)^(B5)^(2C)^(20)^(CE)^(BA)^(CF)^(8C)^(CF)^(83)^(CE)^(BC)^(CE)^(B5)^(21)} ;"Χαῖρε, κόσμε!"
+      z: "} hello-greek-utf8 {"
       
       prin "or119"
       print newline
@@ -499,7 +522,7 @@ REBOL [
 	  prin "or130"
 	  prin mold a
       
-    }
+    }]
     
 ===start-group=== "Basic"
 
@@ -608,7 +631,7 @@ REBOL [
 ===start-group=== "String"
 
   --test-- "or33"
-  --assert-red-printed? "or33HellƩo кошка" 
+  --assert-red-printed? rejoin [#{} "or33" hello-cat-utf8]
   
   --test-- "or34"
   --assert-red-printed? "or34123"
@@ -617,13 +640,13 @@ REBOL [
   --assert-red-printed? "or353"
   
   --test-- "or36"
-  --assert-red-printed? "or36Χαῖρε, κόσμε!" 
+  --assert-red-printed? rejoin [#{} "or36" hello-greek-utf8] 
   
   --test-- "or37"
   --assert-red-printed? "or37a"
   
   --test-- "or38"
-  --assert-red-printed? "or38α"
+  --assert-red-printed? rejoin [#{} "or38" alpha-utf8]
   
   --test-- "or39"
   --assert-red-printed? "or39b"
@@ -737,7 +760,7 @@ REBOL [
   --assert-red-printed? "or75t-tozyx"
   
   --test-- "or76"
-  --assert-red-printed? "or76t-tOzyxα"
+  --assert-red-printed? rejoin [#{} "or76t-tOzyx" alpha-utf8]
   
   --test-- "or77"
   --assert-red-printed? "or778"
@@ -882,7 +905,7 @@ REBOL [
   --assert-red-printed? "or114test5/test2'test3test6:"
   
   --test-- "or115"
-  --assert-red-printed? "or115Χαῖρε, κόσμε!"                
+  --assert-red-printed? rejoin [#{} "or115" hello-greek-utf8]                
   
   --test-- "or116"
   --assert-red-printed? "or116Χ"                
@@ -892,20 +915,20 @@ REBOL [
   
   --test-- "or118"
   --assert-red-printed? "or118xxxxx"                
-  
+    
   --test-- "or119"
   --assert-red-printed? {char: Χ cp: 935}
-  --assert-red-printed? {char: α cp: 945}
-  --assert-red-printed? {char: ῖ cp: 8150}
-  --assert-red-printed? {char: ρ cp: 961}
-  --assert-red-printed? {char: ε cp: 949}
+  --assert-red-printed? rejoin [#{} {char: } alpha-utf8 { cp: 945}]
+  --assert-red-printed? rejoin [#{} {char: } iota-utf8 { cp: 8150}]
+  --assert-red-printed? rejoin [#{} {char: } rho-utf8 { cp: 961}]
+  --assert-red-printed? rejoin [#{} {char: } omicron-utf8 { cp: 949}]
   --assert-red-printed? {char: , cp: 44}
   --assert-red-printed? {char:   cp: 32}
-  --assert-red-printed? {char: κ cp: 954}
-  --assert-red-printed? {char: ό cp: 972}
-  --assert-red-printed? {char: σ cp: 963}
-  --assert-red-printed? {char: μ cp: 956}
-  --assert-red-printed? {char: ε cp: 949}
+  --assert-red-printed? rejoin [#{} {char: } kappa-utf8 { cp: 954}]
+  --assert-red-printed? rejoin [#{} {char: } omicron-utf8 { cp: 972}]
+  --assert-red-printed? rejoin [#{} {char: } sigma-utf8 { cp: 963}]
+  --assert-red-printed? rejoin [#{} {char: } mu-utf8 { cp: 956}]
+  --assert-red-printed? rejoin [#{} {char: } epsilon-utf8 { cp: 949}]
   --assert-red-printed? {char: ! cp: 33}
   
   --test-- "or120"

--- a/run-all.r
+++ b/run-all.r
@@ -7,8 +7,8 @@ REBOL [
 ]
 ;; function to find and run-tests
 run-all-script: func [dir [file!]][
-  qt/tests-dir: system/script/path/:dir
-  foreach line read/lines dir/run-all.r [
+  qt/tests-dir: qt/base-dir/:dir
+  foreach line read/lines qt/tests-dir/run-all.r [
     if any [
       find line "===start-group"
       find line "--run-"
@@ -39,8 +39,8 @@ start-time: now/precise
 
 ***start-run-quiet*** "Complete Red Test Suite"
 
-run-all-script %../red/tests/
-run-all-script %../red-system/tests/
+run-all-script %red/tests/
+run-all-script %red-system/tests/
 
 ***end-run-quiet***
 


### PR DESCRIPTION
This is incomplete work but my original goal was not to get all the regression tests running, but just get a byte-for-byte compatible hello.red executable.  Now, as per Kaj's suggestion it's not necessary to hold it up when there are people who are in a good (and likely better) position to help.  It should not be actually pulled into master until the test regressions are fixed.  But pushing it seemed like the right thing to do at this point.

One important thing is that there is an esoteric bug in R3 which I isolated, and which BrianH is working on a "real fix" for.  I just poked in a workaround temporarily.  Here is the modification I made to [c-word.c around line 238](https://github.com/rebol/r3/blob/master/src/core/c-word.c#L238)... I just wrapped the while loop in an IF:

```
if (LEN_BYTES(VAL_SYM_NAME(words+h)) == len) {
    while ((n = Compare_UTF8(VAL_SYM_NAME(words+h), str, len)) >= 0) {
    ...
}
```

You'll need that or the real fix for Compare_UTF8, for binary compatibility of the R2/R3 build of hello.red.

Performance-wise it suffers because I did not try to tackle a map! rewrite, since defining `hash!` as `block!` was easier. That's something that wouldn't be too hard to do, but more prudent to get the test suite passing again.

I threw most of my miscellaneous routines for R2/R3 support [into the r2-forward.r file](https://github.com/dockimbel/Red/blob/master/red-system/utils/r2-forward.r) just because it was included already and I didn't want to add new files if I could avoid it.  But what we actually want is going to be a mixture of R2/Forward enhancements and the creation of R3/Backward.

These StackOverflow questions pertain to the documentation of issues of R2/R3 compatibility, sorted in rough order of importance:

http://stackoverflow.com/questions/15077974/how-to-use-unicode-codepoints-above-uffff-in-rebol-3-strings-like-in-rebol-2

http://stackoverflow.com/questions/14203426/can-parse-on-binary-in-rebol-2-capture-a-binary-instead-of-a-string-like-in

http://stackoverflow.com/questions/14525958/into-behavior-difference-in-rebol-2-parsing-vs-rebol-3

http://stackoverflow.com/questions/14532596/why-doesnt-rebol-3-honor-quoted-function-parameters-that-are-parenthesized

http://stackoverflow.com/questions/14405471/how-can-i-work-with-a-single-byte-and-binary-byte-arrays-in-rebol-3

http://stackoverflow.com/questions/14368508/weird-behavior-with-select-and-the-and-operators-returns-junk-or-none

http://stackoverflow.com/questions/14352264/difference-between-rebol-2-and-rebol-3-when-mixing-some-in-parse-with-change

http://stackoverflow.com/questions/14352039/expand-the-full-path-of-a-file-in-rebol-without-get-modes

http://stackoverflow.com/questions/14330738/what-does-positional-pick-on-an-object-do-in-rebol-2-and-whats-the-equivalent

http://stackoverflow.com/questions/14319411/how-to-convert-a-binary-to-a-char-in-rebol-2

http://stackoverflow.com/questions/14208269/common-way-of-testing-for-membership-in-a-map-working-in-both-rebol-2-and-3

If possible I'd like to have discussions/feedback about those questions and techniques on StackOverflow, at least as much of the discussion as we can.

Viva la Redolution...! :-)
