### PR TITLE
FIX: issue #2969 (Doc-string wrongly placed in `what-dir` function)

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -568,8 +568,10 @@ normalize-dir: function [
 	dir
 ]
 
-what-dir: func [/local path][
+what-dir: func [
 	"Returns the active directory path"
+	/local path
+][
 	path: to-red-file get-current-dir
 	unless dir? path [append path #"/"]
 	path


### PR DESCRIPTION
Small step for the Red, but huge crawl for a toddler. :baby_bottle: 