### PR TITLE
FIX: HiDPI should be enabled on macOS.

### DIFF
--- a/system/assets/macOS/Info.plist
+++ b/system/assets/macOS/Info.plist
@@ -20,5 +20,7 @@
 	<string>org.redlang.$Red-App-Name$</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.8.0</string>
+    <key>NSHighResolutionCapable</key>
+    <string>YES</string>
 </dict>
 </plist>


### PR DESCRIPTION
macOS apps built by Red compiler are running in low resolution.
Reference: https://developer.apple.com/library/content/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Explained/Explained.html