### PR TITLE
Some variable scope policy fixes in the curses binding

### DIFF
--- a/system/library/curses/curses.reds
+++ b/system/library/curses/curses.reds
@@ -973,6 +973,8 @@ curses: context [
 
 	with curses [
 
+		stdscr: 0        ; stdscr must be defined globally
+
 		getyx: function [
 			wid      [window!]
 			row      [int-ptr!]
@@ -1083,7 +1085,7 @@ curses: context [
 
 		init-screen: func [
 			return:   [window!]
-			/local src
+			/local scr
 		][
 			scr: initscr
 			raw
@@ -1097,7 +1099,7 @@ curses: context [
 
 		init-console: func [
 			return:   [window!]
-			/local src
+			/local scr
 		][
 			scr: initscr
 			keypad scr true  							;-- return Fkeys

--- a/system/library/curses/examples/curses-example.reds
+++ b/system/library/curses/examples/curses-example.reds
@@ -62,7 +62,7 @@ with curses [
 	]
 	;-------------------------------------
 	init-color-pairs: func [							;--  Initialise 64 color-pairs with 8 basic colors
-		/local id
+		/local id colb colf
 	][
 		colb: COLOR_BLACK
 		colf: COLOR_BLACK


### PR DESCRIPTION
As I can see variables defined within functions are no more global ones in Red > 0.6.0. This behaviour has slightly broken the curses library binding (and helped to find two typos).

Also I'm not sure about the initial value of stdscr, so for now it's just zero.