### PR TITLE
docstrings fix for arc* functions and natives

### DIFF
--- a/runtime/datatypes/bitset.reds
+++ b/runtime/datatypes/bitset.reds
@@ -130,7 +130,7 @@ bitset: context [
 			string/append-char GET_BUFFER(buffer) as-integer c
 			
 			p: p + 1
-			part: part - 1
+			part: part - 2
 			if all [part? negative? part][return part]
 		]
 		part
@@ -634,10 +634,13 @@ bitset: context [
 		not?: FLAG_NOT?(s)
 		
 		string/concatenate-literal buffer "make bitset! "
-		if not? [string/concatenate-literal buffer "[not "]
+		part: part - 13
+		if not? [string/concatenate-literal buffer "[not " part: part - 5]
 		
 		string/concatenate-literal buffer "#{"
-		part: form-bytes bits buffer OPTION?(arg) part - 13 not?
+		part: part - 2
+		part: form-bytes bits buffer OPTION?(arg) part not?
+		if all [OPTION?(arg) part <= 0][return part]
 		string/append-char GET_BUFFER(buffer) as-integer #"}"
 		
 		either not? [


### PR DESCRIPTION
arc* functions are not functions of angle, they return angle - fixed the descriptions

arctangent2 docstring was absurdly long and contained rather obvious details, shortened