### PR TITLE
3380

### DIFF
--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -297,6 +297,7 @@ natives: context [
 		
 		either TYPE_OF(value) = TYPE_BLOCK [
 			size: block/rs-length? as red-block! value
+			if 0 >= size [fire [TO_ERROR(script invalid-arg) value]]
 			
 			while [foreach-next-block size][			;-- foreach [..]
 				stack/reset
@@ -3002,7 +3003,7 @@ natives: context [
 		]
 		assert TYPE_OF(blk) = TYPE_BLOCK
 
-		result: loop? series
+		result: (loop? series) and (0 < size)
 		if result [
 			switch type [
 				TYPE_STRING

--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -3003,7 +3003,7 @@ natives: context [
 		]
 		assert TYPE_OF(blk) = TYPE_BLOCK
 
-		result: (loop? series) and (0 < size)
+		result: all [loop? series  size > 0]
 		if result [
 			switch type [
 				TYPE_STRING

--- a/tests/source/units/loop-test.red
+++ b/tests/source/units/loop-test.red
@@ -36,6 +36,11 @@ Red [
     br5-i: 0
     repeat br5-counter 0 [br5-i: br5-i + 1]
   --assert 0 = br5-i
+
+  --test-- "br6"
+    br6-i: 0
+    repeat br6-counter -1 [br6-i: br6-i + 1]
+  --assert 0 = br6-i
   
 ===end-group===
 
@@ -170,6 +175,20 @@ Red [
 		--assert 9 = fa1-count
 		--assert 9 = length? fa1-b
 		--assert 11 = first fa1-b
+
+===end-group===
+
+
+===start-group=== "invalid usage"
+
+	--test-- "invalid until-1"
+		--assert error? try [until []]
+
+	--test-- "invalid foreach-1 (issue #3380)"
+		--assert not error? try [foreach [x] [] [2]]
+		--assert error? try [foreach [] [1] [2]]
+		--assert error? try [foreach [] [] [2]]
+		--assert error? try [foreach (tail [1]) [1] [2]]
 
 ===end-group===
 

--- a/tests/source/units/loop-test.red
+++ b/tests/source/units/loop-test.red
@@ -186,8 +186,9 @@ Red [
 
 	--test-- "invalid foreach-1 (issue #3380)"
 		--assert not error? try [foreach [x] [] [2]]
-		--assert error? try [foreach [] [1] [2]]
-		--assert error? try [foreach [] [] [2]]
+		;-- `do` is required because the compiler won't accept an empty block:
+		--assert error? try [do [foreach [] [1] [2]]]
+		--assert error? try [do [foreach [] [] [2]]]
 		--assert error? try [foreach (tail [1]) [1] [2]]
 
 ===end-group===


### PR DESCRIPTION
Fix for #3380:
- a sanity check against deadlocking in `foreach-next-block` so that it will return false in case the block of words is empty and thus the input cannot possibly be advanced
- a specific error when `foreach` 1st argument is empty `[]`

A couple of related tests