### PR TITLE
FIX: improving make pair! asserts

### DIFF
--- a/runtime/datatypes/pair.reds
+++ b/runtime/datatypes/pair.reds
@@ -108,7 +108,7 @@ pair: context [
 				int: as red-integer! spec
 				push int/value int/value
 			]
-			default [
+			TYPE_BLOCK [
 				int: as red-integer! block/rs-head as red-block! spec
 				int2: int + 1
 				if any [
@@ -116,9 +116,13 @@ pair: context [
 					TYPE_OF(int)  <> TYPE_INTEGER
 					TYPE_OF(int2) <> TYPE_INTEGER
 				][
-					print-line "*** MAKE Error: pair expects a block with two integers"
+					fire [TO_ERROR(syntax malconstruct) spec]
 				]
 				push int/value int2/value
+			]
+			default [
+				fire [TO_ERROR(script invalid-type) spec]
+				push 0 0
 			]
 		]
 	]

--- a/runtime/datatypes/pair.reds
+++ b/runtime/datatypes/pair.reds
@@ -43,7 +43,7 @@ pair: context [
 				y: x
 			]
 			default [
-				print-line "*** Math Error: unsupported right operand for pair operation"
+				fire [TO_ERROR(script invalid-type) datatype/push TYPE_OF(right)]
 			]
 		]
 		


### PR DESCRIPTION
Before this fix:
```
red>> make pair! [2.1 3.456]
*** MAKE Error: pair expects a block with two integers
== -858993459x1408749273
red>> 2x2 + 'c
*** Math Error: unsupported right operand for pair operation
== 4408243x2
red>> make pair! 1.2

*** Runtime Error 1: access violation
*** at: 0041A6ECh
```

With this fix:
```
red>> make pair! [2.1 3.456]
*** Syntax error: invalid construction spec: 2.1 3.456
*** Where: make
red>> 2x2 + 'c
*** Script error: word type is not allowed here
*** Where: +
red>> make pair! 1.2
*** Script error: 1.2 type is not allowed here
*** Where: make
```
