### PR TITLE
Fix GPL violation and prompt protection in console

### DIFF
--- a/runtime/console/input.red
+++ b/runtime/console/input.red
@@ -68,11 +68,13 @@ Red [
 	]
 ]
 
-input: routine [
+ask: routine [
+	prompt [string!]
 	/local
 		len ret str buffer line pos
 ][
 	#either OS = 'Windows [
+		print as c-string! string/rs-head prompt
 		len: 0
 		ret: ReadConsole stdin line-buffer line-buffer-size :len null
 		if zero? ret [print-line "ReadConsole failed!" halt]
@@ -80,7 +82,7 @@ input: routine [
 		line-buffer/pos: null-byte						;-- overwrite CR with NUL
 		str: string/load as-c-string line-buffer len - 1 UTF-16LE
 	][
-		line: read-line null
+		line: read-line as-c-string string/rs-head prompt
 		if line = null [halt]  ; EOF
 
 		add-history line
@@ -91,7 +93,6 @@ input: routine [
 	SET_RETURN(str)
 ]
 
-ask: func [prompt [string!]][
-	prin prompt
-	input
+input: func [][
+	ask ""
 ]


### PR DESCRIPTION
Two console fixes:
1. Switch to the Editline library (BSD-licensed) instead of GNU Readline, to avoid violating the GPL requirements of Readline. As an added bonus, this also brings console history to OSX.
2. Properly pass the prompt down to the Editline call, so that the prompt can be properly protected.

Tested as working on Linux (Ubuntu 14.04, "trusty") and OS X (10.9, "Mavericks"). Editline is bundled by default on at least OSX 10.9, and the 3 most recent LTS versions of Ubuntu (14.04, 12.04, 10.04).
