### PR TITLE
Added missing doc strings, #3413

### DIFF
--- a/environment/console/CLI/input.red
+++ b/environment/console/CLI/input.red
@@ -565,11 +565,11 @@ unless system/console [
 	]
 ]
 
-_set-buffer-history: routine [line [string!] hist [block!]][
+_set-buffer-history: routine ["Internal Use Only" line [string!] hist [block!]][
 	terminal/setup line hist
 ]
 
-_read-input: routine [prompt [string!]][
+_read-input: routine ["Internal Use Only" prompt [string!]][
 	terminal/edit prompt
 ]
 
@@ -581,6 +581,7 @@ _terminate-console: routine [][
 ]
 
 ask: function [
+	"Prompt the user for input"
 	question [string!]
 	return:  [string!]
 ][
@@ -590,4 +591,4 @@ ask: function [
 	buffer
 ]
 
-input: does [ask ""]
+input: func ["Wait for console user input"] [ask ""]

--- a/environment/console/GUI/gui-console.red
+++ b/environment/console/GUI/gui-console.red
@@ -215,6 +215,7 @@ gui-console-ctx: context [
 ]
 
 ask: function [
+	"Prompt the user for input"
 	question [string!]
 	return:  [string!]
 ][
@@ -243,7 +244,7 @@ ask: function [
 	line
 ]
 
-input: function [return: [string!]][ask ""]
+input: function ["Wait for console user input" return: [string!]][ask ""]
 
 #system [
 	red-print-gui: func [

--- a/environment/console/GUI/old/gui-console.red
+++ b/environment/console/GUI/old/gui-console.red
@@ -24,6 +24,7 @@ Red [
 ]
 
 ask: routine [
+	"Prompt the user for input"
 	question [string!]
 	return:  [string!]
 ][
@@ -35,7 +36,7 @@ ask: routine [
 		null
 ]
 
-input: does [ask ""]
+input: function ["Wait for console user input"][ask ""]
 
 gui-console-ctx: context [
 	cfg-path:	 none

--- a/environment/console/auto-complete.red
+++ b/environment/console/auto-complete.red
@@ -13,6 +13,7 @@ Red [
 has-common-part?: no
 
 common-substr: func [
+	"Internal Use Only"
 	blk		[block!]
 	/local a b
 ][
@@ -36,6 +37,7 @@ common-substr: func [
 ]
 
 red-complete-path: func [
+	"Internal Use Only"
 	str		 [string!]
 	console? [logic!]
 	/local s result word w1 ptr words first? sys-word w
@@ -87,6 +89,7 @@ red-complete-path: func [
 ]
 
 red-complete-file: func [
+	"Internal Use Only"
 	str		 [string!]
 	console? [logic!]
 	/local file result path word f files replace? change?
@@ -118,6 +121,7 @@ red-complete-file: func [
 ]
 
 red-complete-input: func [
+	"Internal Use Only"
 	str		 [string!]			;-- should be `tail str`
 	console? [logic!]
 	/local

--- a/environment/console/engine.red
+++ b/environment/console/engine.red
@@ -310,10 +310,10 @@ expand: func [
 	probe expand-directives/clean blk
 ]
 
-ls:		func ['dir [any-type!]][list-dir :dir]
-ll:		func ['dir [any-type!]][list-dir/col :dir 1]
-pwd:	does [prin mold system/options/path]
-halt:	does [throw/name 'halt-request 'console]
+ls:		func ["Display a single column directory listing, for the current dir if none is given" 'dir [any-type!]][list-dir :dir]
+ll:		func ["Display a single column directory listing, for the current dir if none is given" 'dir [any-type!]][list-dir/col :dir 1]
+pwd:	func ["Displays the active directory path (Print Working Dir)"][prin mold system/options/path]
+halt:	func ["Stops evaluation and returns to the input prompt"][throw/name 'halt-request 'console]
 
 cd:	function [
 	"Changes the active directory path"

--- a/environment/functions.red
+++ b/environment/functions.red
@@ -10,12 +10,12 @@ Red [
 	}
 ]
 
-routine: func [spec [block!] body [block!]][
+routine: func ["Defines a function with a given Red spec and Red/System body" spec [block!] body [block!]][
 	cause-error 'internal 'routines []
 ]
 
 also: func [
-	"Returns the first value, but also evaluates the second."
+	"Returns the first value, but also evaluates the second"
 	value1 [any-type!]
 	value2 [any-type!]
 ][
@@ -34,7 +34,7 @@ attempt: func [
 	]
 ]
 
-comment: func ['value][]
+comment: func ["Consume but don't evaluate the next value" 'value][]
 
 quit: func [
 	"Stops evaluation and exits the program"
@@ -75,6 +75,7 @@ probe: func [
 ]
 
 quote: func [
+	"Return but don't evaluate the next value"
 	:value
 ][
 	:value
@@ -260,6 +261,7 @@ math: function [
 ]
 
 charset: func [
+	"Shortcut for `make bitset!`"
 	spec [block! integer! char! string!]
 ][
 	make bitset! spec
@@ -268,6 +270,7 @@ charset: func [
 p-indent: make string! 30								;@@ to be put in a local context
 
 on-parse-event: func [
+	"Standard parse/trace callback used by PARSE-TRACE"
 	event	[word!]   "Trace events: push, pop, fetch, match, iterate, paren, end"
 	match?	[logic!]  "Result of last matching operation"
 	rule	[block!]  "Current rule at current position"
@@ -521,9 +524,10 @@ modulo: func [
 	either any [a - r = a r + b = b][0][r]
 ]
 
-eval-set-path: func [value1][]
+eval-set-path: func ["Internal Use Only" value1][]
 
 to-red-file: func [
+	"Converts a local system file path to a Red file path"
 	path	[file! string!]
 	return: [file!]
 	/local colon? slash? len i c dst
@@ -564,9 +568,10 @@ to-red-file: func [
 	dst
 ]
 
-dir?: func [file [file! url!]][#"/" = last file]
+dir?: func ["Returns TRUE if the value looks like a directory spec" file [file! url!]][#"/" = last file]
 
 normalize-dir: function [
+	"Return the contents of the system clipboard"
 	dir [file! word! path!]
 ][
 	unless file? dir [dir: to file! mold dir]
@@ -803,7 +808,7 @@ split-path: func [
 	reduce [dir pos]
 ]
 
-do-file: func [file [file! url!] /local saved code new-path src][
+do-file: func ["Internal Use Only" file [file! url!] /local saved code new-path src][
 	saved: system/options/path
 	unless src: find/case read file "Red" [
 		cause-error 'syntax 'no-header reduce [file]

--- a/environment/natives.red
+++ b/environment/natives.red
@@ -322,6 +322,7 @@ stats: make native! [[
 ]
 
 bind: make native! [[
+		"Bind words to a context; returns rebound words"
 		word 	[block! any-word!]
 		context [any-word! any-object! function!]
 		/copy
@@ -339,6 +340,7 @@ in: make native! [[
 ]
 
 parse: make native! [[
+		"Process a series using dialected grammar rules"
 		input [binary! any-block! any-string!]
 		rules [block!]
 		/case

--- a/environment/routines.red
+++ b/environment/routines.red
@@ -34,41 +34,42 @@ set-quiet: routine [
 ]
 
 ;-- Following definitions are used to create op! corresponding operators
-shift-right:   routine [data [integer!] bits [integer!]][natives/shift* no -1 -1]
-shift-left:	   routine [data [integer!] bits [integer!]][natives/shift* no  1 -1]
-shift-logical: routine [data [integer!] bits [integer!]][natives/shift* no -1  1]
+shift-right:   routine ["Shift bits to the right" data [integer!] bits [integer!]][natives/shift* no -1 -1]
+shift-left:	   routine ["Shift bits to the left" data [integer!] bits [integer!]][natives/shift* no  1 -1]
+shift-logical: routine ["Shift bits to the right (unsigned)" data [integer!] bits [integer!]][natives/shift* no -1  1]
 
 ;-- Helping routine for console, returns true if last output character was a LF
-last-lf?: routine [/local bool [red-logic!]][
+last-lf?: routine ["Internal Use Only" /local bool [red-logic!]][
 	bool: as red-logic! stack/arguments
 	bool/header: TYPE_LOGIC
 	bool/value:	 natives/last-lf?
 ]
 
-get-current-dir: routine [][
+get-current-dir: routine ["Returns the platform’s current directory for the process"][
 	stack/set-last as red-value! file/get-current-dir
 ]
 
-set-current-dir: routine [path [string!] /local dir [red-file!]][
+set-current-dir: routine ["Sets the platform’s current process directory" path [string!] /local dir [red-file!]][
 	dir: as red-file! stack/arguments
 	unless platform/set-current-dir file/to-OS-path dir [
 		fire [TO_ERROR(access cannot-open) dir]
 	]
 ]
 
-create-dir: routine [path [file!]][			;@@ temporary, user should use `make-dir`
+create-dir: routine ["Create the given directory" path [file!]][			;@@ temporary, user should use `make-dir`
 	simple-io/make-dir file/to-OS-path path
 ]
 
-exists?: routine [path [file!] return: [logic!]][
+exists?: routine ["Returns TRUE if the file exists" path [file!] return: [logic!]][
 	simple-io/file-exists? file/to-OS-path path
 ]
 
-os-info: routine [][
+os-info: routine ["Returns detailed operating system version information"][
 	__get-OS-info
 ]
 
 as-color: routine [
+	"Combine R, G and B values into a tuple"
 	r [integer!]
 	g [integer!]
 	b [integer!]
@@ -89,6 +90,7 @@ as-color: routine [
 ]
 
 as-ipv4: routine [
+	"Combine a, b, c and d values into a tuple"
 	a [integer!]
 	b [integer!]
 	c [integer!]
@@ -114,14 +116,14 @@ as-rgba: :as-ipv4
 
 ;-- Temporary definition --
 
-read-clipboard: routine [][
+read-clipboard: routine ["Return the contents of the system clipboard"][
 	stack/set-last clipboard/read
 ]
 
-write-clipboard: routine [data [string!]][
+write-clipboard: routine ["Write content to the system clipboard" data [string!]][
 	logic/box clipboard/write as red-value! data
 ]
 
-write-stdout: routine [str [string!]][			;-- internal use only
+write-stdout: routine ["Write data to STDOUT" str [string!]][			;-- internal use only
 	simple-io/write null as red-value! str null null no no no
 ]

--- a/modules/view/view.red
+++ b/modules/view/view.red
@@ -17,7 +17,7 @@ Red [
 
 #include %utils.red
 
-event?: routine [value [any-type!] return: [logic!]][TYPE_OF(value) = TYPE_EVENT]
+event?: routine ["Returns true if the value is this type" value [any-type!] return: [logic!]][TYPE_OF(value) = TYPE_EVENT]
 
 face?: function [
 	"Returns TRUE if the value is a face! object"
@@ -112,6 +112,7 @@ metrics?: function [
 ]
 
 set-flag: function [
+	"Sets a flag in a face object"
 	face  [object!]
 	facet [word!]
 	value [any-type!]
@@ -125,6 +126,7 @@ set-flag: function [
 ]
 
 find-flag?: routine [
+	"Checks a flag in a face object"
 	facet	[any-type!]
 	flag 	[word!]
 	/local
@@ -161,7 +163,7 @@ find-flag?: routine [
 	bool/value:	 found?
 ]
 
-debug-info?: func [face [object!] return: [logic!]][
+debug-info?: func ["Internal use only" face [object!] return: [logic!]][
 	all [
 		system/view/debug?
 		not all [
@@ -176,7 +178,7 @@ debug-info?: func [face [object!] return: [logic!]][
 	]
 ]
 
-on-face-deep-change*: function [owner word target action new index part state forced?][
+on-face-deep-change*: function ["Internal use only" owner word target action new index part state forced?][
 	if debug-info? owner [
 		print [
 			"-- on-deep-change event --" 		 lf
@@ -308,7 +310,7 @@ on-face-deep-change*: function [owner word target action new index part state fo
 	]
 ]
 
-link-tabs-to-parent: function [face [object!] /init][
+link-tabs-to-parent: function ["Internal Use Only" face [object!] /init][
 	if faces: face/pane [
 		visible?: face/visible?
 		forall faces [
@@ -321,7 +323,7 @@ link-tabs-to-parent: function [face [object!] /init][
 	]
 ]
 
-link-sub-to-parent: function [face [object!] type [word!] old new][
+link-sub-to-parent: function ["Internal Use Only" face [object!] type [word!] old new][
 	if object? new [
 		unless all [parent: in new 'parent block? get parent][
 			new/parent: make block! 4
@@ -336,7 +338,7 @@ link-sub-to-parent: function [face [object!] type [word!] old new][
 	]
 ]
 
-update-font-faces: function [parent [block! none!]][
+update-font-faces: function ["Internal Use Only" parent [block! none!]][
 	if block? parent [
 		foreach f parent [
 			if f/state [
@@ -678,12 +680,12 @@ do-events: function [
 	:result
 ]
 
-do-safe: func [code [block!] /local result][
+do-safe: func ["Internal Use Only" code [block!] /local result][
 	if error? set/any 'result try/all code [print :result]
 	get/any 'result
 ]
 
-do-actor: function [face [object!] event [event! none!] type [word!] /local result][
+do-actor: function ["Internal Use Only" face [object!] event [event! none!] type [word!] /local result][
 	if all [
 		object? face/actors
 		act: in face/actors name: select system/view/evt-names type
@@ -870,6 +872,7 @@ center-face: function [
 ]
 
 make-face: func [
+	"Make a face from a given style name or example face"
 	style   [word!]  "A face type"
 	/spec 
 		blk [block!] "Spec block of face options expressed in VID"


### PR DESCRIPTION
Added missing doc strings, #3413

```
<<                   : Shift bits to the left
>>                   : Shift bits to the right
>>>                  : Shift bits to the right (unsigned)
_read-input          : Internal Use Only
_set-buffer-history  : Internal Use Only
as-color             : Combine R, G and B values into a tuple
as-ipv4              : Combine a, b, c and d values into a tuple
as-rgba              : Combine a, b, c and d values into a tuple
ask                  : Prompt the user for input
bind                 : Bind words to a context; returns rebound words
charset              : Shortcut for `make bitset!`
comment              : Consume but don't evaluate the next value
common-substr        : Internal Use Only
construct            : Makes a new object from an unevaluated spec; standard logic words are evaluated
context              : Makes a new object from an evaluated spec
create-dir           : Create the given directory
debug-info?          : Internal use only
dir                  : Display a single column directory listing, for the current dir if none is given
dir?                 : Returns TRUE if the value looks like a directory spec
do-actor             : Internal Use Only
do-file              : Internal Use Only
do-safe              : Internal Use Only
eval-set-path        : Internal Use Only
event?               : Returns true if the value is this type
exists?              : Returns TRUE if the file exists
find-flag?           : Checks a flag in a face object
get-current-dir      : Returns the platform’s current directory for the process
halt                 : Stops evaluation and returns to the input prompt
input                : Wait for console user input
last-lf?             : Internal Use Only
link-sub-to-parent   : Internal Use Only
link-tabs-to-parent  : Internal Use Only
ll                   : Display a single column directory listing, for the current dir if none is given
ls                   : Display a single column directory listing, for the current dir if none is given
make-face            : Make a face from a given style name or example face
normalize-dir        : Return the contents of the system clipboard
object               : Makes a new object from an evaluated spec
on-face-deep-change* : Internal use only
on-parse-event       : Standard parse/trace callback used by PARSE-TRACE
os-info              : Returns detailed operating system version information
parse                : Process a series using dialected grammar rules
pwd                  : Displays the active directory path (Print Working Dir)
quote                : Return but don't evaluate the next value
read-clipboard       : Return the contents of the system clipboard
red-complete-file    : Internal Use Only
red-complete-input   : Internal Use Only
red-complete-path    : Internal Use Only
routine              : Defines a function with a given Red spec and Red/System body
set-current-dir      : Sets the platform’s current process directory
set-flag             : Sets a flag in a face object
shift-left           : Shift bits to the left
shift-logical        : Shift bits to the right (unsigned)
shift-right          : Shift bits to the right
to-red-file          : Converts a local system file path to a Red file path
update-font-faces    : Internal Use Only
write-clipboard      : Write content to the system clipboard
write-stdout         : Write data to STDOUT
```
