### PR TITLE
Re-add fix for to-UTC-date + remove uneeded compose in about func

### DIFF
--- a/environment/console/help.red
+++ b/environment/console/help.red
@@ -598,14 +598,12 @@ help-ctx: context [
 		plt: system/platform
 		either debug [
 			print either git [
-				compose [
-					"-----------RED & PLATFORM VERSION-----------" lf
+				[
 					"RED: [ branch:" mold git/branch "tag:" mold git/tag "ahead:" git/ahead
 					"date:" to-UTC-date git/date "commit:" mold git/commit "]^/"
 					"PLATFORM: [ name:" mold plt/name "OS:" mold to lit-word! plt/OS
 					"arch:" mold to lit-word! plt/arch "version:" mold plt/version
 					"build:" mold plt/build "]^/"
-					"--------------------------------------------"
 				]
 			][
 				"Looks like this Red binary has been built from source.^/Please download latest build from our website:^/https://www.red-lang.org/download.html^/and try your code on it before submitting an issue."

--- a/runtime/datatypes/common.reds
+++ b/runtime/datatypes/common.reds
@@ -214,6 +214,7 @@ set-path*: func [
 	parent  [red-value!]
 	element [red-value!]
 ][
+	object/path-parent/header: TYPE_NONE
 	stack/set-last actions/eval-path parent element stack/arguments null no
 	object/path-parent/header: TYPE_NONE				;-- disables owner checking
 ]
@@ -222,6 +223,7 @@ set-int-path*: func [
 	parent  [red-value!]
 	index 	[integer!]
 ][
+	object/path-parent/header: TYPE_NONE
 	stack/set-last actions/eval-path
 		parent
 		as red-value! integer/push index


### PR DESCRIPTION
Commit https://github.com/red/red/commit/be7ff3a992ff8e128e2c051ed474c70ec55792de was added to fix issue with `to-UTC-date` added at commit https://github.com/red/red/commit/1a598cd1d04085cdc062025ee68866777b6b4eca that crashed GUI Console.
Commit https://github.com/red/red/commit/a60656d0074dee4b1377bb8ae3302350555f02fc reverted that commit and the crash came back.

Also removed unneeded `compose` from `about` function.