### PR TITLE
FIX: Can't capture console output on Windows

### DIFF
--- a/quick-test/quick-test.r
+++ b/quick-test/quick-test.r
@@ -347,7 +347,7 @@ qt: make object! [
     ;;exec: join "" compose/deep [(exec either args [join " " parms] [""])]
     clear output
     call/output/wait exec output
-    if all [red? windows-os?] [output: qt/utf-16le-to-utf-8 output]
+    ;if all [red? windows-os?] [output: qt/utf-16le-to-utf-8 output]
     if all [
       source-file?
       not pgm

--- a/system/runtime/win32.reds
+++ b/system/runtime/win32.reds
@@ -76,7 +76,7 @@ win32-startup-ctx: context [
 				handle		[integer!]
 				buffer		[c-string!]
 				len			[integer!]
-				written		[struct! [value [integer!]]]
+				written		[pointer! [integer!]]
 				overlapped	[integer!]
 				return:		[integer!]
 			]


### PR DESCRIPTION
Rebol2's CALL can't capture console output on Windows.
This is because WriteConsoleW not write the output to C's stdout.
