### PR TITLE
FEAT: Added 'clip' command for 'draw' dialect

### DIFF
--- a/modules/view/backends/windows/draw.reds
+++ b/modules/view/backends/windows/draw.reds
@@ -1221,6 +1221,20 @@ OS-draw-grad-pen: func [
 		GdipSetPenBrushFill modes/gp-pen brush
 	]
 ]
+	
+OS-set-clip: func [
+	upper	[red-pair!]
+	lower	[red-pair!]
+][
+	GDI+?: yes
+	GdipSetClipRectI
+		modes/graphics
+		upper/x
+		upper/y
+		lower/x - upper/x + 1
+		lower/y - upper/y + 1
+		GDIPLUS_COMBINEMODEREPLACE
+]
 
 OS-matrix-rotate: func [
 	angle	[red-integer!]

--- a/modules/view/backends/windows/win32.reds
+++ b/modules/view/backends/windows/win32.reds
@@ -443,6 +443,8 @@ Red/System [
 #define GDIPLUS_MATRIXORDERPREPEND	0
 #define GDIPLUS_MATRIXORDERAPPEND	1
 
+#define GDIPLUS_COMBINEMODEREPLACE	0
+
 #define TextRenderingHintSystemDefault		0
 #define TextRenderingHintAntiAliasGridFit	3
 
@@ -1767,6 +1769,15 @@ DwmIsCompositionEnabled!: alias function! [
 		GdipRestoreGraphics: "GdipRestoreGraphics" [
 			graphics	[integer!]
 			state		[integer!]
+			return:		[integer!]
+		]
+		GdipSetClipRectI: "GdipSetClipRectI" [
+			graphics	[integer!]
+			x			[integer!]
+			y			[integer!]
+			width 		[integer!]
+			height 		[integer!]
+			combine 	[integer!]
 			return:		[integer!]
 		]
 		GdipRotateWorldTransform: "GdipRotateWorldTransform" [

--- a/modules/view/draw.red
+++ b/modules/view/draw.red
@@ -33,6 +33,7 @@ Red/System [
 		invert-matrix:	symbol/make "invert-matrix"
 		reset-matrix:	symbol/make "reset-matrix"
 		push:			symbol/make "push"
+		clip:			symbol/make "clip"
 		rotate:			symbol/make "rotate"
 		scale:			symbol/make "scale"
 		translate:		symbol/make "translate"
@@ -420,6 +421,18 @@ Red/System [
 									]
 								]
 								OS-draw-image DC as red-image! start point end color border? pattern
+							]
+							sym = clip [
+								loop 2 [DRAW_FETCH_VALUE(TYPE_PAIR)]
+								DRAW_FETCH_OPT_VALUE(TYPE_BLOCK)
+								either pos = cmd [
+									OS-matrix-push :state
+									OS-set-clip as red-pair! start as red-pair! cmd - 1
+									parse-draw as red-block! cmd DC catch?
+									OS-matrix-pop state
+								][
+									OS-set-clip as red-pair! start as red-pair! cmd
+								]
 							]
 							sym = rotate [
 								DRAW_FETCH_VALUE_2(TYPE_INTEGER TYPE_FLOAT)


### PR DESCRIPTION
Basic clip command for draw dialect. It clips a rectangle area specified by coordinates:
```
  clip <top-left> <bottom-right>

  <top-left>     : coordinates of the top-left of the box (pair!).
  <bottom-right> : coordinates of the bottom-right of the box (pair!).
```

If a sub-block follows clip command, it will affect only that sub-block.

Example:
```
view [base 200x200 draw [ clip 10x10 50x50 box 10x10 100x100]]
view [base 200x200 draw [ clip 10x10 50x50 [box 10x10 100x100] box 20x20 100x100]]
```

It can be extended later for non-rectangle areas.
