### PR TITLE
FIX: do-events returns error on CLI console

### DIFF
--- a/modules/view/view.red
+++ b/modules/view/view.red
@@ -684,10 +684,11 @@ do-events: function [
 	return: [logic! word!] "Returned value from last event"
 	/local result
 ][
-	win: last head system/view/screens/1/pane
-	unless win/state/4 [win/state/4: not no-wait]		;-- mark the window from which the event loop starts
-	set/any 'result system/view/platform/do-event-loop no-wait
-	:result
+	if win: last head system/view/screens/1/pane [
+		unless win/state/4 [win/state/4: not no-wait]		;-- mark the window from which the event loop starts
+		set/any 'result system/view/platform/do-event-loop no-wait
+		:result
+	]
 ]
 
 do-safe: func ["Internal Use Only" code [block!] /local result][


### PR DESCRIPTION
`do-events` doesn't work on CLI console:
```
>> do-events
*** Script Error: path none is not valid for none! type
*** Where: eval-path
*** Stack: do-events
```
This PR fixes `do-events` to return `none` on CLI instead of error above.
