### PR TITLE
Added comment support in count-delimiters

### DIFF
--- a/red/tests/console.red
+++ b/red/tests/console.red
@@ -133,19 +133,19 @@ count-delimiters: function [
 	c: none
 	
 	foreach c buffer [
-	    either in-comment? [
-    		switch c [
-    		    #"^/" [in-comment?: false]
-            ]	        
-	    ][
-    		switch c [
-    		    #";" [in-comment?: true]
-    			#"[" [list/1: list/1 + 1]
-    			#"]" [list/1: list/1 - 1]
-    			#"{" [list/2: list/2 + 1]
-    			#"}" [list/2: list/2 - 1]
-    		]
-    	]
+		either in-comment? [
+			switch c [
+				#"^/" [in-comment?: false]
+			]	        
+		][
+			switch c [
+				#";" [in-comment?: true]
+				#"[" [list/1: list/1 + 1]
+				#"]" [list/1: list/1 - 1]
+				#"{" [list/2: list/2 + 1]
+				#"}" [list/2: list/2 - 1]
+			]
+		]
 	]
 	list
 ]


### PR DESCRIPTION
Opening brackets or braces in comment lines would mess up the count.
