### PR TITLE
proper ceiling in size-text

### DIFF
--- a/modules/view/backends/macOS/gui.reds
+++ b/modules/view/backends/macOS/gui.reds
@@ -179,8 +179,8 @@ get-text-size: func [
 	y: system/cpu/edx								;-- string height on screen
 	rc: as NSRect! :x
 
-	size/width: as-integer rc/x
-	size/height: as-integer rc/y
+	size/width: as-integer ceil rc/x
+	size/height: as-integer ceil rc/y
 	if pair <> null [
 		pair/x: size/width
 		pair/y: size/height

--- a/modules/view/backends/macOS/gui.reds
+++ b/modules/view/backends/macOS/gui.reds
@@ -179,8 +179,8 @@ get-text-size: func [
 	y: system/cpu/edx								;-- string height on screen
 	rc: as NSRect! :x
 
-	size/width: as-integer ceil rc/x
-	size/height: as-integer ceil rc/y
+	size/width: as-integer ceil as-float rc/x
+	size/height: as-integer ceil as-float rc/y
 	if pair <> null [
 		pair/x: size/width
 		pair/y: size/height

--- a/modules/view/backends/windows/gui.reds
+++ b/modules/view/backends/windows/gui.reds
@@ -279,7 +279,6 @@ get-text-size: func [
 	/local
 		saved [handle!]
 		size  [tagSIZE]
-		delta [integer!]
 ][
 	size: declare tagSIZE
 	if null? hFont [hFont: default-font]
@@ -293,9 +292,9 @@ get-text-size: func [
 
 	SelectObject hScreen saved
 	if pair <> null [
-		delta: either dpi-factor = 100 [0][1]
-		pair/x: size/width * 100 / dpi-factor + delta
-		pair/y: size/height * 100 / dpi-factor + delta
+		;-- round to integer ceiling:
+		pair/x: size/width  * 100 + dpi-factor - 1 / dpi-factor
+		pair/y: size/height * 100 + dpi-factor - 1 / dpi-factor
 	]
 	size
 ]


### PR DESCRIPTION
This formula
```
delta: either dpi-factor = 100 [0][1]
....: size/width * 100 / dpi-factor + delta
``` 
relies on 2 assumptions:
- (size/width * 100) / dpi-factor never becomes an integer
- dpi-factor is always <= 100

Both don't look valid to me. I suggest just round the result to the nearest higher integer.
