### PR TITLE
FEAT: [R/S] preliminary support for [bytes! <size>] definitions in struct

### DIFF
--- a/system/compiler.r
+++ b/system/compiler.r
@@ -184,6 +184,7 @@ system-dialect: make-profilable context [
 			| 'c-string!
 			| 'pointer! into [pointer-syntax]
 			| 'struct!  into [struct-syntax] opt 'value
+			| 'bytes! integer!
 		]
 
 		type-spec: [
@@ -604,6 +605,7 @@ system-dialect: make-profilable context [
 					enum-type? name
 					type: [integer!]
 				]
+				name <> 'bytes!
 				not type: find-aliased name
 				any [
 					all [silent return none]
@@ -621,6 +623,7 @@ system-dialect: make-profilable context [
 				local?: all [locals select locals name]
 				select-globals name
 			]
+			if all [block? type type/1 = 'bytes!][ return type ]
 			if all [not type pos: select functions decorate-fun name][
 				if mark: find pos: pos/4 /local [
 					pos: copy/part pos mark			;-- remove locals
@@ -692,7 +695,10 @@ system-dialect: make-profilable context [
 						check-path-index path 'string
 						[byte!]
 					]
-
+					bytes! [ 
+						check-path-index path  'bytes
+						[byte!]
+					]
 				] path-error
 			][
 				resolve-path-type/parent next path second type
@@ -1325,6 +1331,10 @@ system-dialect: make-profilable context [
 					type
 					type/1 = 'integer!
 					enum-type? expected/1				;-- TODO: add also a value check for enums
+				]
+				all [
+					type
+					type/1 = 'bytes!
 				]
 			][
 				if expected = type [type: 'null]		;-- make null error msg explicit

--- a/system/compiler.r
+++ b/system/compiler.r
@@ -623,7 +623,7 @@ system-dialect: make-profilable context [
 				local?: all [locals select locals name]
 				select-globals name
 			]
-			if all [block? type type/1 = 'bytes!][ return type ]
+
 			if all [not type pos: select functions decorate-fun name][
 				if mark: find pos: pos/4 /local [
 					pos: copy/part pos mark			;-- remove locals

--- a/system/targets/IA-32.r
+++ b/system/targets/IA-32.r
@@ -921,6 +921,7 @@ make-profilable make target-class [
 		
 		either any [
 			all [type/1 = 'struct! 'value = last spec/(path/2)]
+			type/1 = 'bytes!
 			all [
 				get-word? first head path
 				tail? skip path 2
@@ -1055,7 +1056,7 @@ make-profilable make target-class [
 		if verbose >= 3 [print [">>>loading path:" mold path]]
 
 		switch type [
-			c-string! [emit-c-string-path path parent]
+			c-string! bytes! [emit-c-string-path path parent]
 			pointer!  [emit-pointer-path  path parent]
 			struct!   [emit-access-path   path parent]
 		]
@@ -1092,7 +1093,7 @@ make-profilable make target-class [
 		]
 
 		switch type [
-			c-string! [emit-c-string-path path parent]
+			c-string! bytes! [emit-c-string-path path parent]
 			pointer!  [emit-pointer-path  path parent]
 			struct!   [
 				unless parent [parent: emit-access-path/short path parent]

--- a/system/targets/target-class.r
+++ b/system/targets/target-class.r
@@ -141,6 +141,7 @@ target-class: context [
 					type: compiler/get-type arg
 					any [
 						all [cdecl type/1 = 'float32! 8]	;-- promote to C double
+						all [type/1 = 'bytes! ptr-size ]    ;-- promote bytes! as byte-ptr!
 						emitter/size-of? type
 					]
 				]

--- a/system/tests/bytes-struct.reds
+++ b/system/tests/bytes-struct.reds
@@ -10,7 +10,7 @@ s!: alias struct! [
     a [integer!]
     b [bytes! 2]
     c [bytes! 2]
-    d [bytes! 1]
+    d [bytes! 10]
     e [integer!] ;note that this value will be aligned
 ]
 s: declare s!
@@ -20,7 +20,7 @@ s/a: 42
 s/e: 24
 
 print-line ["Test struct size: " size? s]
-if 16 <> size? s [
+if 24 <> size? s [
     print-line "Invalid test struct size! Should be 16."
 ]
 print-line ["Value pointers:"]
@@ -28,7 +28,7 @@ print-line ["^-s/a: " :s/a " offset: " as integer! (:s/a - p) " value: " s/a]
 print-line ["^-s/b: " :s/b " offset: " as integer! (:s/b - p) " value: " s/b]
 print-line ["^-s/c: " :s/c " offset: " as integer! (:s/c - p) " value: " s/c]
 print-line ["^-s/d: " :s/d " offset: " as integer! (:s/d - p) " value: " s/d]
-print-line ["^-s/e: " :s/e " offset: " as integer! (:s/e - p) " value: " s/e]
+print-line ["^-s/e: " :s/e " offset: " as integer! (:s/e - p) " value: " s/e #" " (s/e = 24)]
 
 print-line size? s/a
 print-line size? s/b
@@ -44,4 +44,4 @@ pp/value: 64636261h ;this sets values in s/b and s/c bytes at once
 print-line ["s/c/1 = " s/c/1]
 print-line ["s/c/2 = " s/c/2]
 
-print-line as c-string! pp
+print-line [as c-string! pp " <- should be: abcd"]

--- a/system/tests/bytes-struct.reds
+++ b/system/tests/bytes-struct.reds
@@ -1,0 +1,47 @@
+Red/System [
+    Title:   "Red/System test of struct containing bytes! values"
+    Author:  "Oldes"
+    File:    %bytes-struct.reds
+    Rights:  "Copyright (C) 2017 David 'Oldes' Oliva. All rights reserved."
+    License: "BSD-3 - https:;//github.com/red/red/blob/master/BSD-3-License.txt"
+]
+
+s!: alias struct! [
+    a [integer!]
+    b [bytes! 2]
+    c [bytes! 2]
+    d [bytes! 1]
+    e [integer!] ;note that this value will be aligned
+]
+s: declare s!
+p: as int-ptr! s
+
+s/a: 42
+s/e: 24
+
+print-line ["Test struct size: " size? s]
+if 16 <> size? s [
+    print-line "Invalid test struct size! Should be 16."
+]
+print-line ["Value pointers:"]
+print-line ["^-s/a: " :s/a " offset: " as integer! (:s/a - p) " value: " s/a]
+print-line ["^-s/b: " :s/b " offset: " as integer! (:s/b - p) " value: " s/b]
+print-line ["^-s/c: " :s/c " offset: " as integer! (:s/c - p) " value: " s/c]
+print-line ["^-s/d: " :s/d " offset: " as integer! (:s/d - p) " value: " s/d]
+print-line ["^-s/e: " :s/e " offset: " as integer! (:s/e - p) " value: " s/e]
+
+print-line size? s/a
+print-line size? s/b
+
+print-line ["s/b + 1 = " s/b + 1]
+
+s/b/1: #"X"
+print-line "^/Accessing bytes:"
+print-line ["s/b/1 = " s/b/1]
+
+pp: p + 1
+pp/value: 64636261h ;this sets values in s/b and s/c bytes at once
+print-line ["s/c/1 = " s/c/1]
+print-line ["s/c/2 = " s/c/2]
+
+print-line as c-string! pp


### PR DESCRIPTION
When working with system and external binding, you very quickly notice, that many structs use byte arrays... for example Windows Socket data:
```
typedef struct WSAData {
  WORD           wVersion;
  WORD           wHighVersion;
  char           szDescription[WSADESCRIPTION_LEN+1];
  char           szSystemStatus[WSASYS_STATUS_LEN+1];
  unsigned short iMaxSockets;
  unsigned short iMaxUdpDg;
  char FAR       *lpVendorInfo;
} WSADATA, *LPWSADATA;
```
Or `libmpg123`'s id3 tag:
```
typedef struct
{
	char tag[3];         /**< Always the string "TAG", the classic intro. */
	char title[30];      /**< Title string.  */
	char artist[30];     /**< Artist string. */
	char album[30];      /**< Album string. */
	char year[4];        /**< Year string. */
	char comment[30];    /**< Comment string. */
	unsigned char genre; /**< Genre index. */
} mpg123_id3v1;
```

To use these structs from current Red/System is possible, but not easy, so I tried to extend Red/System as you can see in this PR, so for the second example I could use:
```
mpg123_id3v1!: alias struct! [
	tag     [bytes!  3] ; Always the string "TAG", the classic intro.
	title   [bytes! 30] ; Title string. 
	artist  [bytes! 30] ; Artist string.
	album   [bytes! 30] ; Album string.
	year    [bytes!  4] ; Year string.
	comment [bytes! 30] ; Comment string.
	genre   [byte!]     ; Genre index.
]
```  