### PR TITLE
Improvement for converting floats and integers from string

### DIFF
--- a/system/utils/libRedRT-exports.r
+++ b/system/utils/libRedRT-exports.r
@@ -1,6 +1,8 @@
 [
 	red/boot
 	red/get-build-date
+	red/string-float
+	red/string-number
 	red/copy-cell
 	;red/get-root
 	red/get-root-node2

--- a/tests/source/units/convert-test.red
+++ b/tests/source/units/convert-test.red
@@ -90,6 +90,8 @@ Red [
 	--test-- "to-integer!-21"			--assert 32400 == to integer! 09:00
 	--test-- "to-integer!-22"			--assert 86399 == to integer! 23:59:59
 	--test-- "to-integer!-23"			--assert 86400 == to integer! 23:59:59.999999
+	--test-- "to-integer!-24"			--assert 14 == to integer! 1423.5%
+	--test-- "to-integer!-25"			--assert 14 == to integer! "1423.5%"
 	
 ===end-group===
 
@@ -128,6 +130,8 @@ Red [
 			float! == type? to float! 23:59:59.999999
 			86399.999999 = to float! 23:59:59.999999
 		]
+	--test-- "to-float!-11"				--assert 14.235 == to float! 1423.5%
+	--test-- "to-float!-12"				--assert 14.235 == to float! "1423.5%"
 	
 ===end-group===
 


### PR DESCRIPTION
Let me know if I placed correctly functions in ```common.reds```

Main reason of the change is to get rid of extra memory allocation during conversion.
Now it works also:
```
>> to integer! "15623%"
== 156
```

Error message displayed like:
```
>> to integer! "156#23%"
*** Script Error: cannot MAKE/TO percent! from: "156#23%"
*** Where: to
```