### PR TITLE
FIX: build/git.r file looks modified after each build on Windows

### DIFF
--- a/build/build.r
+++ b/build/build.r
@@ -91,7 +91,7 @@ if Windows? [
 ]
 
 ;-- Restore git file
-attempt [write git-file "none^/"]								;-- tests require it!
+attempt [write/binary git-file "none^/"]								;-- tests require it!
 
 ;-- Remove temporary files
 attempt [delete ts-file]


### PR DESCRIPTION
git.r file looks modified after each build on Windows because of line endings difference. Might be possible to ignore by changing git settings, but better to keep the original line endings.