### PR TITLE
FIX: substract an unexpected char when preprocess escaped string.

### DIFF
--- a/red/runtime/tokenizer.reds
+++ b/red/runtime/tokenizer.reds
@@ -99,7 +99,7 @@ tokenizer: context [
 					#"/"	[#"^/"]
 					#"^""	[#"^""]
 					#"^^"	[#"^^"]
-					default [src/1 - #"@"]
+					default [src/1]
 				]
 			][
 				if dst <> src [dst/1: src/1]


### PR DESCRIPTION
This is will fix TEST in load-test.red: 
--test-- "load-10" --assert "{"     = load "{^{}" 
