### PR TITLE
FEAT: Transcode/next

### DIFF
--- a/environment/lexer.red
+++ b/environment/lexer.red
@@ -315,6 +315,7 @@ system/lexer: context [
 		dst	[block! none!]
 		/part	
 			length [integer! string!]
+		/next "Load the next value only. Return block with value and new position"
 		return: [block!]
 		/local
 			new s e c hex pos value cnt type process path
@@ -618,7 +619,7 @@ system/lexer: context [
 			slash [
 				some slash (type: word!) e:				;--  ///... case
 				| ahead [not-word-char | ws-no-count | control-char] (type: word!) e: ;-- / case
-				| symbol-rule (type: refinement! s: next s)
+				| symbol-rule (type: refinement! s: skip s 1) ;-- don't use next in place of skip
 			]
 			(to-word stack copy/part s e type)
 		]
@@ -767,7 +768,12 @@ system/lexer: context [
 		unless either part [
 			parse/case/part src red-rules length
 		][
-			parse/case src red-rules
+			either next [
+				parse/case src [any ws literal-value pos:]
+				append/only stack/1 pos
+			][
+				parse/case src red-rules
+			]	
 		][
 			throw-error ['value pos]
 		]

--- a/tests/source/environment/lexer-test.red
+++ b/tests/source/environment/lexer-test.red
@@ -95,5 +95,11 @@ Red [
 
 ===end-group===
 
+===start-group=== "/next"
+		
+	--test-- "next1"
+		--assert [1 " 2 3"] = system/lexer/transcode "1 2 3" make block! 2
+
+===end-group===
 
 ~~~end-file~~~

--- a/tests/source/environment/lexer-test.red
+++ b/tests/source/environment/lexer-test.red
@@ -98,7 +98,7 @@ Red [
 ===start-group=== "/next"
 		
 	--test-- "next1"
-		--assert [1 " 2 3"] = system/lexer/transcode "1 2 3" make block! 2
+		--assert [1 " 2 3"] = system/lexer/transcode/next "1 2 3" make block! 2
 
 ===end-group===
 


### PR DESCRIPTION
USAGE as R3:
red> system/lexer/transcode/next "1 2 3" [ ]
== [1 " 2 3"]

You should pass your own returning block since the default allocated one is of length 200.
Like in:
red> system/lexer/transcode/next "1 2 3" none