### PR TITLE
FIX: issue #1542 (incorrect conversion from odd whole float! to integer)

### DIFF
--- a/runtime/datatypes/float.reds
+++ b/runtime/datatypes/float.reds
@@ -84,7 +84,6 @@ float: context [
 	][
 		;-- Based on this method: http://stackoverflow.com/a/429812/494472
 		;-- A bit more explanation: http://lolengine.net/blog/2011/3/20/understanding-fast-float-integer-conversions
-		number: either number < 0.0 [number - 0.00000005][number + 0.00000005]
 		f: number + 6755399441055744.0
 		d: as int-ptr! :f
 		d/value
@@ -433,7 +432,7 @@ float: context [
 			TYPE_INTEGER [
 				int: as red-integer! type
 				int/header: TYPE_INTEGER
-				int/value: to-integer either f < 0.0 [f + 0.4999999999999999][f - 0.4999999999999999]
+				int/value: to-integer f
 			]
 			TYPE_PERCENT [
 				fl: as red-float! type

--- a/runtime/datatypes/tuple.reds
+++ b/runtime/datatypes/tuple.reds
@@ -120,7 +120,7 @@ tuple: context [
 				n: n + 1
 				f1: integer/to-float as-integer tp1/n
 				f1: float/do-math-op f1 f2 type
-				v1: float/to-integer either f1 < 0.0 [f1 + 0.4999999999999999][f1 - 0.4999999999999999]
+				v1: float/to-integer f1
 				either v1 > 255 [v1: 255][if negative? v1 [v1: 0]]
 				tp1/n: as byte! v1
 				n = size1

--- a/runtime/datatypes/vector.reds
+++ b/runtime/datatypes/vector.reds
@@ -394,7 +394,7 @@ vector: context [
 			][
 				fl: as red-float! right
 				f1: fl/value
-				v2: float/to-integer either f1 < 0.0 [f1 + 0.4999999999999999][f1 - 0.4999999999999999]
+				v2: float/to-integer f1
 			]
 			while [i < len][
 				v1: get-value-int as int-ptr! p unit


### PR DESCRIPTION
Note: now the convertion will round the float number to nearest number.
This is different from Rebol, which will truncate the float number.

I think we need R/S support to get truncation work correctly.