### PR TITLE
Fix parse-trace indentation issue

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -297,6 +297,7 @@ parse-trace: func [
 		limit [integer!]
 	return: [logic! block!]
 ][
+	clear p-indent
 	either case [
 		parse/case/trace input rules :on-parse-event
 	][


### PR DESCRIPTION
Reset indentation state between calls. Current output:

```
>> parse-trace [1 2] [2 number!]
 -->
   match: [2 number!] 
   input: [1 2]   
   -->
     ==> matched
     match: [number!] 
     input: [2]     
     ==> matched
   <--
return: true
== true
>> parse-trace [1 2] [2 number!]
   -->
     match: [2 number!] 
     input: [1 2]     
     -->
       ==> matched
       match: [number!] 
       input: [2]       
       ==> matched
     <--
return: true
== true
>> parse-trace [1 2] [2 number!]
     -->
       match: [2 number!] 
       input: [1 2]       
       -->
         ==> matched
         match: [number!] 
         input: [2]         
         ==> matched
       <--
return: true
== true
```