### PR TITLE
Fix: order of colors in RTD

### DIFF
--- a/modules/view/RTD.red
+++ b/modules/view/RTD.red
@@ -13,7 +13,7 @@ Red [
 context [
 	stack: make block! 10
 	color-stk: make block! 5
-	out: text: s-idx: mark: s: pos: v: l: col: none
+	out: text: s-idx: mark: s: pos: v: l: col: cur: pos1: none
 
 	;--- Parsing rules ---
 
@@ -66,13 +66,13 @@ context [
 	]
 
 	close-colors: has [pos][
-		pos: color-stk
-		while [pos: find/tail pos '_][
-			pos/-1: tail-idx?
-			append out as-pair pos/-2 tail-idx? - pos/-2
-			append out pos/1
-			new-line skip tail out -2 on
-			pos: remove/part skip pos -2 3
+		pos: tail color-stk
+		while [pos: find/reverse pos '_][
+			pos/1: tail-idx?
+			insert out as-pair pos/-1 tail-idx? - pos/-1
+			insert next out pos/2
+			new-line skip out 2 on
+			pos: remove/part skip pos -1 3
 		]
 	]
 
@@ -111,13 +111,35 @@ context [
 	optimize: function [][								;-- combine same ranges together
 		parse out [
 			any [
-				pos: pair! (range: pos/1) to pair! pos:
+				cur: pos: pair! (range: pos/1) [to pair! e: pos: | to end e:]
 				any [
 					to range s: skip [to pair! | to end] e: (
 						s: remove s
 						e: skip move/part s pos l: offset? s back e l
 					) :e
-				]
+				]( 
+					pos: :cur mov: no
+					while [pos: find/reverse pos pair!][
+						case [
+							any [
+								pos/1/1 > cur/1/1
+								all [pos/1/1 = cur/1/1 pos/1/2 > pos/1/2]
+							][
+								mov: yes 
+								pos1: :pos
+								if head? pos1 [
+									move/part cur pos1 offset? cur e
+									break
+								]
+							]
+							mov [
+								move/part cur pos1 offset? cur e
+								break
+							]
+							'else [break]
+						]
+					]
+				)
 			]
 		]
 	]


### PR DESCRIPTION
Currently, if colors which where open in the beginning are closed in the end then other colors which where inserted in between are overwritten. Like this:

```
view [rich-text data [
    "black " red "red " green ["green " blue ["blue "]] "red"
]]
```

[![rt-colors-1](http://vooglaid.ee/red/rt-colors1-1.png)](http://vooglaid.ee/red/rt-colors1-1.png)

To prevent this, unclosed colors should be inserted in the beginning of the out block in `close-colors`:

```
    close-colors: has [pos][
        pos: tail color-stk
        while [pos: find/reverse pos '_][
            pos/1: tail-idx?
            insert out as-pair pos/-1 tail-idx? - pos/-1
            insert next out pos/2
            new-line skip out 2 on
            pos: remove/part skip pos -1 3
        ]
    ]
```

The above rich-text snippet will show better with this change, but not perfect, because similar problem affects colors which are immediately closed, but nested. To fix this, `optimize` func may be made to sort styles:

[![rt-colors-2](http://vooglaid.ee/red/rt-colors2-1.png)](http://vooglaid.ee/red/rt-colors2-1.png)

```
    optimize: function [][                                ;-- combine same ranges together
        parse out [
            any [
                cur: pos: pair! (range: pos/1) [to pair! e: pos: | to end e:]
                any [
                    to range s: skip [to pair! | to end] e: (
                        s: remove s
                        e: skip move/part s pos l: offset? s back e l 
                    ) :e
                ]( 
                    pos: :cur mov: no
                    while [pos: find/reverse pos pair!][
                        case [
                            any [
                                pos/1/1 > cur/1/1
                                all [pos/1/1 = cur/1/1 pos/1/2 > pos/1/2]
                            ][
                                mov: yes 
                                pos1: :pos
                                if head? pos1 [
                                    move/part cur pos1 offset? cur e
                                    break
                                ]
                            ]
                            any [mov head? pos] [
                                move/part cur pos1 offset? cur e
                                break
                            ]
                            'else [break]
                        ]
                    ]
                )
            ]
        ]
    ]
```

With this the above view snippet will show perfectly.
[![rt-colors-3](http://vooglaid.ee/red/rt-colors3-1.png)](http://vooglaid.ee/red/rt-colors3-1.png)