### PR TITLE
DOCS: fix INC function in the example for #call

### DIFF
--- a/docs/red-system-specs.txt
+++ b/docs/red-system-specs.txt
@@ -3223,7 +3223,7 @@ Once the Red function returns, the normal execution of Red/System code continues
 
  Red []
 
- inc: func [n][n + 1]
+ inc: func [n [integer!]][n + 1]
 
  #system [
  	#call [inc 123]


### PR DESCRIPTION
If no type! specified, will cause compiling error.
