### PR TITLE
FEAT: qt-verbose flag

### DIFF
--- a/quick-test/quick-test.red
+++ b/quick-test/quick-test.red
@@ -33,6 +33,7 @@ Red [
   ]  
 ]
 qt-file-name: none
+qt-verbose: false
 
 ;; group switches
 qt-group-name-not-printed: true
@@ -82,6 +83,10 @@ qt-init-file: func [] [
 ===start-group===: func [
   title [string!]
 ][
+  if qt-verbose [
+    prin "===group=== "
+    print title
+  ]
   qt-group-name: title
   qt-group?: true
 ]
@@ -89,6 +94,10 @@ qt-init-file: func [] [
 --test--: func [
   title [string!]
 ][
+  if qt-verbose [
+    prin "--test-- "
+    print title
+  ]
   qt-test-name: title
   qt-file-tests: qt-file-tests + 1
 ]


### PR DESCRIPTION
I added this flag when using `quick-test.red` as otherwise it was impossible to know at which test it crashes or complains. Let it be in the repo, ok? @PeterWAWood 

Usage: add `qt-verbose: yes` after the #include of quick-test.red.