### PR TITLE
FIX: to-char with integer > 10FFFFh crashes, #3437

### DIFF
--- a/runtime/datatypes/char.reds
+++ b/runtime/datatypes/char.reds
@@ -93,7 +93,7 @@ char: context [
 		switch TYPE_OF(spec) [
 			TYPE_INTEGER
 			TYPE_CHAR [
-				proto/value: spec/data2
+				proto/value: spec/data2 and 1114111 ;10FFFFh
 			]
 			TYPE_FLOAT
 			TYPE_PERCENT [


### PR DESCRIPTION
FIX: to-char with integer > 10FFFFh crashes