### PR TITLE
path-thru filename as md5 checksum

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -825,7 +825,7 @@ path-thru: function [
 	so: system/options
 	unless so/thru-cache [make-dir/deep so/thru-cache: append copy so/cache %cache/]
 
-	hash: checksum form file 'MD5
+	hash: checksum form url 'MD5
 	file: head (remove back tail remove remove (form hash))
 	path: dirize append copy so/thru-cache copy/part file 2
     unless exists? path [make-dir path] 

--- a/environment/functions.red
+++ b/environment/functions.red
@@ -824,12 +824,12 @@ path-thru: function [
 ][
 	so: system/options
 	unless so/thru-cache [make-dir/deep so/thru-cache: append copy so/cache %cache/]
-	
-	if pos: find/tail file: to-file url "//" [file: pos]
-	clear find pos charset "?#"
-	path: first split-path file: append copy so/thru-cache file
-	unless exists? path [make-dir/deep path]
-	file
+
+	hash: checksum form file 'MD5
+	file: head (remove back tail remove remove (form hash))
+	path: dirize append copy so/thru-cache copy/part file 2
+    unless exists? path [make-dir path] 
+	append path file
 ]
 
 exists-thru?: function [

--- a/tests/source/environment/functions-test.red
+++ b/tests/source/environment/functions-test.red
@@ -387,7 +387,7 @@ Red [
 
 ===start-group=== "path-thru tests"
 	--test-- "path-thru test"
-		--assert not none? find (path-thru http://red-lang.com) "/cache/red-lang.com"
+		--assert not none? find (path-thru http://red-lang.com) "/cache/33/334C4A4C42FDB79D7EBC3E73B517E6F8"
 ===end-group===
 
 ===start-group=== "exists-thru? tests"

--- a/tests/source/environment/functions-test.red
+++ b/tests/source/environment/functions-test.red
@@ -387,7 +387,7 @@ Red [
 
 ===start-group=== "path-thru tests"
 	--test-- "path-thru test"
-		--assert not none? find (path-thru http://red-lang.com) "/cache/33/334C4A4C42FDB79D7EBC3E73B517E6F8"
+		--assert not none? find (path-thru http://red-lang.com) "/cache/91/91DD75833FAA7FF66B9BD4638549782B"
 ===end-group===
 
 ===start-group=== "exists-thru? tests"


### PR DESCRIPTION
no need to convert from url! to thru-cache dir structure
cache file is placed under path based on md5 checksum

>> path-thru http://www.red-lang.org/
== %/C/ProgramData/Red/cache/C3/C36ABFBA6FA8418E5BF6E31127F1DCFD

>> path-thru http://rowery.olsztyn.pl/?r=10
== %/C/ProgramData/Red/cache/B4/B4BCF480EF4282064228FDE953F255B7

Pijoter