### PR TITLE
FIX: missing link to contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Note: The red git repository does not include a .gitignore file. If you run the 
 
 Contributing
 -------------------------
-If you want to contribute code to the Red project be sure to read the [guidelines](https://github.com/red/red/wiki/Contributor-Guidelines) first.
+If you want to contribute code to the Red project be sure to read the [guidelines](https://github.com/red/red/wiki/%5BDOC%5D-Contributor-Guidelines) first.
 
 It is usually a good idea to inform the Red team about what changes you are going to make in order to ensure that someone is not already working on the same thing. You can reach us through the [mailing-list](https://groups.google.com/forum/?hl=en#!forum/red-lang) or our [chat room](https://gitter.im/red/red).
 


### PR DESCRIPTION
The page was moved during wiki reorganization.