### PR TITLE
Fix for #3268

### DIFF
--- a/runtime/datatypes/error.reds
+++ b/runtime/datatypes/error.reds
@@ -45,6 +45,16 @@ error: context [
 		type/symbol
 	]
 	
+	get-id: func [
+		err		[red-object!]
+		return: [integer!]
+		/local
+			id [red-word!]
+	][
+		id: as red-word! (object/get-values err) + field-id
+		id/symbol
+	]
+	
 	get-stack-id: func [return: [integer!]][field-stack]
 	
 	get-call-argument: func [

--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -1872,11 +1872,13 @@ natives: context [
 		/local
 			err	[red-object!]
 			id  [integer!]
+			type [integer!]
 	][
 		err: as red-object! stack/get-top
 		assert TYPE_OF(err) = TYPE_ERROR
-		id: error/get-type err
-		either id = words/errors/throw/symbol [			;-- check if error is of type THROW
+		id: error/get-id err
+		type: error/get-type err
+		either all [id = type id = words/errors/throw/symbol] [			;-- check if error is of type THROW
 			re-throw 									;-- let the error pass through
 		][
 			stack/adjust-post-try

--- a/tests/source/compiler/compile-error-test.r
+++ b/tests/source/compiler/compile-error-test.r
@@ -8,8 +8,40 @@ REBOL [
 
 ~~~start-file~~~ "Red compile errors"
 
+===start-group=== "issue #608"
+
 	--test-- "ce-1 issue #608"
 		--compile-this-red {s: "open ended string}
 		--assert-msg? "*** Syntax Error: Invalid string! value"
+
+===end-group===	
+
+===start-group=== "issue #3268"
+	
+	--test-- "ce-2a"
+		--compile-this-red {try [continue]}
+		--assert-msg? "*** Compilation Error: CONTINUE used with no loop"
+
+	--test-- "ce-2b"
+		--compile-this-red {try [break]}
+		--assert-msg? "*** Compilation Error: BREAK used with no loop"
+
+	--test-- "ce-2c"
+		--compile-this-red {try [exit]}
+		--assert-msg? "*** Compilation Error: EXIT used outside of a function"
+
+	--test-- "ce-2d"
+		--compile-this-red {try [return 1]}
+		--assert-msg? "*** Compilation Error: RETURN used outside of a function"
+
+	--test-- "ce-2e"
+		--compile-this-red {try [while [continue][]]}
+		--assert-msg? "*** Compilation Error: CONTINUE used with no loop"
+		
+	--test-- "ce-2f"
+		--compile-this-red {try [while [break][]]}
+		--assert-msg? "*** Compilation Error: BREAK used with no loop"
+
+===end-group===	
   
 ~~~end-file~~~ 

--- a/tests/source/units/all-tests.txt
+++ b/tests/source/units/all-tests.txt
@@ -46,6 +46,7 @@ decompress-test.red
 recycle-test.red
 debase-test.red
 enbase-test.red
+try-test.red
 auto-tests/lexer-auto-test.red
 power-test.red
 ../environment/scalars-test.red

--- a/tests/source/units/try-test.red
+++ b/tests/source/units/try-test.red
@@ -1,0 +1,122 @@
+Red [
+  Title:   "Red TRY test script"
+  Author:  "hiiamboris"
+  File:    %try-test.red
+  Tabs:    4
+  Rights:  "Copyright (C) 2011-2018 Red Foundation. All rights reserved."
+  License: "BSD-3 - https://github.com/red/red/blob/origin/BSD-3-License.txt"
+]
+
+#include  %../../../quick-test/quick-test.red
+
+~~~start-file~~~ "try"
+
+===start-group=== "try (interpreted)"
+
+	type+id?: func ['type 'id err] [all [error? :err type = err/type id = err/id]]
+
+	--test-- "tt11" --assert not error? try [0]
+
+	;-- thorough tests of the 'throw' group --
+
+	--test-- "tt21" --assert 1 = catch [try [throw 1] 2]
+
+	; try/all should discard any outer loops here
+	--test-- "tt22a" --assert yes = try/all [type+id? throw break do [try [break/return 1]]]
+	--test-- "tt22b" --assert yes = try/all [type+id? throw break do [try [break]]]
+	--test-- "tt22c" --assert 1 = loop 1 [try [break/return 1] 2]
+	--test-- "tt22d" --assert unset? loop 1 [do [try [break] 2]]
+
+	; FIXME: compiled version returns 1 (loop count) instead of unset
+	;--test-- "tt22e" --assert unset? loop 1 [try [break] 2]
+	
+	--test-- "tt23a" --assert type+id? throw return do [try [exit]]
+	--test-- "tt23b"
+		tt-ret-func1: does [try [return 1]]
+		--assert 1 = tt-ret-func1
+	--test-- "tt23c"
+		tt-ret-func2: does [try [exit]]
+		--assert unset? tt-ret-func2
+	
+	; try/all should discard any outer loops here
+	--test-- "tt24a" --assert yes = try/all [type+id? throw continue do [try [continue 1]]]
+	--test-- "tt24b" --assert unset? loop 1 [do [try [continue 1] 2]]
+
+	; FIXME: compiled version returns 1 (loop count) instead of unset
+	;--test-- "tt24c" --assert unset? loop 1 [try [continue 1] 2]
+	
+	--test-- "tt25a" --assert type+id? throw while-cond do [try [while [break][]]]
+	--test-- "tt25b" --assert type+id? throw while-cond do [loop 1 [try [while [break][]]]]
+	--test-- "tt26a" --assert type+id? throw while-cond do [try [while [continue][]]]
+	--test-- "tt26b" --assert type+id? throw while-cond do [loop 1 [try [while [continue][]]]]
+
+	;-- minimal tests of other groups --
+
+	--test-- "tt31" --assert type+id? math zero-divide try [1 / 0]
+	--test-- "tt41" --assert type+id? access cannot-open try [read %"///^@:<>?*"]
+	--test-- "tt51" --assert type+id? user message try [do make error! "error"]
+	--test-- "tt61" --assert type+id? script no-arg do [try [try]]
+	--test-- "tt71" --assert type+id? syntax missing try [do "["]
+
+===end-group===
+
+===start-group=== "try/all (interpreted)"
+
+	type+id?: func ['type 'id err] [all [error? :err type = err/type id = err/id]]
+
+	--test-- "tta11" --assert not error? try/all [0]
+
+	;-- thorough tests of the 'throw' group --
+
+	--test-- "tta21" --assert type+id? throw throw try/all [throw 1]
+
+	--test-- "tta22a" --assert type+id? throw break do [try/all [break]]
+	--test-- "tta22b" --assert type+id? throw break loop 1 [do [try/all [break]]]
+	
+	; FIXME: should work + compiler's error message for this is nonsensical:
+	; --test-- "tta22c" --assert type+id? throw break loop 1 [try/all [break]]
+	; *** Script Error: loop does not allow none! for its count argument
+
+	; FIXME: compiler should not complain about this:
+	; --test-- "tta22d" --assert type+id? throw break try/all [break]
+	; as `try/all` also must accept `break`
+	
+	--test-- "tta23a" --assert type+id? throw return do [try/all [exit]]
+	--test-- "tta23b"
+		tta-ret-func: does [do [try/all [exit]]]
+		--assert type+id? throw return tta-ret-func
+
+	; FIXME: should work + compiler's error message for this is nonsensical:
+	; --test-- "tta23c"
+	;	tta-ret-func: does [try/all [exit]]
+	;	--assert type+id? throw return tta-ret-func
+	; *** Script Error: body does not allow unset! for its <anon> argument
+	
+	; FIXME: compiler should not complain about this:
+	; --test-- "tta23d" --assert type+id? throw return try/all [exit]
+	; as `try/all` also must accept `exit`
+	
+	--test-- "tta24a" --assert type+id? throw continue do [try/all [continue]]
+	--test-- "tta24b" --assert type+id? throw continue loop 1 [do [try/all [continue]]]
+
+	; FIXME: should work + compiler's error message for this is nonsensical:
+	; --test-- "tta24c" --assert type+id? throw continue loop 1 [try/all [continue]]
+	; *** Script Error: loop does not allow none! for its count argument
+
+	--test-- "tta25a" --assert type+id? throw while-cond do [try/all [while [break][]]]
+	--test-- "tta25b" --assert type+id? throw while-cond do [loop 1 [try/all [while [break][]]]]
+	--test-- "tta26a" --assert type+id? throw while-cond do [try/all [while [continue][]]]
+	--test-- "tta26b" --assert type+id? throw while-cond do [loop 1 [try/all [while [continue][]]]]
+
+	;-- minimal tests of other groups --
+
+	--test-- "tta31" --assert type+id? math zero-divide try/all [1 / 0]
+	--test-- "tta41" --assert type+id? access cannot-open try/all [read %"///^@:<>?*"]
+	--test-- "tta51" --assert type+id? user message try/all [do make error! "error"]
+	--test-- "tta61" --assert type+id? script no-arg do [try/all [try]]
+	--test-- "tta71" --assert type+id? syntax missing try/all [do "["]
+
+===end-group===
+	
+~~~end-file~~~
+


### PR DESCRIPTION
It did not crash, just exited silently, as R/S part believed that Red part has displayed the error already:
https://github.com/red/red/blob/master/system/runtime/common.reds#L258

On a side note: it's debatable if returning `0` after a Red error is a good idea. @dockimbel what do you think?

Then, Red part executed `try [break]` like this:
- `throw-break` couldn't find the *loop frame*, so it called `throw-error` to throw a Red error https://github.com/red/red/blob/master/runtime/stack.reds#L446
- `throw-error` was finding the *try frame* https://github.com/red/red/blob/master/runtime/stack.reds#L399 and threw an R/S error https://github.com/red/red/blob/master/runtime/stack.reds#L415
- `try*` was catching that R/S error https://github.com/red/red/blob/master/runtime/natives.reds#L1923 and re-threw it https://github.com/red/red/blob/master/runtime/natives.reds#L1880 as if it was a `throw ...` Red call (and a `throw` is being caught on the top R/S level: https://github.com/red/red/blob/master/system/runtime/common.reds#L260)

`throw` error group (type) spans more than just `throw`, but also `break`, `continue`, `exit`/`return` and `while` errors. If I interpret the code logic right, `try` is supposed to re-throw only errors resulting from `throw value` statement, and catch all the other Red errors in this group. Normal (not misplaced) uses of `break`, `exit`, etc. are not producing Red errors, but throw corresponding R/S errors, which are caught in other places. So I narrowed down the errors that `try` is supposed to re-throw from all of the `throw` type to only the single `type=throw, id=throw` error.

@dockimbel should review the code part to confirm if my interpretation is correct.
@PeterWAWood should review the test file I made.

There can be also an extended solution to this issue: to also use some flag to track if an issue was indeed displayed and check that flag before the exit, to prevent any possible further hiding of errors. Depends on how much one code part is supposed to trust the other parts ☺
