### PR TITLE
Fix: allow loading url! of type not image! on non Windows platforms

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -287,8 +287,10 @@ load: function [
 			]
 		]
 		url!	[
-			img: read-decode source
-			if image! = type? img [return img]
+			#if OS = 'Windows [
+				img: read-decode source
+				if image! = type? img [return img]
+			]
 			source: read source
 		]
 		binary! [source]

--- a/environment/functions.red
+++ b/environment/functions.red
@@ -287,10 +287,8 @@ load: function [
 			]
 		]
 		url!	[
-			#if OS = 'Windows [
-				img: read-decode source
-				if image! = type? img [return img]
-			]
+			img: read-decode source
+			if image! = type? img [return img]
 			source: read source
 		]
 		binary! [source]


### PR DESCRIPTION
without fix:
```rebol
  load http://domain/source.red
*** Script error: transcode does not allow url for its <anon> argument
*** Where: transcode
```
with fix:
```rebol
  load http://domain/source.red
;   [Red [] print 123]

```
```rebol
system/platform
;   MacOSX
```