### PR TITLE
FEAT: always create layered window as a POP_UP window.

### DIFF
--- a/modules/view/backends/windows/base.reds
+++ b/modules/view/backends/windows/base.reds
@@ -327,7 +327,6 @@ BaseWndProc: func [
 		WM_MOUSEACTIVATE [
 			flags: GetWindowLong hWnd GWL_EXSTYLE
 			if flags and WS_EX_LAYERED > 0 [
-				SetActiveWindow GetParent hWnd
 				return 3							;-- do not make it activated when click it
 			]
 		]

--- a/modules/view/backends/windows/gui.reds
+++ b/modules/view/backends/windows/gui.reds
@@ -306,10 +306,7 @@ init: func [
 
 	version-info/dwOSVersionInfoSize: size? OSVERSIONINFO
 	GetVersionEx version-info
-	win8+?: all [
-		version-info/dwMajorVersion >= 6
-		version-info/dwMinorVersion >= 2
-	]
+	win8+?: no
 
 	ver: as red-tuple! #get system/view/platform/version
 


### PR DESCRIPTION
Layered window as child window on windows version above Win 7 has some odd
behaviours. see issue #1635 and issue #1604.

FIX: unfocus parent window when click a base window.