### PR TITLE
FEAT: on-drop-files event handler on Windows

### DIFF
--- a/modules/view/backends/platform.red
+++ b/modules/view/backends/platform.red
@@ -172,6 +172,8 @@ system/view/platform: context [
 				EVT_TIME
 				EVT_DRAWING
 				EVT_SCROLL
+
+				EVT_DROP_FILES
 			]
 			
 			#enum event-flag! [
@@ -346,6 +348,7 @@ system/view/platform: context [
 			_time:			word/load "time"
 			_drawing:		word/load "drawing"
 			_scroll:		word/load "scroll"
+			_drop-files:	word/load "drop-files"
 
 			_track:			word/load "track"
 			_page-left:		word/load "page-left"
@@ -425,6 +428,7 @@ system/view/platform: context [
 					EVT_ROTATE		 [_rotate]
 					EVT_TWO_TAP		 [_two-tap]
 					EVT_PRESS_TAP	 [_press-tap]
+					EVT_DROP_FILES	 [_drop-files]
 				]
 			]
 			
@@ -471,6 +475,7 @@ system/view/platform: context [
 					sym = _rotate/symbol		[sym: EVT_ROTATE]
 					sym = _two-tap/symbol		[sym: EVT_TWO_TAP]
 					sym = _press-tap/symbol		[sym: EVT_PRESS_TAP]
+					sym = _drop-files/symbol 	[sym: EVT_DROP_FILES]
 					true [
 						fire [TO_ERROR(script not-event-type) word]
 					]

--- a/modules/view/backends/windows/events.reds
+++ b/modules/view/backends/windows/events.reds
@@ -306,15 +306,15 @@ get-event-picked: func [
 			buf: allocate bsz ;allocates temp buffer used to query dropped file names
 			i: 0
 			while [i < num][
-				sz: 1 + DragQueryFile msg/wParam i null 0 ;returns the required size, in characters
-				if sz > bsz [
+				sz: DragQueryFile msg/wParam i null 0 ;returns the required size, in characters
+				if sz >= bsz [
 					;reallocating temp buffer to hold result
 					free buf
-					bsz: sz
+					bsz: sz + 1
 					buf: allocate bsz
 				]
 				if 0 <> DragQueryFile msg/wParam i buf bsz [
-					string/load-in as c-string! buf sz - 1 blk UTF-16LE
+					string/load-in as c-string! buf sz blk UTF-16LE
 				]
 				i: i + 1
 			]

--- a/modules/view/backends/windows/events.reds
+++ b/modules/view/backends/windows/events.reds
@@ -319,6 +319,8 @@ get-event-picked: func [
 				i: i + 1
 			]
 			free buf
+			DragFinish msg/wParam ;- this will prevent receiving any content from multiple `event/picked`
+			                      ;- calls but better to do it than have some memory leak
 			blk
 		]
 		default	 [integer/push evt/flags << 16 >> 16]

--- a/modules/view/backends/windows/events.reds
+++ b/modules/view/backends/windows/events.reds
@@ -1172,9 +1172,6 @@ WndProc: func [
 				]
 			]
 		]
-		;WM_DROPFILES [
-		;	print-line "DROP FILES!! events.reds WndProc"
-		;]
 		default [0]
 	]
 	if ext-parent-proc? [call-custom-proc hWnd msg wParam lParam]

