### PR TITLE
FEAT: debug function for displaying size of arguments and call stacks

### DIFF
--- a/runtime/stack.reds
+++ b/runtime/stack.reds
@@ -762,5 +762,9 @@ stack: context [										;-- call stack
 				(as-integer ctop + 2 - cbottom) >> 4
 			print-line ["ctop: " ctop]
 		]
+		dump-size: does [
+			print-line ["Arguments: " as-integer ( top - bottom)  "/" as-integer (a-end - bottom)]
+			print-line ["Call.....: " as-integer (ctop - cbottom) "/" as-integer (c-end - cbottom)]
+		]
 	]
 ]


### PR DESCRIPTION
This function could be useful to trace stack leaks.