### PR TITLE
 Add support for get-word!s in `is~`

### DIFF
--- a/environment/reactivity.red
+++ b/environment/reactivity.red
@@ -174,7 +174,7 @@ system/reactivity: context [
 		words: words-of obj: context? field
 		parse reaction rule: [
 			any [
-				item: word! (
+				item: word! | get-word! (
 					if find words item/1 [repend relations [obj item/1 reaction field]]
 				)
 				| set-path! | any-string!

--- a/environment/reactivity.red
+++ b/environment/reactivity.red
@@ -174,8 +174,8 @@ system/reactivity: context [
 		words: words-of obj: context? field
 		parse reaction rule: [
 			any [
-				item: word! | get-word! (
-					if find words item/1 [repend relations [obj item/1 reaction field]]
+				item: [word! | get-word!] ( 
+					if find words item/1 [repend relations [obj to word! item/1 reaction field]]
 				)
 				| set-path! | any-string!
 				| into rule

--- a/tests/source/units/reactivity-test.red
+++ b/tests/source/units/reactivity-test.red
@@ -38,8 +38,8 @@ Red [
 		--assert [x + y] = react? b 'x
 		--assert [x + y] = react? b 'y
 		--assert [x + y] = react?/target b 'z
-    
-    --test-- "is-5"
+	
+	--test-- "is-5"
 		c: make reactor! [x: 1 y: is [x + 1] z: is [y + 1]]
 		--assert c/x == 1
 		--assert c/y == 2
@@ -56,13 +56,56 @@ Red [
 		--assert none? react? c 'z
 		--assert [y + 1] = react?/target c 'z
 
- --test-- "is-7"
+	--test-- "is-7"
 		;d: make reactor! [x: is [y + 1] y: is [x + 3]]
 		;--assert none? d/x
 		;--assert none? d/y
 		;d/x: 1
 		;--assert d/x = 5
 		;--assert d/y = 4
+
+	--test-- "is-get-word-8"
+		a: make reactor! [x: 1 y: is [:x + 1]]
+		--assert a/x == 1
+		--assert a/y == 2
+		a/x: 5
+		--assert a/y == 6
+
+	--test-- "is-get-word-9"
+		a: make reactor! [x: 1 y: is [1 + :x]]
+		--assert a/x == 1
+		--assert a/y == 2
+		a/x: 5
+		--assert a/y == 6
+
+	--test-- "is-get-word-10"
+		a: make reactor! [x: 1 y: 2 z: is [:x + :y]]
+		--assert a/x == 1
+		--assert a/y == 2
+		--assert a/z == 3
+		a/x: 5
+		--assert a/z == 7
+		a/y: 6
+		--assert a/z == 11
+
+	--test-- "is-get-word-path-11"
+		
+		blk: [["A" 100] ["B" 200]]
+		a: make reactor! [
+			x: 1
+			y: 1
+			z: is [blk/:x/:y]
+		]
+		--assert a/x == 1
+		--assert a/y == 1
+		--assert a/z == "A"
+		a/x: 2
+		--assert a/z == "B"
+		a/y: 2
+		--assert a/z == 200
+		a/x: 1
+		--assert a/z == 100
+		
 
 ===end-group===
 


### PR DESCRIPTION
lepinekong noted on gitter that this didn't work:
```
portfolio: [
    ["GOOG" 1000 [1018.07 07/12/2017] [1046.67 13/12/2017]]
    ["AAPL" 100 [175.95 18/12/2017] [177.80 19/12/2017]]
    ["FB" 200 [176.29 04/12/2017] []]
]

trade: make reactor! [
    x: 1
    symbol: is [portfolio/:x/1]  ; << This is where the problem lies
 ]
 
view [
    field react [face/data: form trade/symbol]
    button "change" [trade/x: 2]
]
```

I deduced that `symbol: is [pick pick portfolio x 1]` work, then also that `symbol: is [portfolio/(x)/1]`.