### PR TITLE
FEAT: Now returns process exit code and delines 'out and 'err.

### DIFF
--- a/utils/call.r
+++ b/utils/call.r
@@ -336,6 +336,10 @@ context [
 			if msg: try* [res: get-process-info][return msg]
 			res
 		]
-		none
+		
+		if all [out string? out][deline out]
+		if all [err string? err][deline err]
+		
+		cmd/exit-code/int
 	]
 ]


### PR DESCRIPTION
This makes it R2 compatible, as a drop-in replacement for CALL.