### PR TITLE
FIX: Clarify Rebol SDK is not needed for sources

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -1,6 +1,8 @@
 Building Red binaries
 ------------------------
 
+_Note: This is **not** required to build or run red from sources. It is for a feature used by the red team. Check the [main readme](/README.md#running-red-from-the-sources) if you want to build red from sources_
+
 _Prerequisite_
 
 _You need a [Rebol SDK](http://www.rebol.com/sdk.html) copy with a valid license file in order to rebuild the Red binary, this is a constraint from using Rebol2 for the bootstrapping. Once selfhosted, Red will not have such constraint._


### PR DESCRIPTION
Since people keep asking this question. As this is temporary, when the time comes, this message and the SDK requirement can be removed. So I don't see any reason not to add this note.

The wording could be improved tho