### PR TITLE
FIX: extend system/console context

### DIFF
--- a/environment/console/input.red
+++ b/environment/console/input.red
@@ -19,6 +19,7 @@ unless system/console [
 	system/console: context [
 		history: make block! 200
 		size: 0x0
+		terminate: make block! 0
 	]
 ]
 ;; End patch


### PR DESCRIPTION
Without `terminate: []` compilation in release mode with this included file will fail (in case user wants to use `ask`).
```
*** Compilation Error: word terminate not defined in system/console/terminate 
```