### PR TITLE
FIX: issue #1243 (union with /skip refinement gives incorrect results)

### DIFF
--- a/environment/natives.red
+++ b/environment/natives.red
@@ -350,59 +350,59 @@ parse: make native! [[
 
 union: make native! [[
 		"Returns the union of two data sets"
-		set1 [block! string! bitset! typeset!]
-		set2 [block! string! bitset! typeset!]
+		set1 [block! hash! string! bitset! typeset!]
+		set2 [block! hash! string! bitset! typeset!]
 		/case "Use case-sensitive comparison"
 		/skip "Treat the series as fixed size records"
 			size [integer!]
-		return: [block! string! bitset! typeset!]
+		return: [block! hash! string! bitset! typeset!]
 	]
 	#get-definition NAT_UNION
 ]
 
 unique: make native! [[
 		"Returns the data set with duplicates removed"
-		set [block! string!]
+		set [block! hash! string!]
 		/case "Use case-sensitive comparison"
 		/skip "Treat the series as fixed size records"
 			size [integer!]
-		return: [block! string!]
+		return: [block! hash! string!]
 	]
 	#get-definition NAT_UNIQUE
 ]
 
 intersect: make native! [[
 		"Returns the intersection of two data sets"
-		set1 [block! string! bitset! typeset!]
-		set2 [block! string! bitset! typeset!]
+		set1 [block! hash! string! bitset! typeset!]
+		set2 [block! hash! string! bitset! typeset!]
 		/case "Use case-sensitive comparison"
 		/skip "Treat the series as fixed size records"
 			size [integer!]
-		return: [block! string! bitset! typeset!]
+		return: [block! hash! string! bitset! typeset!]
 	]
 	#get-definition NAT_INTERSECT
 ]
 
 difference: make native! [[
 		"Returns the special difference of two data sets"
-		set1 [block! string! bitset! typeset!]
-		set2 [block! string! bitset! typeset!]
+		set1 [block! hash! string! bitset! typeset!]
+		set2 [block! hash! string! bitset! typeset!]
 		/case "Use case-sensitive comparison"
 		/skip "Treat the series as fixed size records"
 			size [integer!]
-		return: [block! string! bitset! typeset!]
+		return: [block! hash! string! bitset! typeset!]
 	]
 	#get-definition NAT_DIFFERENCE
 ]
 
 exclude: make native! [[
 		"Returns the first data set less the second data set"
-		set1 [block! string! bitset! typeset!]
-		set2 [block! string! bitset! typeset!]
+		set1 [block! hash! string! bitset! typeset!]
+		set2 [block! hash! string! bitset! typeset!]
 		/case "Use case-sensitive comparison"
 		/skip "Treat the series as fixed size records"
 			size [integer!]
-		return: [block! string! bitset! typeset!]
+		return: [block! hash! string! bitset! typeset!]
 	]
 	#get-definition NAT_EXCLUDE
 ]

--- a/runtime/datatypes/block.reds
+++ b/runtime/datatypes/block.reds
@@ -1972,6 +1972,7 @@ block: context [
 		/local
 			blk1	[red-block!]
 			blk2	[red-block!]
+			hs		[red-hash!]
 			new		[red-block!]
 			value	[red-value!]
 			tail	[red-value!]
@@ -2015,10 +2016,10 @@ block: context [
 		n: 2
 		hash: null
 		blk?: yes
-		hash?: either any [
+		hash?: any [
 			TYPE_OF(blk1) = TYPE_HASH
 			TYPE_OF(blk2) = TYPE_HASH
-		][yes][no]
+		]
 
 		until [
 			s: GET_BUFFER(blk1)
@@ -2028,7 +2029,8 @@ block: context [
 			if check? [
 				hash: either TYPE_OF(blk2) = TYPE_HASH [
 					blk?: no
-					as node! blk2/_pad
+					hs: as red-hash! blk2
+					hs/table
 				][
 					if all [blk? hash <> null] [_hashtable/destroy hash]
 					blk?: yes
@@ -2072,8 +2074,9 @@ block: context [
 		]
 
 		either hash? [
-			blk1/header: TYPE_HASH
-			blk1/_pad: as-integer table
+			hs: as red-hash! blk2
+			hs/header: TYPE_HASH
+			hs/table: table
 		][
 			_hashtable/destroy table
 		]

--- a/runtime/datatypes/block.reds
+++ b/runtime/datatypes/block.reds
@@ -1975,6 +1975,7 @@ block: context [
 			new		[red-block!]
 			value	[red-value!]
 			tail	[red-value!]
+			key		[red-value!]
 			i		[integer!]
 			n		[integer!]
 			s		[series!]
@@ -1987,6 +1988,8 @@ block: context [
 			both?	[logic!]
 			find?	[logic!]
 			skip?	[logic!]
+			blk?	[logic!]
+			hash?	[logic!]
 	][
 		step: 1
 		if OPTION?(skip-arg) [
@@ -2011,6 +2014,11 @@ block: context [
 		table: _hashtable/init len new HASH_TABLE_HASH
 		n: 2
 		hash: null
+		blk?: yes
+		hash?: either any [
+			TYPE_OF(blk1) = TYPE_HASH
+			TYPE_OF(blk2) = TYPE_HASH
+		][yes][no]
 
 		until [
 			s: GET_BUFFER(blk1)
@@ -2018,8 +2026,14 @@ block: context [
 			tail: s/tail
 
 			if check? [
-				if hash <> null [_hashtable/destroy hash]
-				hash: _hashtable/init length? blk2 blk2 HASH_TABLE_HASH
+				hash: either TYPE_OF(blk2) = TYPE_HASH [
+					blk?: no
+					as node! blk2/_pad
+				][
+					if all [blk? hash <> null] [_hashtable/destroy hash]
+					blk?: yes
+					_hashtable/init length? blk2 blk2 HASH_TABLE_HASH
+				]
 			]
 
 			while [value < tail] [			;-- iterate over first series
@@ -2042,7 +2056,10 @@ block: context [
 					all [value < tail i < step]
 				][
 					i: i + 1
-					unless skip? [rs-append new value]
+					unless skip? [
+						key: rs-append new value
+						if hash? [_hashtable/put table key]
+					]
 				]
 			]
 
@@ -2053,8 +2070,14 @@ block: context [
 			][n: 0]
 			zero? n
 		]
-		_hashtable/destroy table
-		if check? [_hashtable/destroy hash]
+
+		either hash? [
+			blk1/header: TYPE_HASH
+			blk1/_pad: as-integer table
+		][
+			_hashtable/destroy table
+		]
+		if all [check? blk?][_hashtable/destroy hash]
 		blk1/node: new/node
 		blk1/head: 0
 		stack/pop 1

--- a/runtime/datatypes/block.reds
+++ b/runtime/datatypes/block.reds
@@ -1986,6 +1986,7 @@ block: context [
 			invert? [logic!]
 			both?	[logic!]
 			find?	[logic!]
+			skip?	[logic!]
 	][
 		step: 1
 		if OPTION?(skip-arg) [
@@ -2022,6 +2023,7 @@ block: context [
 			]
 
 			while [value < tail] [			;-- iterate over first series
+				skip?: yes
 				if check? [
 					find?: null <> _hashtable/get hash value 0 1 case? no no
 					if invert? [find?: not find?]
@@ -2030,6 +2032,7 @@ block: context [
 					find?
 					null = _hashtable/get table value 0 1 case? no no
 				][
+					skip?: no
 					_hashtable/put table rs-append new value
 				]
 
@@ -2039,7 +2042,7 @@ block: context [
 					all [value < tail i < step]
 				][
 					i: i + 1
-					rs-append new value
+					unless skip? [rs-append new value]
 				]
 			]
 

--- a/runtime/datatypes/native.reds
+++ b/runtime/datatypes/native.reds
@@ -60,7 +60,7 @@ native: context [
 			]
 			base: base + 1
 		]
-		if base = end [fire [TO_ERROR(script no-refine) fname as red-word! pos]]
+		if base = end [fire [TO_ERROR(script no-refine) fname as red-word! value]]
 
 		s: GET_BUFFER(vec)
 		ref-array: as int-ptr! s/offset

--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -1063,7 +1063,8 @@ natives: context [
 		case?:	  as logic! cased + 1
 		
 		switch TYPE_OF(set1) [
-			TYPE_BLOCK   [block/do-set-op case? as red-integer! skip-arg op]
+			TYPE_BLOCK   
+			TYPE_HASH    [block/do-set-op case? as red-integer! skip-arg op]
 			TYPE_STRING  [string/do-set-op case? as red-integer! skip-arg op]
 			TYPE_BITSET  [bitset/do-bitwise op]
 			TYPE_TYPESET [typeset/do-bitwise op]


### PR DESCRIPTION
FEAT: added set operations for hash! datatype

Note: when one of the two arguments is hash datatype, the set function always returns a hash.