### PR TITLE
added check and prompt for Rebol SDK setup.

### DIFF
--- a/build/build.r
+++ b/build/build.r
@@ -9,6 +9,23 @@ REBOL [
 
 Windows?: system/version/4 = 3
 
+;-- Check Rebol SDK setup
+unless exists? %encap-paths.r [
+	write  %encap-paths.r read  %encap-paths.r.sample
+	print "--------------------------------------------------"
+	print "  Build setup Error!"
+	print ""
+	print "  Rebol SDK paths are not yet setup for building"
+	print ["  unable to find file: " to-local-file clean-path %encap-paths.r ]
+	print ""
+	print "  Created a new %encap-paths.r file..."
+	print "  Edit this file and change the paths to your system's configuration"
+	print "---------------------------------------------"
+	print ""
+	ask "to continue build (after you've edited file) ... ^/ press enter ..."
+	
+]
+
 ;-- Parameters
 encapper: 		%enpro
 bin:			%bin/


### PR DESCRIPTION
build script just checks to see if the sdk path setup was properly created before building.  

if not:
-it prompts user
-copies sample file
-allows him to edit file by pausing build.
-allows him to continues build by pressing enter in the main build window.