### PR TITLE
 arctangent2 radians/degrees support 

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -964,7 +964,7 @@ asin: func [
 ]
 
 atan: func [
-	"Returns the trigonometric arctangent (in radians in range [-inf,+inf])"
+	"Returns the trigonometric arctangent (in radians in range [-pi/2,+pi/2])"
 	tangent [float!] "in range [-inf,+inf]"
 ][
 	#system [
@@ -974,7 +974,7 @@ atan: func [
 ]
 
 atan2: func [
-	"Returns the angle of the point y/x in radians"
+	"Returns the smallest angle between the vectors (1,0) and (x,y) in range (-pi,pi]"
 	y		[number!]
 	x		[number!]
 	return:	[float!]

--- a/environment/natives.red
+++ b/environment/natives.red
@@ -514,8 +514,8 @@ tangent: make native! [[
 ]
 
 arcsine: make native! [[
-		"Returns the trigonometric arcsine (in degrees by default)"
-		value	[number!]
+		"Returns the trigonometric arcsine (in degrees by default in range [-90,90])"
+		sine	[number!] "in range [-1,1]"
 		/radians "Angle is returned in radians"
 		return: [float!]
 	]
@@ -523,8 +523,8 @@ arcsine: make native! [[
 ]
 
 arccosine: make native! [[
-		"Returns the trigonometric arccosine (in degrees by default)"
-		value	[number!]
+		"Returns the trigonometric arccosine (in degrees by default in range [0,180])"
+		cosine	[number!] "in range [-1,1]"
 		/radians "Angle is returned in radians"
 		return: [float!]
 	]
@@ -532,17 +532,18 @@ arccosine: make native! [[
 ]
 
 arctangent: make native! [[
-		"Returns the trigonometric arctangent (in degrees by default)"
-		value	[number!]
+		"Returns the trigonometric arctangent (in degrees by default in range [-90,90])"
+		tangent	[number!] "in range [-inf,+inf]"
 		/radians "Angle is returned in radians"
 		return: [float!]
 	]
 	#get-definition NAT_ARCTANGENT
 ]
 arctangent2: make native! [[
-		"Returns the smallest angle between the X axis and the point (x,y) (-pi to pi)"
+		"Returns the smallest angle between the vectors (1,0) and (x,y) in degrees by default (-180,180]"
 		y       [number!]
 		x       [number!]
+		/radians "Angle is returned in radians (-pi,pi]"
 		return: [float!]
 	]
 	#get-definition NAT_ARCTANGENT2

--- a/environment/natives.red
+++ b/environment/natives.red
@@ -516,7 +516,7 @@ tangent: make native! [[
 arcsine: make native! [[
 		"Returns the trigonometric arcsine (in degrees by default in range [-90,90])"
 		sine	[number!] "in range [-1,1]"
-		/radians "Angle is returned in radians"
+		/radians "Angle is returned in radians [-pi/2,pi/2]"
 		return: [float!]
 	]
 	#get-definition NAT_ARCSINE
@@ -525,7 +525,7 @@ arcsine: make native! [[
 arccosine: make native! [[
 		"Returns the trigonometric arccosine (in degrees by default in range [0,180])"
 		cosine	[number!] "in range [-1,1]"
-		/radians "Angle is returned in radians"
+		/radians "Angle is returned in radians [0,pi]"
 		return: [float!]
 	]
 	#get-definition NAT_ARCCOSINE
@@ -534,7 +534,7 @@ arccosine: make native! [[
 arctangent: make native! [[
 		"Returns the trigonometric arctangent (in degrees by default in range [-90,90])"
 		tangent	[number!] "in range [-inf,+inf]"
-		/radians "Angle is returned in radians"
+		/radians "Angle is returned in radians [-pi/2,pi/2]"
 		return: [float!]
 	]
 	#get-definition NAT_ARCTANGENT

--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -1693,6 +1693,7 @@ natives: context [
 
 	arctangent2*: func [
 		check? [logic!]
+		radians [integer!]
 		/local
 			f	[red-float!]
 			n	[red-integer!]
@@ -1716,6 +1717,7 @@ natives: context [
 			x: f/value
 		]
 		f/value: atan2 y x
+		if radians < 0 [f/value: 180.0 / PI * f/value]			;-- to degrees
 		stack/set-last as red-value! f
 	]
 

--- a/tests/source/units/float-test.red
+++ b/tests/source/units/float-test.red
@@ -69,11 +69,25 @@ Red [
 		--assert 45 = arctangent 1
 
 	--test-- "float-arctangent2"
-		--assertf~=  3.1415926535898  arctangent2 0 -1 1E-13
-		--assertf~=  3.1415926535898  arctangent2 0.0 -1.0 1E-13
-		--assertf~= -1.5707963267949  arctangent2 -1 0 1E-13
-		--assertf~= -0.78539816339745 arctangent2 -1 1 1E-13
-		--assertf~= -0.78539816339745 arctangent2 -1.5 1.5 1E-13
+		--assertf~=  3.1415926535898  atan2 0 -1 1E-13
+		--assertf~=  3.1415926535898  atan2 0.0 -1.0 1E-13
+		--assertf~= -1.5707963267949  atan2 -1 0 1E-13
+		--assertf~= -0.78539816339745 atan2 -1 1 1E-13
+		--assertf~= -0.78539816339745 atan2 -1.5 1.5 1E-13
+
+	--test-- "float-arctangent3"
+		--assertf~=  3.1415926535898  arctangent2/radians 0 -1 1E-13
+		--assertf~=  3.1415926535898  arctangent2/radians 0.0 -1.0 1E-13
+		--assertf~= -1.5707963267949  arctangent2/radians -1 0 1E-13
+		--assertf~= -0.78539816339745 arctangent2/radians -1 1 1E-13
+		--assertf~= -0.78539816339745 arctangent2/radians -1.5 1.5 1E-13
+
+	--test-- "float-arctangent4"
+		--assertf~=  180.0 arctangent2 0 -1 1E-13
+		--assertf~=  180.0 arctangent2 0.0 -1.0 1E-13
+		--assertf~= -90.0  arctangent2 -1 0 1E-13
+		--assertf~= -45.0  arctangent2 -1 1 1E-13
+		--assertf~= -45.0  arctangent2 -1.5 1.5 1E-13
 
 ===end-group===
 


### PR DESCRIPTION
So I was asleep when my mind brought it up to me that there was a typo in the previous docstrings. And then @greggirwin wished to also modify docstrings of corresponding natives. And then I noticed that arctangent2 was definitely meant to support radians, yet never implemented:
- otherwise it is meaningless to have atan2 and arctangent2 doing the same thing under 2 names
- https://github.com/red/red/blob/c87d85e8e7fbfb6b753538971e3ddfa8345cae9c/runtime/natives.reds#L1702 (presence of a check for nonexistent argument)
- https://github.com/red/red/blob/c87d85e8e7fbfb6b753538971e3ddfa8345cae9c/environment/functions.red#L984 (passing of `1` into nowhere as only a single arg is accepted)

Then I thought what's the better time than now... ;)