### PR TITLE
FEAT: including fmod import in libc

### DIFF
--- a/system/runtime/libc.reds
+++ b/system/runtime/libc.reds
@@ -132,6 +132,11 @@ Red/System [
 			value		[float!]
 			return:		[float!]
 		]
+		fmod:		"fmod" [
+			x           [float!]
+			y           [float!]
+			return:     [float!]
+		]
 	]
 ]
 


### PR DESCRIPTION
`fmod` function was maybe not needed in Red runtime, but as `libc` is used also for Red/System, could you please include it? Btw... there is more math related functions missing.. I can add them if you would accept it.