### PR TITLE
FEAT: handle special float literal 1.#NaN and +/-1.#INF.

### DIFF
--- a/lexer.red
+++ b/lexer.red
@@ -96,7 +96,7 @@ trans-float: routine [
 	]
 
 	cur/1: #"^@"
-	float/box strtod s0 null
+	float/box string/to-float s0
 	cur/1: as-byte 10
 ]
 
@@ -465,11 +465,15 @@ transcode: function [
 	float-exp-rule: [[#"e" | #"E"] opt [#"-" | #"+"] 1 3 digit]
 	
 	float-number-rule: [
-		[dot | comma] some digit opt float-exp-rule e: (type: float!)
+		[dot | comma] [
+			[some digit opt float-exp-rule]
+			| #"#" [[[#"N" | #"n"] [#"a" | #"A"] [#"N" | #"n"]]
+					| [[#"I" | #"i"] [#"N" | #"n"] [#"F" | #"f"]]]
+		] e: (type: float!)
  	]
  	
  	float-rule: [
- 		float-number-rule
+		opt [#"-" | #"+"] float-number-rule
  		ahead [integer-end | ws-no-count | end]
  	]
 	

--- a/runtime/datatypes/float.reds
+++ b/runtime/datatypes/float.reds
@@ -20,10 +20,19 @@ float: context [
 	uint64!: alias struct! [int1 [byte-ptr!] int2 [byte-ptr!]]
 	int64!:  alias struct! [int1 [integer!] int2 [integer!]]
 
-	DOUBLE_MAX: 0.0										;-- rebol can't load INF
-	double-int-union: as uint64! :DOUBLE_MAX			;-- set to largest number
-	double-int-union/int2: as byte-ptr! 7FEFFFFFh
-	double-int-union/int1: as byte-ptr! FFFFFFFFh
+	DOUBLE_MAX: 0.0
+	+INF: 0.0											;-- rebol can't load INF, NaN
+	QNaN: 0.0
+
+	double-int-union: as int64! :DOUBLE_MAX				;-- set to largest number
+	double-int-union/int2: 7FEFFFFFh
+	double-int-union/int1: FFFFFFFFh
+
+	double-int-union: as int64! :+INF
+	double-int-union/int2: 7FF00000h
+
+	double-int-union: as int64! :QNaN					;-- smallest quiet NaN
+	double-int-union/int2: 7FF80000h
 
 	abs: func [
 		value	[float!]

--- a/runtime/datatypes/string.reds
+++ b/runtime/datatypes/string.reds
@@ -59,6 +59,27 @@ string: context [
 
 	utf8-buffer: [#"^(00)" #"^(00)" #"^(00)" #"^(00)"]
 
+	to-float: func [
+		s		[byte-ptr!]
+		return: [float!]
+		/local
+			s0	[byte-ptr!]
+	][
+		s0: s
+		if any [s/1 = #"-" s/1 = #"+"] [s: s + 1]
+		if s/3 = #"#" [										;-- 1.#NaN, -1.#INF" or "1.#INF
+			if any [s/4 = #"I" s/4 = #"i"] [
+				return either s0/1 = #"-" [
+					0.0 - float/+INF
+				][float/+INF]
+			]
+			if any [s/4 = #"N" s/4 = #"n"] [
+				return float/QNaN
+			]
+		]
+		strtod s0 null
+	]
+
 	to-hex: func [
 		value	 [integer!]
 		char?	 [logic!]

--- a/tests/source/units/load-test.red
+++ b/tests/source/units/load-test.red
@@ -54,6 +54,10 @@ Red [
 	--test-- "load-34" --assert "1200.0" = mold load "1.2E3"
 	--test-- "load-35" --assert "10.0"   = mold load ".1E2"
 	--test-- "load-36" --assert "12.3"   = mold load ".123E2"
+	--test-- "load-36" --assert "-0.3"   = mold load "-.3"
+	--test-- "load-36" --assert "1.#NaN"  = mold load "1.#nan"
+	--test-- "load-36" --assert "1.#INF"  = mold load "1.#INF"
+	--test-- "load-36" --assert "-1.#INF" = mold load "-1.#Inf"
 
 ===end-group===
 


### PR DESCRIPTION
FIX: lexer can't handle string like "-.3".
TESTS: added tests for special float literal.
