### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+#
+# .travis.yaml contains YAML-formatted (http://www.yaml.org/) build
+# instructions for continuous integration via Travis CI
+# (http://docs.travis-ci.com/).
+#
+
+# Send notifications on every build failure to comitter and author. Never send
+# notifications for sucessful builds.
+notifications:
+    email:
+        on_success: never
+
+# We're not really using C (but Red and Rebol, of course), but setting language
+# to C disables Travis CI's Ruby-specific defaults.
+language: c
+
+before_install:
+    - sudo apt-get update
+
+install:
+    # 32b "multiarch" libraries are necessary to run 32b binaries on the 64b
+    # Travis VM.
+    - sudo apt-get install -y libc6:i386
+    # Rebol 2 is necessary for building Red.
+    - wget http://www.rebol.com/downloads/v278/rebol-core-278-4-2.tar.gz
+    - tar xvfz rebol-core-278-4-2.tar.gz -C /tmp
+    - sudo mv /tmp/releases/rebol-core/rebol /usr/local/bin/rebol2
+
+script:
+    - rebol2 -qws run-all.r --batch


### PR DESCRIPTION
This adds basic continuous integration support via Travis CI, automatically running the regression tests.