### PR TITLE
Update help.red

### DIFF
--- a/tests/help.red
+++ b/tests/help.red
@@ -31,13 +31,14 @@ To see all words of a specific datatype:
     ? function!
     ? datatype!
 
-Other debug functions:
+Other useful functions:
 
     ?? - display a variable and its value
     probe - print a value (molded)
     source func - show source code of func
     what - show a list of known functions
     system/version - display version number and build date
+    q or quit - leave the Red console
 }
 		]
 		datatype? get :word [						;-- HELP <datatype!>


### PR DESCRIPTION
Added hint for quit in the help function.

result:
-=== Red Console alpha version ===-
Type HELP for starting information.

red>> help
Use HELP or ? to see built-in info:

```
help insert
? insert
```

To see all words of a specific datatype:

```
? native!
? function!
? datatype!
```

Other useful functions:

```
?? - display a variable and its value
probe - print a value (molded)
source func - show source code of func
what - show a list of known functions
system/version - display version number and build date
q or quit - leave the Red console
```

red>>