--- a/modules/view/backends/windows/gui.reds
+++ b/modules/view/backends/windows/gui.reds
@@ -752,6 +752,8 @@ init-window: func [										;-- post-creation settings
 	SetWindowLong handle wc-offset - 4 0
 	SetWindowLong handle wc-offset - 24 0
 
+	DragAcceptFiles handle true
+
 	modes: SWP_NOZORDER
 
 	if bits and FACET_FLAGS_MODAL	  <> 0 [

--- a/modules/view/backends/windows/win32.reds
+++ b/modules/view/backends/windows/win32.reds
@@ -299,6 +299,7 @@ Red/System [
 #define WM_MOVING			0216h
 #define WM_ENTERSIZEMOVE	0231h
 #define WM_EXITSIZEMOVE		0232h
+#define WM_DROPFILES		0233h
 #define WM_IME_SETCONTEXT	0281h
 #define WM_IME_NOTIFY		0282h
 #define WM_COPY				0301h
@@ -2707,6 +2708,19 @@ XFORM!: alias struct! [
 			pidl		[integer!]
 			pszPath		[byte-ptr!]
 			return:		[logic!]
+		]
+		DragAcceptFiles: "DragAcceptFiles" [
+			hWnd	[handle!]
+			fAccept [logic!]
+		]
+		DragQueryFile: "DragQueryFileW" [
+			hDrop    [integer!]
+			iFile    [integer!]  ;Index of the file to query. If the value of this parameter is 0xFFFFFFFF, DragQueryFile returns a count of the files dropped.
+			lpszFile [byte-ptr!] ;The address of a buffer that receives the file name of a dropped file when the function returns.
+								 ; This file name is a null-terminated string. If this parameter is NULL, DragQueryFile returns
+								 ; the required size, in characters, of this buffer.
+			cch      [integer!]  ;The size, in characters, of the lpszFile buffer.
+			return:  [integer!]  ;A nonzero value indicates a successful call.
 		]
 	]
 	"ole32.dll" stdcall [

--- a/modules/view/backends/windows/win32.reds
+++ b/modules/view/backends/windows/win32.reds
@@ -2722,6 +2722,10 @@ XFORM!: alias struct! [
 			cch      [integer!]  ;The size, in characters, of the lpszFile buffer.
 			return:  [integer!]  ;A nonzero value indicates a successful call.
 		]
+		DragFinish: "DragFinish" [
+			;Releases memory that the system allocated for use in transferring file names to the application.
+			hDrop    [integer!]
+		]
 	]
 	"ole32.dll" stdcall [
 		CoTaskMemFree: "CoTaskMemFree" [

--- a/modules/view/view.red
+++ b/modules/view/view.red
@@ -554,6 +554,7 @@ system/view: context [
 		drag-start		on-drag-start
 		drag			on-drag
 		drop			on-drop
+		drop-files		on-drop-files
 		click			on-click
 		dbl-click		on-dbl-click
 		over			on-over

--- a/tests/view-drop-files.red
+++ b/tests/view-drop-files.red
@@ -1,0 +1,65 @@
+Red [
+	Purpose: "Test drop-files event handlers"
+	Needs: 'View
+	Author: "Oldes"
+	File: 	%view-drop-files.reds
+	Tabs: 	4
+	Rights: "Copyright (C) 2017 Oldes. All rights reserved."
+	License: {
+		Distributed under the Boost Software License, Version 1.0.
+		See https://github.com/red/red/blob/master/BSL-License.txt
+	}
+]
+
+system/view/debug?: no ;turn this on to see more info
+
+result: none
+
+win: layout [
+	title "VID drop-files event test"
+	below
+	text "Drop file or multiple files into this window"
+	result: area 600x400 "no files dropped yet"
+]
+
+;this is example how to handle dropped files per window:
+
+win/actors: make object! [
+	on-drop-files: function [face [object!] event [event!]][
+		clear result/text
+		foreach file event/picked [
+			append append result/text file lf
+		]
+	]
+]
+
+view win
+
+;or it is possible to handle it for all windows:
+;note: print output will be visible only if run from console
+
+on-drop-files-global: func [face [object!] event [event!]][
+	if event/type = 'drop-files [
+		print "dropped-files:" ;@@ this will crash compiled script, I don't know how to make it interpreted and also compiled with one file:/
+		clear result/text
+		foreach file event/picked [
+			probe file
+			append append result/text file lf
+		]
+		print "target face:"
+		dump-face face
+	]
+	none
+]
+
+insert-event-func :on-drop-files-global
+
+view/no-wait win
+view layout [
+	size 550x240
+	title "VID drop-files event test 2"
+	text "This is just some window for testing global on-drop-files event."
+]
+
+;this will remove the global handler:
+remove-event-func :on-drop-files-global


### PR DESCRIPTION
With this modification it is possible on Windows drag files from OS and drop them into Red opened windows. Result is an event with block of file names.

See `tests\view-drop-files.red` file for basic usage example.

So far it is only for Windows... other systems will just ignore this event so nothing will be fired there.