### PR TITLE
FIX: Printed output of SOURCE for non-function! types

### DIFF
--- a/tests/help.red
+++ b/tests/help.red
@@ -183,7 +183,7 @@ source: function [
 	print either function? get func-name [
 		[append mold func-name #":" mold get func-name]
 	][
-		["Sorry," func-name "is a" type? get func-name "so no source is available"]
+		["Sorry," func-name "is a" mold type? get func-name "so no source is available"]
 	]
 ]
 


### PR DESCRIPTION
Will now print actual type instead of "word" for non-functions:

```
red>> source input
Sorry, input is a word so no source is available
```

With fix:
    red>> source input
    Sorry, input is a routine! so no source is available
