### PR TITLE
FIX for #3582

### DIFF
--- a/runtime/datatypes/image.reds
+++ b/runtime/datatypes/image.reds
@@ -656,6 +656,7 @@ image: context [
 		either out-range = 1 [
 			fire [TO_ERROR(script out-of-range) boxed]
 		][
+			unless TYPE_TUPLE = TYPE_OF(data) [fire [TO_ERROR(script invalid-arg) data]]
 			color: as red-tuple! data
 			p: (as byte-ptr! color) + 4
 			r: as-integer p/1

--- a/tests/source/units/image-test.red
+++ b/tests/source/units/image-test.red
@@ -87,4 +87,26 @@ img: make image! 2x2
 		--assert error? try [img/(3x2): 1.2.3]
 ===end-group===
 
+===start-group=== "image pixel assignment validity"
+	--test-- "image pixel 3-tuple assignment 1"
+		--assert 255.255.255 = img/1: 255.255.255
+	--test-- "image pixel 3-tuple assignment 2"
+		--assert 255.255.255.0 = img/1
+	--test-- "image pixel 4-tuple assignment"
+		--assert 255.255.255.255 = img/2: 255.255.255.255
+	--test-- "image pixel 5-tuple assignment 1"
+		--assert 1.2.3.4.5 = img/3: 1.2.3.4.5
+	--test-- "image pixel 5-tuple assignment 2"
+		--assert 1.2.3.4 = img/3
+	--test-- "image pixel junk assignment 1"
+		--assert error? try [img/1: "junk"]
+	--test-- "image pixel junk assignment 2"
+		--assert error? try [img/1: []]
+	--test-- "image pixel junk assignment 3"
+		--assert error? try [img/1: 3.14]
+	--test-- "image pixel unaffected by junk assignments?"
+		--assert 255.255.255.0 = img/1
+===end-group===
+
+
 ~~~end-file~~~


### PR DESCRIPTION
Apparently there's no integer-to-pixel assignment yet. It just allows to assign anything:
```
>> poke im 1 "junk"
== "junk"
>> im/1: 'junk
== junk
>> im/1
== 132.56.50.0
```
I added a type check and a couple of tests.
New behavior for everything but tuples:
```
>> i/1: "junk"
*** Script Error: invalid argument: "junk"
*** Where: set-path
*** Stack:  
```