### PR TITLE
FIX: Interpreter skip get-word! as return value

### DIFF
--- a/runtime/interpreter.reds
+++ b/runtime/interpreter.reds
@@ -689,7 +689,12 @@ interpreter: context [
 				pc: eval-path value pc end yes no sub? no
 			]
 			TYPE_GET_WORD [
-				copy-cell _context/get as red-word! pc stack/push*
+				value: _context/get as red-word! pc
+				either sub? [
+					stack/push value
+				][
+					stack/set-last value
+				]
 				pc: pc + 1
 			]
 			TYPE_LIT_WORD [


### PR DESCRIPTION
A vicious one which occurs in interpreted code sometimes, and disappear as soon as you try to debug it.
It literally took me hours to figure it out in my failing code... T_T

Red>> (a: 'ok 1 :a)
== ok

Red>> (a: 'ok 1 + 1 :a)    ; NOT OK
== 2

Red>> (a: 'ok 1 + 1 probe :a)
ok
== ok