### PR TITLE
FEAT: support integer key in hashtable

### DIFF
--- a/runtime/datatypes/block.reds
+++ b/runtime/datatypes/block.reds
@@ -1471,7 +1471,7 @@ block: context [
 		len: rs-length? blk1
 		len: len + either op = OP_UNION [rs-length? blk2][0]
 		new: make-at as red-block! stack/push* len
-		table: _hashtable/init len new HASH_TABLE_HASH
+		table: _hashtable/init len new HASH_TABLE_HASH 1
 		n: 2
 		hash: null
 		blk?: yes
@@ -1493,7 +1493,7 @@ block: context [
 				][
 					if all [blk? hash <> null] [_hashtable/destroy hash]
 					blk?: yes
-					_hashtable/init rs-length? blk2 blk2 HASH_TABLE_HASH
+					_hashtable/init rs-length? blk2 blk2 HASH_TABLE_HASH 1
 				]
 			]
 

--- a/runtime/datatypes/hash.reds
+++ b/runtime/datatypes/hash.reds
@@ -48,7 +48,7 @@ hash: context [
 		if blk? [
 			block/copy as red-block! spec blk null no null
 		]
-		table: _hashtable/init size blk HASH_TABLE_HASH
+		table: _hashtable/init size blk HASH_TABLE_HASH 1
 		hash: as red-hash! blk
 		hash/header: TYPE_HASH							;-- implicit reset of all header flags
 		hash/table: table
@@ -102,7 +102,7 @@ hash: context [
 
 		block/copy as red-block! hash new part-arg deep? types
 		size: block/rs-length? new
-		table: _hashtable/init size new HASH_TABLE_HASH
+		table: _hashtable/init size new HASH_TABLE_HASH 1
 		hash: as red-hash! new
 		hash/header: TYPE_HASH							;-- implicit reset of all header flags
 		hash/table: table

--- a/runtime/datatypes/map.reds
+++ b/runtime/datatypes/map.reds
@@ -171,7 +171,7 @@ map: context [
 			table [node!]
 			map	  [red-hash!]
 	][
-		table: _hashtable/init size blk HASH_TABLE_MAP
+		table: _hashtable/init size blk HASH_TABLE_MAP 1
 		map: as red-hash! slot
 		map/header: TYPE_MAP							;-- implicit reset of all header flags
 		map/table: table

--- a/runtime/datatypes/series.reds
+++ b/runtime/datatypes/series.reds
@@ -622,7 +622,7 @@ _series: context [
 				hash: as red-hash! ser
 				_hashtable/refresh hash/table 0 - part size
 				hash: as red-hash! ser2
-				hash/table: _hashtable/init part ser2 HASH_TABLE_HASH
+				hash/table: _hashtable/init part ser2 HASH_TABLE_HASH 1
 			]
 		][return as red-value! ser2]
 

--- a/runtime/hashtable.reds
+++ b/runtime/hashtable.reds
@@ -408,7 +408,8 @@ _hashtable: context [
 		h: as hashtable! s/offset
 
 		if h/n-occupied >= h/upper-bound [			;-- update the hash table
-			n-buckets: h/n-buckets + either h/n-buckets > (h/size << 1) [-1][1]
+			vsize: either h/n-buckets > (h/size << 1) [-1][1]
+			n-buckets: h/n-buckets + vsize
 			resize node n-buckets
 		]
 
@@ -542,7 +543,8 @@ _hashtable: context [
 		][return null]
 
 		if h/n-occupied >= h/upper-bound [			;-- update the hash table
-			n-buckets: h/n-buckets + either h/n-buckets > (h/size << 1) [-1][1]
+			idx: either h/n-buckets > (h/size << 1) [-1][1]
+			n-buckets: h/n-buckets + idx
 			resize node n-buckets
 		]
 

--- a/runtime/red.reds
+++ b/runtime/red.reds
@@ -165,7 +165,7 @@ red: context [
 		global-ctx: _context/create 1000 no no
 
 		case-folding/init
-		symbol/table: _hashtable/init 1000 symbols HASH_TABLE_SYMBOL
+		symbol/table: _hashtable/init 1000 symbols HASH_TABLE_SYMBOL 1
 
 		datatype/make-words								;-- build datatype names as word! values
 		words/build										;-- create symbols used internally


### PR DESCRIPTION
New hashtable API:

```
;-- hashtable/init num-of-buckets null HASH_TABLE_INTEGER num-of-values
table: _hashtable/init 16 null HASH_TABLE_INTEGER 2

;-- Put value:
value: as cell! _hashtable/put-key table 0045A387h
copy-cell as cell! str value
copy-cell as cell! int (value + 1)

;-- Get value:
value: as cell! _hashtable/get-value table 0045A387h
str: as red-string!  value               ;-- value 1
int: as red-integer! value + 1           ;-- value 2
```