### PR TITLE
FIX: adjust rotate, scale, translate, skew, transform to affect also commands after sub-block

### DIFF
--- a/modules/view/draw.red
+++ b/modules/view/draw.red
@@ -426,8 +426,8 @@ Red/System [
 								DRAW_FETCH_OPT_VALUE(TYPE_PAIR)
 								DRAW_FETCH_OPT_VALUE(TYPE_BLOCK)
 								either pos = cmd [
-									OS-matrix-push :state
 									OS-matrix-rotate as red-integer! start as red-pair! cmd - 1
+									OS-matrix-push :state
 									parse-draw as red-block! cmd DC catch?
 									OS-matrix-pop state
 								][
@@ -438,8 +438,8 @@ Red/System [
 								loop 2 [DRAW_FETCH_VALUE_2(TYPE_INTEGER TYPE_FLOAT)]
 								DRAW_FETCH_OPT_VALUE(TYPE_BLOCK)
 								either pos = cmd [
-									OS-matrix-push :state
 									OS-matrix-scale as red-integer! start as red-integer! cmd - 1
+									OS-matrix-push :state
 									parse-draw as red-block! cmd DC catch?
 									OS-matrix-pop state
 								][
@@ -451,8 +451,8 @@ Red/System [
 								point: as red-pair! start
 								DRAW_FETCH_OPT_VALUE(TYPE_BLOCK)
 								either pos = cmd [
-									OS-matrix-push :state
 									OS-matrix-translate point/x point/y
+									OS-matrix-push :state
 									parse-draw as red-block! cmd DC catch?
 									OS-matrix-pop state
 								][
@@ -464,8 +464,8 @@ Red/System [
 								DRAW_FETCH_OPT_VALUE_2(TYPE_INTEGER TYPE_FLOAT)
 								DRAW_FETCH_OPT_VALUE(TYPE_BLOCK)
 								either pos = cmd [
-									OS-matrix-push :state
 									OS-matrix-skew as red-integer! start as red-integer! cmd - 1
+									OS-matrix-push :state
 									parse-draw as red-block! cmd DC catch?
 									OS-matrix-pop state
 								][
@@ -480,11 +480,11 @@ Red/System [
 								DRAW_FETCH_VALUE(TYPE_PAIR)
 								DRAW_FETCH_OPT_VALUE(TYPE_BLOCK)
 								either pos = cmd [
-									OS-matrix-push :state
 									OS-matrix-transform
 										as red-integer! start
 										as red-integer! value
 										as red-pair! cmd - 1
+									OS-matrix-push :state
 									parse-draw as red-block! cmd DC catch?
 									OS-matrix-pop state
 								][


### PR DESCRIPTION
Within a 'draw' block,commands 'rotate', 'scale', 'translate', 'skew' and 'transform' will not affect commands after a sub-block:
```
view [base 100x100 draw [ translate 10x10 [ pen blue box 0x0 30x30] pen red box 0x0 50x50 ] ]
```
the red rectangle will be drawn at 0x0 instead of 10x10
This happens because state is saved on stack using 'push' before executing one of those commands. When 'pop' is executed, it will discard the effect of that command.
The fix will save state on stack after transformation command is executed and before parsing sub-block.
