### PR TITLE
MISS: allow path! for some options in VID dialect

### DIFF
--- a/modules/view/VID.red
+++ b/modules/view/VID.red
@@ -91,7 +91,7 @@ system/view/VID: context [
 			value
 		][
 			if all [
-				type = word!
+				any [type = word! type = path!]
 				value: get value
 				any [
 					all [datatype? expected expected = type? value]


### PR DESCRIPTION
In fetch-options:
fetch-argument must behave similarly to fetch-value

Allow:
view [base 100x100 draw my-obj/my-block]

used for draw,font,para,font-name,font-color,font-size,react