### PR TITLE
Implemented MOLD/ALL for LOGIC! and NONE! values

### DIFF
--- a/runtime/datatypes/logic.reds
+++ b/runtime/datatypes/logic.reds
@@ -217,7 +217,12 @@ logic: context [
 	][
 		#if debug? = yes [if verbose > 0 [print-line "logic/mold"]]
 
-		form boolean buffer arg part
+		either all? [
+			string/concatenate-literal buffer either boolean/value ["#[true]"] ["#[false]"]
+			part - either boolean/value [7] [8]
+		] [
+			form boolean buffer arg part
+		]
 	]
 	
 	compare: func [

--- a/runtime/datatypes/none.reds
+++ b/runtime/datatypes/none.reds
@@ -92,7 +92,12 @@ none: context [
 	][
 		#if debug? = yes [if verbose > 0 [print-line "none/mold"]]
 
-		form value buffer arg part
+		either all? [
+			string/concatenate-literal buffer "#[none]"
+			part - 7
+		] [
+			form value buffer arg part
+		]
 	]
 	
 	compare: func [

--- a/tests/source/units/mold-test.red
+++ b/tests/source/units/mold-test.red
@@ -169,5 +169,26 @@ Red [
 
 ===end-group=== 
 
+===start-group=== "mold-all"
+	
+	--test-- "mold-true" --assert "true" = mold true
+
+	--test-- "mold-all-true" --assert "#[true]" = mold/all true
+
+	--test-- "mold-false" --assert "false" = mold false
+
+	--test-- "mold-all-false" --assert "#[false]" = mold/all false
+
+	--test-- "mold-none" --assert "none" = mold none
+
+	--test-- "mold-all-none" --assert "#[none]" = mold/all none
+
+	--test-- "mold-block" --assert "[true false none]" = mold [#[true] #[false] #[none]]
+
+	--test-- "mold-all-block"
+		--assert "[#[true] #[false] #[none]]" = mold/all [#[true] #[false] #[none]]
+
+===end-group=== 
+
 
 ~~~end-file~~~


### PR DESCRIPTION
This is a very simple change that implements the `/all` refinement for `mold` on `logic!` and `none!` values.