### PR TITLE
Add check for SSE3 instruction on Linux

### DIFF
--- a/red.r
+++ b/red.r
@@ -119,6 +119,13 @@ redc: context [
 			libc: load/library libc
 			sys-call: make routine! [cmd [string!]] libc "system"
 			join any [attempt [to-rebol-file get-env "HOME"] %/tmp] %/.red/
+
+			cpuinfo: ""
+			either 0 = call/wait/output "cat /proc/cpuinfo" cpuinfo [
+				SSE3?: parse cpuinfo [any [thru ["flags" any space ":"] to "sse3" to newline to end ]]
+			][
+				fail "Can't read /proc/cpuinfo"
+			]
 		]
 	]
 

--- a/system/utils/libRedRT-exports.r
+++ b/system/utils/libRedRT-exports.r
@@ -134,6 +134,7 @@
 	red/integer/get-any*
 	red/integer/get*
 	red/integer/get
+	red/integer/form-signed
 	red/logic/get
 	red/float/get
 
@@ -171,6 +172,7 @@
 	red/symbol/make
 
 	red/unicode/load-utf8
+	red/unicode/decode-utf8-char
 
 	red/object/unchanged?
 	red/object/unchanged2?


### PR DESCRIPTION
**FIX: added two functions to export list: decode-utf8-char and form-signed**
   - this commit adds two functions to the export list of libred. I couldn't compile red console on my Ubuntu 16.04 without this change

**FIX: issue #3196 (missing check for SSE3 instructions on Linux)**
   - this commit will check for string "sse3" in /proc/cpuinfo using a parse rule and it will set SSE3? to true if it founds or false otherwise