### PR TITLE
FIX: issue #1098 (OSX: red console crash upon window resize)

### DIFF
--- a/environment/console/POSIX.reds
+++ b/environment/console/POSIX.reds
@@ -441,6 +441,7 @@ init: func [
 		term [termios!]
 		cc	 [byte-ptr!]
 		so	 [sigaction!]
+		mask [integer!]
 ][
 	relative-y: 0
 	utf-char: as-c-string allocate 10
@@ -449,8 +450,10 @@ init: func [
 	copy-cell as red-value! hist-blk as red-value! history
 
 	so: declare sigaction!						;-- install resizing signal trap
+	mask: (as-integer so) + 4
+	sigemptyset mask
 	so/sigaction: as-integer :on-resize
-	so/flags: 	SA_SIGINFO ;or SA_RESTART
+	so/flags: 0
 	sigaction SIGWINCH so as sigaction! 0
 
 	term: declare termios!

--- a/environment/console/input.red
+++ b/environment/console/input.red
@@ -186,7 +186,7 @@ default-input-completer: func [
 			cp > FFh
 		]
 
-		on-resize: does [
+		on-resize: func [[cdecl] sig [integer!]][
 			get-window-size
 			refresh
 		]

--- a/system/runtime/POSIX.reds
+++ b/system/runtime/POSIX.reds
@@ -18,6 +18,10 @@ Red/System [
 			oldact	[sigaction!]
 			return: [integer!]
 		]
+		sigemptyset: "sigemptyset" [
+			mask	[integer!]
+			return: [integer!]
+		]
 	]
 ]
 


### PR DESCRIPTION
```
struct sigaction {
       void     (*sa_handler)(int);
       void     (*sa_sigaction)(int, siginfo_t *, void *);
       sigset_t   sa_mask;
       int        sa_flags;
       void     (*sa_restorer)(void);
};
```
If SA_SIGINFO is specified in sa_flags, then sa_sigaction (instead of sa_handler) specifies the signal-handling function for signum.
As we use `sa_handler` here, we don't need to set the ` SA_SIGINFO ` flag.