### PR TITLE
gui-sys-call is only defined for Windows

### DIFF
--- a/red.r
+++ b/red.r
@@ -522,7 +522,7 @@ redc: context [
 		]
 		exe: safe-to-local-file exe
 
-		either gui? [
+		either all [Windows? gui?] [
 			gui-sys-call exe any [all [file form-args file] ""]
 		][
 			if with [repend exe [" " form-args file]]


### PR DESCRIPTION
One less step to compile GUI Console by default for macOS