### PR TITLE
FEAT: use macro to automatically track number of datatypes in all code

### DIFF
--- a/runtime/datatypes/datatype.reds
+++ b/runtime/datatypes/datatype.reds
@@ -48,7 +48,7 @@ datatype: context [
 			name	[names!]
 	][
 		type: list/value
-		assert type < 50								;-- hard limit of action table
+		assert type < TYPE_TOTAL_COUNT								;-- hard limit of action table
 		if type > top-id [top-id: type]					;@@ unreliable, needs automatic type IDs
 		list: list + 1
 		

--- a/runtime/macros.reds
+++ b/runtime/macros.reds
@@ -63,6 +63,7 @@ Red/System [
 	TYPE_EVENT											
 	TYPE_CLOSURE
 	TYPE_PORT
+	TYPE_TOTAL_COUNT									;-- keep tabs on number of datatypes.
 ]
 
 #enum actions! [

--- a/runtime/red.reds
+++ b/runtime/red.reds
@@ -146,8 +146,8 @@ red: context [
 		_random/init
 		init-mem										;@@ needs a local context
 		
-		name-table: as names! allocate 50 * size? names!	 ;-- datatype names table
-		action-table: as int-ptr! allocate 256 * 50 * size? pointer! ;-- actions jump table	
+		name-table: as names! allocate TYPE_TOTAL_COUNT * size? names!	 ;-- datatype names table
+		action-table: as int-ptr! allocate 256 * TYPE_TOTAL_COUNT * size? pointer! ;-- actions jump table	
 
 		datatype/init
 		unset/init


### PR DESCRIPTION
used a long and explicit macro name (```TYPE_TOTAL_COUNT```) so it doesn't get mixed up with a type name within code.
```
TYPE_COUNT    TYPE_MAX   
```
could look like data type names and not be as obvious in intent.