### PR TITLE
Added SHA 256/384/512 support (Windows only).

### DIFF
--- a/environment/natives.red
+++ b/environment/natives.red
@@ -752,13 +752,13 @@ wait: make native! [[
 ]
 
 checksum: make native! [[
-		"Computes a checksum, CRC, or hash"
+		"Computes a checksum, CRC, or hash. Default is CRC32."
 		data 	[binary! string! file!]
 		/tcp 				"Returns an Internet TCP 16-bit checksum"
 		/hash 				"Returns a hash value"
 			size [integer!] "Size of the hash table"
 		/method				"Method to use"
-			word [word!]	"Methods: SHA1 MD5 CRC32"
+			word [word!]	"Methods: CRC32 MD5 SHA1 SHA256 SHA384 SHA512"
 		/key				"Returns keyed HMAC value"
 			key-value [any-string!] "Key to use"
 		return: [integer! binary!]

--- a/environment/routines.red
+++ b/environment/routines.red
@@ -60,28 +60,10 @@ quit-return: routine [
 	quit status
 ]
 
-;-- The following definitions are used to create op! corresponding operators
-shift-right: routine [
-	"Perform a right (decreasing) signed bit shift operation"
-	data [integer!]
-	bits [integer!]
-][
-	natives/shift* no -1 -1
-]
-shift-left: routine [
-	"Perform a left (increasing) signed bit shift operation"
-	data [integer!]
-	bits [integer!]
-][
-	natives/shift* no 1 -1
-]
-shift-logical: routine [
-	"Perform a right (decreasing) logical/unsigned bit shift operation"
-	data [integer!]
-	bits [integer!]
-][
-	natives/shift* no -1 1
-]
+;-- Following definitions are used to create op! corresponding operators
+shift-right:   routine [data [integer!] bits [integer!]][natives/shift* no -1 -1]
+shift-left:	   routine [data [integer!] bits [integer!]][natives/shift* no 1 -1]
+shift-logical: routine [data [integer!] bits [integer!]][natives/shift* no -1 1]
 
 ;-- Helping routine for console, returns true if last output character was a LF
 last-lf?: routine [/local bool [red-logic!]][

--- a/environment/routines.red
+++ b/environment/routines.red
@@ -60,10 +60,28 @@ quit-return: routine [
 	quit status
 ]
 
-;-- Following definitions are used to create op! corresponding operators
-shift-right:   routine [data [integer!] bits [integer!]][natives/shift* no -1 -1]
-shift-left:	   routine [data [integer!] bits [integer!]][natives/shift* no 1 -1]
-shift-logical: routine [data [integer!] bits [integer!]][natives/shift* no -1 1]
+;-- The following definitions are used to create op! corresponding operators
+shift-right: routine [
+	"Perform a right (decreasing) signed bit shift operation"
+	data [integer!]
+	bits [integer!]
+][
+	natives/shift* no -1 -1
+]
+shift-left: routine [
+	"Perform a left (increasing) signed bit shift operation"
+	data [integer!]
+	bits [integer!]
+][
+	natives/shift* no 1 -1
+]
+shift-logical: routine [
+	"Perform a right (decreasing) logical/unsigned bit shift operation"
+	data [integer!]
+	bits [integer!]
+][
+	natives/shift* no -1 1
+]
 
 ;-- Helping routine for console, returns true if last output character was a LF
 last-lf?: routine [/local bool [red-logic!]][

--- a/runtime/crypto.reds
+++ b/runtime/crypto.reds
@@ -194,7 +194,7 @@ crypto: context [
 				hash	[byte-ptr!]
 				size	[integer!]
 		][
-		    ; The hash buffer needs to be big enough to hold the longest result.
+			; The hash buffer needs to be big enough to hold the longest result.
 			hash: as byte-ptr! "0000000000000000000000000000000000000000000000000000000000000000"
 			provider: 0
 			handle: 0
@@ -204,7 +204,7 @@ crypto: context [
 				ALG_SHA256  [type: CALG_SHA_256  size: 32]
 				ALG_SHA384  [type: CALG_SHA_384  size: 48]
 				ALG_SHA512  [type: CALG_SHA_512  size: 64]
-            ]
+			]
 			CryptAcquireContext :provider null null PROV_RSA_AES CRYPT_VERIFYCONTEXT
 			CryptCreateHash provider type null 0 :handle
 			CryptHashData handle data len 0

--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -2043,6 +2043,18 @@ natives: context [
 						b: crypto/SHA1 data len
 						len: 20
 					]
+					type = crypto/_sha256 [
+						b: crypto/SHA256 data len
+						len: 32
+					]
+					type = crypto/_sha384 [
+						b: crypto/SHA384 data len
+						len: 48
+					]
+					type = crypto/_sha512 [
+						b: crypto/SHA512 data len
+						len: 64
+					]
 					type = crypto/_crc32 [
 						integer/box crypto/CRC32 data len
 						exit


### PR DESCRIPTION
There is some refactoring that could be done in %natives.reds and condensing the %crypto.reds CRC/MD5/SHA* funcs to take an alg type arg. 