### PR TITLE
FEAT: Keep rebol console on screen when syntax error occur while compiling red from sources

### DIFF
--- a/system/compiler.r
+++ b/system/compiler.r
@@ -258,6 +258,7 @@ system-dialect: make-profilable context [
 		
 		quit-on-error: does [
 			clean-up
+			if find system/options/args "-show-error" [ halt ]
 			if system/options/args [quit/return 1]
 			halt
 		]


### PR DESCRIPTION
Rebol console does not remain on screen if there is a syntax error in red sources while compiling it.
This change will keep the console on screen giving a chance to developer to see the error message.
Usage: add ```-show-error``` at the end of command line when compiling:
```
rebol -s red.r -t Windows environment/console/gui-console.red -show-error
```