### PR TITLE
FIX: #2016 (load-utf16 can't return empty strings)

### DIFF
--- a/runtime/unicode.reds
+++ b/runtime/unicode.reds
@@ -570,7 +570,11 @@ unicode: context [
 		unit: scan-utf16 src size
 		
 		either null? str [
-			node: alloc-series size unit 0
+			node: either size = 0 [
+				alloc-series 1 2 0						;-- create an empty string
+			][
+				alloc-series size unit 0
+			]
 			s: as series! node/value
 		][
 			node: str/node


### PR DESCRIPTION
This bug impact list-env (windows version in /runtime/utils.red), through the call path:
 list-env => load-in => load-utf16

To avoid a crash (because of an inner assertion), alloc-series must be called with a size different of zero.

To test it:
> >> set-env "TEST" none
> == none
> >> print mold list-env
> ...
> "TEST" ""
> ...