### PR TITLE
FIX: patch KillTimer call after  #6fdf75bb

### DIFF
--- a/environment/console/GUI/old/windows.reds
+++ b/environment/console/GUI/old/windows.reds
@@ -507,7 +507,7 @@ ConsoleWndProc: func [
 				vt/select?: no
 				vt/s-end?: no
 				if scroll-count <> 0 [
-					KillTimer hWnd timer
+					KillTimer hWnd timer/value
 					scroll-count: 0
 				]
 				out: vt/out
@@ -543,7 +543,7 @@ ConsoleWndProc: func [
 					timer: SetTimer hWnd 1 10 null
 				][
 					if scroll-count <> 0 [
-						KillTimer hWnd timer
+						KillTimer hWnd timer/value
 						scroll-count: 0
 					]
 					if all [


### PR DESCRIPTION
As always, more of a blind guess than anything. I'm naively assuming that `handle!` is just a shortcut for `int-ptr!`. Fix ix related to [this](https://github.com/red/red/commit/6fdf75bb) commit, also see [original bug report](https://gitter.im/red/bugs?at=5af602d6f04ce53632ce6080) on Gitter.