### PR TITLE
console: better support for Ctrl-K and Ctrl-D.

### DIFF
--- a/environment/console/input.red
+++ b/environment/console/input.red
@@ -388,8 +388,25 @@ unless system/console [
 							refresh
 						]
 					]
-					KEY_CTRL_C
+					KEY_CTRL_K [
+						unless string/rs-tail? line [
+							string/remove-part line line/head string/rs-length? line
+							refresh
+						]
+					]
 					KEY_CTRL_D [
+						either string/rs-tail? line [
+							if zero? line/head [
+								string/rs-reset line
+								string/append-char GET_BUFFER(line) as-integer #"q"
+								exit
+							]
+						][
+							string/remove-char line line/head
+							refresh
+						]
+					]
+					KEY_CTRL_C [
 						string/rs-reset line
 						string/append-char GET_BUFFER(line) as-integer #"q"
 						exit


### PR DESCRIPTION
Ctrl-K will erase to end of line.
Ctrl-D will remove character or exit like Ctrl-C if empty line.