### PR TITLE
Add support for get-word!s in `is~`

### DIFF
--- a/environment/reactivity.red
+++ b/environment/reactivity.red
@@ -174,7 +174,7 @@ system/reactivity: context [
 		words: words-of obj: context? field
 		parse reaction rule: [
 			any [
-				item: word! (
+				item: word! | get-word! (
 					if find words item/1 [repend relations [obj item/1 reaction field]]
 				)
 				| set-path! | any-string!


### PR DESCRIPTION
lepinekong noted on gitter that this didn't work:
```
portfolio: [
    ["GOOG" 1000 [1018.07 07/12/2017] [1046.67 13/12/2017]]
    ["AAPL" 100 [175.95 18/12/2017] [177.80 19/12/2017]]
    ["FB" 200 [176.29 04/12/2017] []]
]

trade: make reactor! [
    x: 1
    symbol: is [portfolio/:x/1]  ; << This is where the problem lies
 ]
 
view [
    field react [face/data: form trade/symbol]
    button "change" [trade/x: 2]
]
```

I deduced that `symbol: is [pick pick portfolio x 1]` work, then also that `symbol: is [portfolio/(x)/1]`.