### PR TITLE
FIX: Replace function infinite loop problem

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -196,7 +196,9 @@ replace: function [
 				pos: insert pos value
 			]
 		][
-			while [pos: find pos :pattern][pos/1: value]
+			while [pos: find pos :pattern][
+				pos: change pos value
+			]
 		]
 	][
 		if pos: find series :pattern [

--- a/tests/source/units/series-test.red
+++ b/tests/source/units/series-test.red
@@ -960,6 +960,7 @@ Red [
 		--assert "Xbab" = replace "abab" #"a" #"X"
 		--assert "XbXb" = replace/all "abab" #"a" #"X"
 		--assert "Xab" = replace "abab" "ab" "X"
+		--assert "abab" = replace/all "abab" #"a" #"a"
 
 	--test-- "replace-bin"
 		--assert #{FF0201} = replace #{010201} #{01} #{FF}


### PR DESCRIPTION
This PR fixes infinite loop problem for `replace/all "abab" #"a" #"a"` 