### PR TITLE
FIX: #3385 (`now` no need support more than one refinements)

### DIFF
--- a/environment/system.red
+++ b/environment/system.red
@@ -122,6 +122,7 @@ system: context [
 				bad-func-extern:	["invalid /extern value:" :arg1]
 				no-refine:			[:arg1 "has no refinement called" :arg2]
 				bad-refines:		"incompatible or invalid refinements"
+				too-many-refines:	"Too many refinements"
 				bad-refine:			["incompatible refinement:" :arg1]
 				word-first:			["path must start with a word:" :arg1]
 				empty-path:			"cannot evaluate an empty path value"

--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -57,6 +57,24 @@ natives: context [
 		]
 	]
 	
+	;-- used to check if native function has more than one refinement
+	unique-refinement?: func[
+		[variadic]
+		count [integer!] list [int-ptr!]
+		return: [logic!]
+		/local
+			num		[integer!]
+	][
+		num: 0
+		until [
+			if list/value > -1 [num: num + 1]
+			list: list + 1
+			count: count - 1
+			any [zero? count num > 1]
+		]
+		num <= 1
+	]
+
 	;--- Natives ----
 	
 	if*: func [check? [logic!]][
@@ -2433,6 +2451,9 @@ natives: context [
 			n	[integer!]
 	][
 		#typecheck [now year month day time zone _date weekday yearday precise utc]
+		if not unique-refinement? [year month day time zone weekday yearday][
+			fire [TO_ERROR(script too-many-refines)]
+		]
 
 		dt: as red-date! stack/arguments
 		dt/header: TYPE_DATE


### PR DESCRIPTION
>> now
== 14-May-2018/12:17:53+08:00
>> now/day
== 14
>> now/time
== 12:17:58
>> now/time/day
*** Script Error: Too many refinements
*** Where: now
*** Stack:

>> now/day/time
*** Script Error: Too many refinements
*** Where: now
*** Stack:

>> now/day/time/year
*** Script Error: Too many refinements
*** Where: now
*** Stack:

>>