### PR TITLE
FIX Issue#548 Update Loader: INCLUDED? doesn't work properly with encapp...

### DIFF
--- a/red-system/loader.r
+++ b/red-system/loader.r
@@ -57,7 +57,7 @@ loader: make-profilable context [
 	]
 
 	included?: func [file [file!]][
-		if encap? [file: join encap-fs/base file]
+		if all [encap? encap-fs/base] [file: join encap-fs/base file]
 		
 		attempt [file: get-modes file 'full-path]
 		either find include-list file [true][


### PR DESCRIPTION
...ed Re

The code run during encap: `join encap-fs/base file` seems to attach 'none value to the beginning of the file name, so the file does not match properly with previously included files.

I tested this by encapping red and testing with Kaj's SDL examples that were double including common.reds and failing to compile.  With this change, those files compiled without trouble.
