### PR TITLE
FIX: compiler does not compile 'reduce' correctly.

### DIFF
--- a/compiler.r
+++ b/compiler.r
@@ -2456,6 +2456,7 @@ red: context [
 			if into? [comp-expression]				;-- optionally compile /into argument
 			emit-native/with 'reduce reduce [pick [1 -1] into?]
 			emit-close-frame
+			pop-call
 			exit
 		]
 		

--- a/runtime/datatypes/object.reds
+++ b/runtime/datatypes/object.reds
@@ -697,7 +697,7 @@ object: context [
 		#if debug? = yes [if verbose > 0 [print-line "object/mold"]]
 		
 		string/concatenate-literal buffer "make object! ["
-		part: serialize obj buffer only? all? flat? arg part - 15 yes indent + 1
+		part: serialize obj buffer only? all? flat? arg part - 14 yes indent + 1
 		if indent > 0 [part: do-indent buffer indent part]
 		string/append-char GET_BUFFER(buffer) as-integer #"]"
 		part - 1

--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -430,29 +430,21 @@ natives: context [
 		#if debug? = yes [if verbose > 0 [print-line "native/prin"]]
 		
 		arg: stack/arguments
-		
-		either any [
-			TYPE_OF(arg) = TYPE_STRING 						;@@ replace by ANY_STRING?
-			TYPE_OF(arg) = TYPE_FILE
-			TYPE_OF(arg) = TYPE_URL
-		][
-			str: as red-string! arg
-		][
+
+		if TYPE_OF(arg) = TYPE_BLOCK [
 			block/rs-clear buffer-blk
 			stack/push as red-value! buffer-blk
 			assert stack/top - 2 = stack/arguments			;-- check for correct stack layout
-			
-			if TYPE_OF(arg) = TYPE_BLOCK [
-				reduce* 1
-				blk: as red-block! arg
-				blk/head: 0									;-- head changed by reduce/into
-			]
-			actions/form* -1
-			str: as red-string! stack/arguments + 1
-			assert any [
-				TYPE_OF(str) = TYPE_STRING
-				TYPE_OF(str) = TYPE_SYMBOL					;-- symbol! and string! structs are overlapping
-			]
+			reduce* 1
+			blk: as red-block! arg
+			blk/head: 0										;-- head changed by reduce/into
+		]
+
+		actions/form* -1
+		str: as red-string! stack/arguments
+		assert any [
+			TYPE_OF(str) = TYPE_STRING
+			TYPE_OF(str) = TYPE_SYMBOL						;-- symbol! and string! structs are overlapping
 		]
 		series: GET_BUFFER(str)
 		offset: (as byte-ptr! series/offset) + (str/head << (GET_UNIT(series) >> 1))


### PR DESCRIPTION
FIX: mold/part object! incorrectly.
FEAT: code refactoring PRINT native.
