### PR TITLE
FEAT: Added case refinement to REPLACE function

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -205,54 +205,59 @@ replace: function [
 	value "New value, replaces pattern in the series"
 	/all "Replace all occurrences, not just the first"
 	/deep "Replace pattern in all sub-lists as well"
-	/local p rule s e many? len pos
+	/case "Case-sensitive replacement"
+	/local p rule s e many? len pos do-parse do-find
 ][
-	if system/words/all [deep any-list? series][
-		pattern: to block! either word? pattern [to lit-word! pattern][pattern]
-		parse series rule: [
-			some [
-				s: pattern e: (
-				s: change/part s value e
-					unless all [return series]
-				) :s
-				| ahead any-list! into rule | skip
-			]
-		]
-		return series
-	]
-	if system/words/all [char? :pattern any-string? series][
-		pattern: form pattern
-	]
-	either system/words/all [any-string? :series block? :pattern] [
-		p: [to pattern change pattern (value)]
-		parse series either all [[some p]][p]
-	][
-		many?: any [
-			system/words/all [series? :pattern any-string? series]
-			binary? series
-			system/words/all [any-list? series any-list? :pattern]
-		] 
-		len: either many? [length? pattern][1]
-		either all [
-			pos: series
-			either many? [
-				while [pos: find pos pattern][
-					remove/part pos len
-					pos: insert pos value
-				]
-			] [
-				while [pos: find pos :pattern] [
-					pos: insert remove pos value
+	do-parse: pick [parse/case parse] case
+    if system/words/all [deep any-list? series] [
+        pattern: to block! either word? pattern [to lit-word! pattern] [pattern]
+        do compose [
+			(do-parse) series rule: [
+				some [
+					s: pattern e: (
+						s: change/part s value e
+						unless all [return series]
+					) :s
+					| ahead any-list! into rule | skip
 				]
 			]
-		] [
-			if pos: find series :pattern [
-				remove/part pos len 
-				insert pos value
-			]
-		]
-	]
-	series
+        ]
+        return series
+    ]
+    if system/words/all [char? :pattern any-string? series] [
+        pattern: form pattern
+    ]
+    either system/words/all [any-string? :series block? :pattern] [
+        p: [to pattern change pattern (value)]
+        do reduce [do-parse series either all [[some p]] [p]]
+    ] [
+        many?: any [
+            system/words/all [series? :pattern any-string? series]
+            binary? series
+            system/words/all [any-list? series any-list? :pattern]
+        ]
+        len: either many? [length? pattern] [1]
+		do-find: pick [find/case find] case
+        either all [
+            pos: series
+            either many? [
+                while [pos: do reduce [do-find pos pattern]] [
+                    remove/part pos len
+                    pos: insert pos value
+                ]
+            ] [
+                while [pos: do reduce [do-find pos :pattern]] [
+                    pos: insert remove pos value
+                ]
+            ]
+        ] [
+            if pos: do reduce [do-find series :pattern] [
+                remove/part pos len
+                insert pos value
+            ]
+        ]
+    ]
+    series
 ]
 
 math: function [


### PR DESCRIPTION
`case` refinement added to `replace` function. See https://github.com/red/REP/issues/18

```
>> replace/all/case/deep quote (a (A a (A a))) ['a] 'x
== (x (A x (A x)))
```