### PR TITLE
FEAT: adding support for `time!` as an argument for `wait` native

### DIFF
--- a/environment/natives.red
+++ b/environment/natives.red
@@ -735,8 +735,8 @@ to-local-file: make native! [[
 ]
 
 wait: make native! [[
-		"Waits for a duration in seconds"
-		value [number! block! none!]
+		"Waits for a duration in seconds or specified time"
+		value [number! time! block! none!]
 		/all "Returns all in a block"
 		;/only "Only check for ports given in the block to this function"
 	]

--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -2082,6 +2082,9 @@ natives: context [
 				if ftime < 1.0 [ftime: 1.0]
 				time: as-integer ftime
 			]
+			TYPE_TIME [
+				time: as-integer (val/value / #either OS = 'Windows [1E6][1E3])
+			]
 			default [fire [TO_ERROR(script invalid-arg) val]]
 		]
 		val/header: TYPE_NONE


### PR DESCRIPTION
Now it is possible to use `time!` to represent time.
```
>> t: now/time/precise wait 0:0:0.1 now/time/precise - t
== 0:00:00.100000001
>> t: now/time/precise wait 42:0:0.01 now/time/precise - t
== 42:00:00.010000001
```