### PR TITLE
Improvements on shape and draw

### DIFF
--- a/modules/view/backends/windows/draw.reds
+++ b/modules/view/backends/windows/draw.reds
@@ -933,15 +933,16 @@ OS-draw-shape-arc: func [
         either GDI+? [
             path: 0
             GdipCreatePath 0 :path	; alternate fill
-            GdipAddPathArcI 
+            GdipAddPathArc 
                 path 
-                as integer! center-x - radius-x
-                as integer! center-y - radius-y
-                as integer! (radius-x * 2.0)
-                as integer! (radius-y * 2.0)
+                as float32! center-x - radius-x
+                as float32! center-y - radius-y
+                as float32! (radius-x * 2.0)
+                as float32! (radius-y * 2.0)
                 as float32! angle-1
                 as float32! angle-len
             m: 0
+
             GdipCreateMatrix :m
             GdipTranslateMatrix m as float32! (center-x * -1) as float32! (center-y * -1) GDIPLUS_MATRIXORDERAPPEND 
             GdipRotateMatrix m as float32! theta GDIPLUS_MATRIXORDERAPPEND

--- a/modules/view/backends/windows/draw.reds
+++ b/modules/view/backends/windows/draw.reds
@@ -591,7 +591,6 @@ OS-draw-shape-beginpath: func [
     /local
         path    [integer!]
 ][
-    GDI+?: false
     either GDI+? [
         path: 0
         GdipCreatePath 0 :path	; alternate fill
@@ -630,16 +629,11 @@ OS-draw-shape-endpath: func [
             GdipDeletePath modes/gp-path
         ][ if count > max-edges [ result: false ] ]
     ][
+        if close? [ CloseFigure dc ]
         EndPath dc
         count: GetPath dc edges types 0
         either all [ count > 0 count <= max-edges ][
             count: GetPath dc edges types count
-            if close? [
-                point: edges + count
-                point/x: edges/x
-                point/y: edges/y
-                count: count + 1
-            ]
             FillPath dc
             PolyDraw dc edges types count
         ][ if count > max-edges [ result: false ] ]
@@ -771,7 +765,7 @@ OS-draw-shape-axis: func [
         either GDI+? [
             GdipAddPathLine2I modes/gp-path edges nb
         ][
-            PolylineTo dc edges nb
+            Polyline dc edges nb
         ]
         prev-shape/type: SHAPE_OTHER
     ]
@@ -979,8 +973,6 @@ OS-draw-shape-arc: func [
             prev-dir: GetArcDirection dc
             arc-dir: either sweep? [ AD_CLOCKWISE ][ AD_COUNTERCLOCKWISE ]
             SetArcDirection dc arc-dir
-            pt: declare tagPOINT
-            MoveToEx dc as integer! arc-points/start-x as integer! arc-points/start-y pt
             Arc
                 dc
                 as integer! center-x - radius-x

--- a/modules/view/backends/windows/draw.reds
+++ b/modules/view/backends/windows/draw.reds
@@ -1876,17 +1876,42 @@ OS-draw-grad-pen: func [
 ]
 	
 OS-set-clip: func [
-	upper	[red-pair!]
-	lower	[red-pair!]
+	upper	[red-value!]
+	lower	[red-value!]
+    rect?   [logic!]
+    dc      [handle!]
+    /local
+        u   [red-pair!]
+        l   [red-pair!]
 ][
-	GDI+?: yes
-	GdipSetClipRectI
-		modes/graphics
-		upper/x
-		upper/y
-		lower/x - upper/x + 1
-		lower/y - upper/y + 1
-		GDIPLUS_COMBINEMODEREPLACE
+    either GDI+? [
+        either rect? [
+            u: as red-pair! upper
+            l: as red-pair! lower
+            GdipSetClipRectI
+                modes/graphics
+                u/x
+                u/y
+                l/x - u/x + 1
+                l/y - u/y + 1
+                GDIPLUS_COMBINEMODEREPLACE
+        ][
+            GdipSetClipPath
+                modes/graphics
+                modes/gp-path
+                GDIPLUS_COMBINEMODEREPLACE
+            GdipDeletePath modes/gp-path
+        ]
+    ][
+        if rect? [
+            u: as red-pair! upper
+            l: as red-pair! lower
+            BeginPath dc
+            Rectangle dc u/x u/y l/x l/y  
+        ]
+        EndPath dc  ;-- a path has already been started
+        SelectClipPath dc RGN_COPY
+    ]
 ]
 
 OS-matrix-rotate: func [

--- a/modules/view/backends/windows/draw.reds
+++ b/modules/view/backends/windows/draw.reds
@@ -66,6 +66,7 @@ arcPOINTS!: alias struct! [
     end-x       [float!]
     end-y       [float!]
 ]
+connect-subpath: 0
 
 anti-alias?: no
 GDI+?: no
@@ -523,6 +524,7 @@ draw-curves: func [
     prev-shape/type: SHAPE_CURVE
     prev-shape/control/x: point/x
     prev-shape/control/y: point/y
+	connect-subpath: 1
 ]
 
 draw-short-curves: func [
@@ -584,6 +586,7 @@ draw-short-curves: func [
         pt: edges
         nb: 0
     ]
+	connect-subpath: 1
 ]
 
 OS-draw-shape-beginpath: func [
@@ -591,6 +594,7 @@ OS-draw-shape-beginpath: func [
     /local
         path    [integer!]
 ][
+    connect-subpath: 0
     either GDI+? [
         path: 0
         GdipCreatePath 0 :path	; alternate fill
@@ -655,6 +659,7 @@ OS-draw-shape-moveto: func [
         path-last-point/x: coord/x
         path-last-point/y: coord/y
     ]
+	connect-subpath: 0
     last-point?: yes
     prev-shape/type: SHAPE_OTHER
     either GDI+? [
@@ -706,6 +711,7 @@ OS-draw-shape-line: func [
     ]
 	last-point?: yes
     prev-shape/type: SHAPE_OTHER
+	connect-subpath: 1
 ]
 
 OS-draw-shape-axis: func [
@@ -768,6 +774,7 @@ OS-draw-shape-axis: func [
             Polyline dc edges nb
         ]
         prev-shape/type: SHAPE_OTHER
+		connect-subpath: 1
     ]
 ]
 
@@ -945,7 +952,7 @@ OS-draw-shape-arc: func [
             GdipTransformPath path m  
             GdipDeleteMatrix m
 
-            GdipAddPathPath modes/gp-path path 0
+            GdipAddPathPath modes/gp-path path connect-subpath
             GdipDeletePath path
         ][
             either theta <> 0.0 [
@@ -995,6 +1002,7 @@ OS-draw-shape-arc: func [
         path-last-point/x: as integer! p2-x
         path-last-point/y: as integer! p2-y
         prev-shape/type: SHAPE_OTHER
+		connect-subpath: 1
     ]
 ]
 

--- a/modules/view/backends/windows/win32.reds
+++ b/modules/view/backends/windows/win32.reds
@@ -2313,6 +2313,16 @@ XFORM!: alias struct! [
 			sweepAngle	[float32!]
 			return:		[integer!]
 		]
+		GdipAddPathArc: "GdipAddPathArc" [
+			path		[integer!]
+			x			[float32!]
+			y			[float32!]
+			width		[float32!]
+			height		[float32!]
+			startAngle	[float32!]
+			sweepAngle	[float32!]
+			return:		[integer!]
+		]
         GdipAddPathBeziersI: "GdipAddPathBeziersI" [
             path        [integer!]
             points      [tagPOINT]

--- a/modules/view/backends/windows/win32.reds
+++ b/modules/view/backends/windows/win32.reds
@@ -1713,6 +1713,10 @@ XFORM!: alias struct! [
             hdc         [handle!]
             return:     [logic!]
         ]
+        CloseFigure: "CloseFigure" [
+            hdc         [handle!]
+            return:     [logic!]
+        ]
 		Polyline: "Polyline" [
 			hdc			[handle!]
 			lppt		[tagPOINT]

--- a/modules/view/backends/windows/win32.reds
+++ b/modules/view/backends/windows/win32.reds
@@ -510,6 +510,8 @@ Red/System [
 #define AD_COUNTERCLOCKWISE 1
 #define AD_CLOCKWISE        2
 
+#define RGN_COPY            5
+
 BUTTON_IMAGELIST: alias struct! [
 	handle		[integer!]
 	left		[integer!]
@@ -1687,6 +1689,11 @@ XFORM!: alias struct! [
 			nHeight		[integer!]
 			return:		[logic!]
 		]
+        SelectClipPath: "SelectClipPath" [
+            hdc         [handle!]
+            iMode       [integer!]
+            return:     [logic!]
+        ]
         BeginPath: "BeginPath" [
             hdc         [handle!]
             return:     [logic!]
@@ -1937,6 +1944,12 @@ XFORM!: alias struct! [
 			combine 	[integer!]
 			return:		[integer!]
 		]
+        GdipSetClipPath: "GdipSetClipPath" [
+			graphics	[integer!]
+			path		[integer!]
+            combineMode [integer!]
+            return:     [integer!]
+        ]
 		GdipRotateWorldTransform: "GdipRotateWorldTransform" [
 			graphics	[integer!]
 			angle		[float32!]

--- a/modules/view/draw.red
+++ b/modules/view/draw.red
@@ -221,7 +221,6 @@ Red/System [
                 sym     [integer!]
                 rel?    [logic!]
                 close?  [logic!]
-                first?  [logic!]
                 sweep?  [logic!]
                 large?  [logic!]
         ][
@@ -231,7 +230,6 @@ Red/System [
             close?: no
             OS-draw-shape-beginpath DC
             while [cmd < tail][
-                first?: either cmd = block/rs-head cmds [ yes ][ no ]
                 case [
                     any [ TYPE_OF(cmd) = TYPE_WORD TYPE_OF(cmd) = TYPE_LIT_WORD ][
                         rel?: TYPE_OF(cmd) = TYPE_LIT_WORD
@@ -254,10 +252,8 @@ Red/System [
                             any [ sym = hline sym = vline ][
                                 DRAW_FETCH_VALUE_2(TYPE_INTEGER TYPE_FLOAT)
                                 DRAW_FETCH_SOME_2(TYPE_INTEGER TYPE_FLOAT)
-                                unless first? [
-                                    OS-draw-shape-axis DC start cmd rel? (sym = hline)
-                                    close?: yes
-                                ]
+                                OS-draw-shape-axis DC start cmd rel? (sym = hline)
+                                close?: yes
                             ]
                             sym = _arc [
                                 sweep?: false


### PR DESCRIPTION
Following improvements have been done:

- FEAT: Shape - preserve last point among different shape blocks
Last point of a shape block will be saved and used as start point for next shape block within same draw block if no 'move' command used before using one of drawing shape commands. This might be useful when drawing one shape requires changing different graphic attributes (pen, fill, width). In this case shape block can be split and next shape block can continue from where it stopped previous block.

- FEAT: Draw - Improve clip command
Clip command have been improved by allowing to clip a region (given by a path), not only a rectangle. The region can be specified as a block of shape commands, like:
```
view [base 200x200 draw [clip [move 80x120 'arc 1x1 30 30 0 large sweep] fill-pen red box 0x0 199x199]]
```

- FIX: Shape - joint mismatch for shape arc when scaled
Multiple figures does not join exactly when shape is scaled. With this fix, they will join exactly.

- FIX: Shape - make GDI start end points as float!
For GDI, start and end points were ```integer!``` type which might lead to incorrect join for multiple figures. With this fix, they are of type ```float!```

- FIX: Shape - GDI shape arc start point
Removed explicit setting of current position with ```MoveToEx``` and improving ```OS-draw-shape-endpath``` by using ```CloseFigure``` API

- FIX: Shape - GDI+ connect subpaths
```arc``` shape must be part of current path if not preceded by  ```move``` command
