### PR TITLE
Update run-all.r (removed 'ask' to avoid halting tests)

### DIFF
--- a/run-all.r
+++ b/run-all.r
@@ -113,7 +113,6 @@ either batch-mode [
 	quit/return either qt/test-run/failures > 0 [1] [0]
 ][
 	print ["The test output was logged to" qt/log-file]
-	ask "hit enter to finish"
 	print ""
 	qt/test-run/failures
 ]


### PR DESCRIPTION
I'm running a test suite on a debian docker container:
https://circleci.com/gh/eranws/red-docker/53

Is the `ask` necessary at the end of the tests? it causes the system to halt (for ~10minutes until timeout)