### PR TITLE
Added doc strings for some refinements

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -312,8 +312,8 @@ parse-trace: func [
 	"Wrapper for parse/trace using the default event processor"
 	input [series!]
 	rules [block!]
-	/case
-	/part
+	/case "Uses case-sensitive comparison"
+	/part "Limit to a length or position"
 		limit [integer!]
 	return: [logic! block!]
 ][
@@ -347,7 +347,7 @@ load: function [
 	/trap	"Load all values, returns [[values] position error]"
 	/next	"Load the next value only, updates source series word"
 		position [word!] "Word updated with new series position"
-	/part
+	/part	"Limit to a length or position"
 		length [integer! string!]
 	/into "Put results in out block, instead of creating a new block"
 		out [block!] "Target block for results"
@@ -497,11 +497,12 @@ cause-error: function [
 
 pad: func [
 	"Pad a FORMed value on right side with spaces"
-	str						"Value to pad, FORM it if not a string"
-	n		[integer!]		"Total size (in characters) of the new string"
-	/left					"Pad the string on left side"
-	/with c	[char!]			"Pad with char"
-	return:	[string!]		"Modified input string at head"
+	str					"Value to pad, FORM it if not a string"
+	n		[integer!]	"Total size (in characters) of the new string"
+	/left				"Pad the string on left side"
+	/with				"Pad with char"
+	c		[char!]
+	return:	[string!]	"Modified input string at head"
 ][
 	unless string? str [str: form str]
 	head insert/dup

--- a/environment/natives.red
+++ b/environment/natives.red
@@ -325,7 +325,7 @@ bind: make native! [[
 		"Bind words to a context; returns rebound words"
 		word 	[block! any-word!]
 		context [any-word! any-object! function!]
-		/copy
+		/copy	"Deep copy blocks before binding"
 		return: [block! any-word!]
 	]
 	#get-definition NAT_BIND
@@ -343,9 +343,9 @@ parse: make native! [[
 		"Process a series using dialected grammar rules"
 		input [binary! any-block! any-string!]
 		rules [block!]
-		/case
+		/case "Uses case-sensitive comparison"
 		;/strict
-		/part
+		/part "Limit to a length or position"
 			length [number! series!]
 		/trace
 			callback [function! [
@@ -880,9 +880,11 @@ browse: make native! [[
 
 decompress: make native! [[
 		"Decompresses data. Data in GZIP format (RFC 1952) by default"
-		data		  [binary!]
-		/zlib	 size [integer!] "Data in ZLIB format (RFC 1950), uncompressed file size is required"
-		/deflate size [integer!] "Data in DEFLATE format (RFC 1951), uncompressed file size is required"
+		data		[binary!]
+		/zlib		"Data in ZLIB format (RFC 1950)"
+		size		[integer!] "Uncompressed data size"
+		/deflate	"Data in DEFLATE format (RFC 1951)"
+		size		[integer!] "Uncompressed data size"
 	]
 	#get-definition NAT_DECOMPRESS
 ]

--- a/modules/view/draw.red
+++ b/modules/view/draw.red
@@ -1138,7 +1138,7 @@ draw: function [
 	"Draws scalable vector graphics to an image"
 	image	[image! pair!]	"Image or size for an image"
 	cmd		[block!]		"Draw commands"
-	/transparent
+	/transparent			"Make a transparent image, if pair! spec is used"
 	return: [image!]
 ][
 	if pair? image [

--- a/modules/view/view.red
+++ b/modules/view/view.red
@@ -310,7 +310,11 @@ on-face-deep-change*: function ["Internal use only" owner word target action new
 	]
 ]
 
-link-tabs-to-parent: function ["Internal Use Only" face [object!] /init][
+link-tabs-to-parent: function [
+	"Internal Use Only"
+	face	[object!]
+	/init	"Force /show of first tab"
+][
 	if faces: face/pane [
 		visible?: face/visible?
 		forall faces [


### PR DESCRIPTION
Added doc strings of refinements for `bind`, `decompress`, `draw`, `link-tabs-to-parent`, `load`, `pad`, `parse`, `parse-trace` functions.