### PR TITLE
FIX: #1470 - lexer inconsistency with Rebol for issue! type

### DIFF
--- a/environment/lexer.red
+++ b/environment/lexer.red
@@ -314,9 +314,9 @@ system/lexer: context [
 			digit hexa-upper hexa-lower hexa hexa-char not-word-char not-word-1st
 			not-file-char not-str-char not-mstr-char caret-char
 			non-printable-char integer-end ws-ASCII ws-U+2k control-char
-			four half non-zero path-end base base64-char slash-end
+			four half non-zero path-end base base64-char slash-end not-issue-char
 	][
-		cs:		[- - - - - - - - - - - - - - - - - - - - - -]	;-- memoized bitsets
+		cs:		[- - - - - - - - - - - - - - - - - - - - - - -]	;-- memoized bitsets
 		stack:	clear []
 		count?:	yes										;-- if TRUE, lines counter is enabled
 		line: 	1
@@ -372,12 +372,13 @@ system/lexer: context [
 				#"A" - #"Z" #"a" - #"z" #"+" #"/" #"="
 			]
 			cs/22: charset {[](){}":;}					;-- slash-end
+			cs/23: charset {/\,[](){}"%$@;}				;-- not-issue-char
 		]
 		set [
 			digit hexa-upper hexa-lower hexa hexa-char not-word-char not-word-1st
 			not-file-char not-str-char not-mstr-char caret-char
 			non-printable-char integer-end ws-ASCII ws-U+2k control-char
-			four half non-zero path-end base64-char slash-end
+			four half non-zero path-end base64-char slash-end not-issue-char
 		] cs
 
 		byte: [
@@ -603,7 +604,8 @@ system/lexer: context [
 		]
 
 		issue-rule: [
-			#"#" (type: issue!) s: symbol-rule (
+			#"#" (type: issue!)
+			s: some [ahead [not-issue-char | ws-no-count | control-char] break | skip] e: (
 				if (index? s) = index? e [
 					cause-error 'syntax 'invalid [mold type trim/lines copy skip s -4]
 				]

--- a/lexer.r
+++ b/lexer.r
@@ -75,6 +75,7 @@ lexer: context [
 	UTF8-char: [pos: UTF8-1 | UTF8-2 | UTF8-3 | UTF8-4]
 	
 	not-word-char:  charset {/\^^,[](){}"#%$@:;}
+	not-issue-char: charset {/\,[](){}"%$@;}
 	not-word-1st:	union union not-word-char digit charset {'}
 	not-file-char:  charset {[](){}"@:;}
 	not-url-char:	charset {[](){}";}
@@ -223,7 +224,10 @@ lexer: context [
 		)
 	]
 	
-	issue-rule: [#"#" (type: issue!) s: symbol-rule]
+	issue-rule: [
+		#"#" (type: issue!)
+		s: (stop: [not-issue-char | ws-no-count | control-char])	some UTF8-filtered-char e:
+	]
 	
 	refinement-rule: [slash (type: refinement!) s: symbol-rule]
 	


### PR DESCRIPTION
Before:
```
red>> type? load {#.+.#}
*** Syntax error: invalid value at #
*** Where: do
```
now:
```
red>> type? load {#.+.#}
== issue!
```
