### PR TITLE
FIX: change write paths to relative for libred

### DIFF
--- a/system/compiler.r
+++ b/system/compiler.r
@@ -3278,7 +3278,7 @@ system-dialect: make-profilable context [
 					]
 					replace/all tmpl "% " {%"" }
 					replace/all tmpl ">>>" {">>>"}
-					write %/c/dev/red/libred-defs.red tmpl
+					write %./../libred-defs.red tmpl
 				]
 				if empty? exports [
 					throw-error "missing #export directive for library production"

--- a/system/utils/libRed.r
+++ b/system/utils/libRed.r
@@ -380,7 +380,7 @@ libRed: context [
 		]
 		append template mold imports
 		tmpl: load replace/all mold template "[red/" "["
-		write %/c/dev/red/libred-include.red tmpl
+		write %./../libred-include.red tmpl
 		template
 	]
 	


### PR DESCRIPTION
Changed absolute paths to relative, so it works regardless of where the red source folder is.
If this isn't what you were intending to do, feel free to close it.

I did this partly to understand how github pull requests work (so a simple change)