### PR TITLE
Add: 'random/seed now' test in the date-test.red

### DIFF
--- a/tests/source/units/date-test.red
+++ b/tests/source/units/date-test.red
@@ -851,6 +851,16 @@ Red [
 			26-Feb-6712/17:07:12-10:00
 		]
 
+	--test-- "misc-5"
+		res1: make block! 5
+		res2: make block! 5 
+		random/seed now 
+		res1: collect [loop 5 [keep random 10]]
+		wait 1
+		random/seed now 
+		res2: collect [loop 5 [keep random 10]]
+		--assert res1 <> res2 
+
 ===end-group===
 
 ~~~end-file~~~


### PR DESCRIPTION
This is a quick test for the #3252 .  
Because the code speed is very fast, and the ```now``` is not changed when the  ```random/seed now```  second called. I add a ```wait 1 ``` between the two calls in the test.