### PR TITLE
Add .editorconfig.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+indent_size = 4


### PR DESCRIPTION
GitHub will use this indent size when rendering files which makes it a bit nicer to browse the red repro online as everything lines up better.

Example comparison:
- [With change](https://github.com/jacobdufault/red/blob/add-editor-config/modules/view/view.red#L33)
- [Without change](https://github.com/red/red/blob/master/modules/view/view.red#L33)