### PR TITLE
FEAT: added preliminary support for WAIT native

### DIFF
--- a/environment/natives.red
+++ b/environment/natives.red
@@ -720,3 +720,12 @@ request-file: make native! [[
 	]
 	#get-definition NAT_REQUEST_FILE
 ]
+
+wait: make native! [[
+		"Waits for a duration, port, or both"
+		value [number! block! none!]
+		/all "Returns all in a block"
+		/only "Only check for ports given in the block to this function"
+	]
+	#get-definition NAT_WAIT
+]

--- a/runtime/macros.reds
+++ b/runtime/macros.reds
@@ -221,6 +221,7 @@ Red/System [
 	NAT_DEBASE
 	NAT_TO_LOCAL_FILE
 	NAT_REQUEST_FILE
+	NAT_WAIT
 ]
 
 #enum math-op! [

--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -1701,6 +1701,32 @@ natives: context [
 			multi? <> -1
 	]
 
+	wait*: func [
+		all?	[integer!]
+		only?	[integer!]
+		/local
+			val		[red-float!]
+			int		[red-integer!]
+			time	[integer!]
+			ftime	[float!]
+	][
+		val: as red-float! stack/arguments
+		switch TYPE_OF(val) [
+			TYPE_INTEGER [
+				int: as red-integer! val
+				time: int/value * #either OS = 'Windows [1000][1000000]
+			]
+			TYPE_FLOAT [
+				ftime: val/value * #either OS = 'Windows [1000.0][1000000.0]
+				if ftime < 1.0 [ftime: 1.0]
+				time: float/to-integer ftime
+			]
+			default [fire [TO_ERROR(script invalid-arg) val]]
+		]
+		val/header: TYPE_NONE
+		platform/wait time
+	]
+
 	;--- Natives helper functions ---
 
 	argument-as-float: func [
@@ -2095,6 +2121,7 @@ natives: context [
 			:debase*
 			:to-local-file*
 			:request-file*
+			:wait*
 		]
 	]
 

--- a/runtime/platform/POSIX.reds
+++ b/runtime/platform/POSIX.reds
@@ -37,8 +37,14 @@ Red/System [
 			size	[integer!]
 			return: [byte-ptr!]
 		]
+		usleep: "usleep" [
+			microseconds [integer!]
+			return: 	 [integer!]
+		]
 	]
 ]
+
+wait: func [time [integer!]][usleep time]
 
 ;-------------------------------------------
 ;-- Print a UCS-4 string to console

--- a/runtime/platform/win32.reds
+++ b/runtime/platform/win32.reds
@@ -139,6 +139,9 @@ platform: context [
 				hMem			[integer!]
 				return:			[integer!]
 			]
+			Sleep: "Sleep" [
+				dwMilliseconds	[integer!]
+			]
 		]
 		"gdiplus.dll" stdcall [
 			GdiplusStartup: "GdiplusStartup" [
@@ -152,6 +155,8 @@ platform: context [
 			]
 		]
 	]
+
+	wait: func [time [integer!]][Sleep time]
 
 	error-msg: func [
 		error	[integer!]


### PR DESCRIPTION
Note: the granularity of `wait` is millisecond.