### PR TITLE
feat: improvements on git version integration and new about/debug command

### DIFF
--- a/build/git-version.r
+++ b/build/git-version.r
@@ -34,7 +34,7 @@ context [
 					date: to-local-date to date! (
 						to integer! git {log -1 --pretty=format:"%at"}
 					)
-					commit: (to issue! next temp/3)
+					commit: (to issue! git "rev-parse HEAD")
 					message: (git "log -1 --pretty=%B")
 				]
 			]

--- a/docs/issue_template.md
+++ b/docs/issue_template.md
@@ -3,6 +3,7 @@
 ### Steps to reproduce the problem
 ### Red and platform version
 ```
-Run below code in Red Console and replace this text with the result:
-any [attempt[about/debug] about]
+Run below code in Red Console and replace these 3 lines enclosed in ``` with the result:
+  any [attempt[about/debug] about]
+(add OS version if not in above command result)
 ```

--- a/docs/issue_template.md
+++ b/docs/issue_template.md
@@ -1,4 +1,8 @@
 ### Expected behavior
 ### Actual behavior
 ### Steps to reproduce the problem
-### Version (run `about` in the Red Console and paste the result here) also add OS version.
+### Red and platform version
+```
+Run below code in Red Console and replace this text with the result:
+any [attempt[about/debug] about]
+```

--- a/environment/console/GUI/settings.red
+++ b/environment/console/GUI/settings.red
@@ -81,7 +81,12 @@ display-about: function [][
 		at 0x230 link "http://red-lang.org" font-size 10 font-color white
 		at 0x260 link "http://github.com/red/red" font-size 10 font-color white
 		at 154x300 button "Close" [unview win/selected: console]
-		do [ver/text: form reduce ["Build" system/version #"-" system/build/date]]
+		do [ver/text: form reduce [
+				"Build" system/version #"-" any [
+					all [system/build/git system/build/git/date]
+					system/build/date
+				]
+		]]
 	]
 	center-face/with lay win
 	view/flags lay [modal no-title]

--- a/environment/console/help.red
+++ b/environment/console/help.red
@@ -600,7 +600,7 @@ help-ctx: context [
 			print either git [
 				compose [
 					"-----------RED & PLATFORM VERSION-----------" lf
-					"GIT: [ branch:" mold git/branch "tag:" mold git/tag "ahead:" git/ahead
+					"RED: [ branch:" mold git/branch "tag:" mold git/tag "ahead:" git/ahead
 					"date:" to-UTC-date git/date "commit:" mold git/commit "]^/"
 					"PLATFORM: [ name:" mold plt/name "OS:" mold to lit-word! plt/OS
 					"arch:" mold to lit-word! plt/arch "version:" mold plt/version

--- a/environment/console/help.red
+++ b/environment/console/help.red
@@ -591,16 +591,36 @@ help-ctx: context [
 
 	set 'about func [
 		"Print Red version information"
+		/debug "Print full Red and OS version information suitable for submitting issues"
+		/local git plt
 	][
-		prin [
-			'Red system/version
-			'for system/platform/OS
-			'built to-UTC-date system/build/date
+		git: system/build/git
+		plt: system/platform
+		either debug [
+			print either git [
+				compose [
+					"-----------RED & PLATFORM VERSION-----------" lf
+					"GIT: [ branch:" mold git/branch "tag:" mold git/tag "ahead:" git/ahead
+					"date:" to-UTC-date git/date "commit:" mold git/commit "]^/"
+					"PLATFORM: [ name:" mold plt/name "OS:" mold to lit-word! plt/OS
+					"arch:" mold to lit-word! plt/arch "version:" mold plt/version
+					"build:" mold plt/build "]^/"
+					"--------------------------------------------"
+				]
+			][
+				"Looks like this Red binary has been built from source.^/Please download latest build from our website:^/https://www.red-lang.org/download.html^/and try your code on it before submitting an issue."
+			]
+		][
+			prin [
+				'Red system/version
+				'for plt/OS
+				'built any [all [git git/date] system/build/date]
+			]
+			if git [
+				prin [ " commit" copy/part mold system/build/git/commit 8]
+			]
+			print lf
 		]
-		if system/build/git [
-			prin [ " commit" mold system/build/git/commit]
-		]
-		print lf
 	]
 
 ]


### PR DESCRIPTION
- use full size commit hash in `system/build/git/commit` (@rebolek)
- add `/debug` refinement to `about` to return values suitable for submitting issues
- use `system/build/git/date` instead of `system/build/date` in return of `about` command (the later is the date of the locally built console, toolchain build date more appropriate)
- use commit of length 7 for commit hash in `about`, compatible with GitHub website (@meijeru).
- use local zone for build date returned by `about` as this is not meant to be shared and more human friendly. `about/debug` uses UTC zone to not leak user zone info on GitHub issues.
- updated issue template, format debug versions string as code, we'll have a transitiong time where this has to be run `any [attempt[about/debug] about]` after which we will change the code to run to just `about/debug`

Example return value from `about/debug`:
```
RED: [ branch: "git-data-integration" tag: #v0.6.3 ahead: 582 date: 1-Apr-2018/3:59:38 commit: #ddacd32c0ad63c8dd68a335fc652f8e4959ecbdd ]
PLATFORM: [ name: "macOS High Sierra 10.13.4" OS: 'macOS arch: 'x86-64 version: 10.13.4 build: "17E199" ]
```