### PR TITLE
FIX: Allowed nested style-paths

### DIFF
--- a/modules/view/RTD.red
+++ b/modules/view/RTD.red
@@ -13,8 +13,8 @@ Red [
 context [
 	stack: make block! 10
 	color-stk: make block! 5
-	out: text: s-idx: mark: s: pos: v: l: cur: pos1: none
-	col: 0
+	out: text: s-idx: s: pos: v: l: cur: pos1: none
+	mark: copy [] col: 0 cols: copy []
 
 	;--- Parsing rules ---
 
@@ -43,13 +43,13 @@ context [
 		| color (push-color v) opt [nested (pop-color)]
 		| ahead path!
 		  into [
-			(mark: tail stack) some [					;@@ implement any-single
+			(col: 0 insert/only mark tail stack) some [					;@@ implement any-single
 				(v: none)
 				s: ['b | 'i | 'u | 's | word! if (tuple? attempt [v: get s/1])]
 				(either v [col: col + 1 push-color v][push s/1])
-			]
+			](insert cols col)
 		  ]
-		  nested (pop-all mark)
+		  nested (pop-all take mark)
 	]]
 	rtd: [some [pos: style | s: [string! | char!] (append text s/1 s-idx: tail-idx?)]]
 
@@ -102,7 +102,7 @@ context [
 
 	pop-all: function [mark [block!] /extern col][
 		first?: yes
-		repeat i col [pop-color] col: 0
+		unless empty? cols [repeat i take cols [pop-color]]
 		while [mark <> tail stack][
 			pop last stack
 			either first? [first?: no][remove skip tail out -2]

--- a/modules/view/RTD.red
+++ b/modules/view/RTD.red
@@ -14,7 +14,7 @@ context [
 	stack: make block! 10
 	color-stk: make block! 5
 	out: text: s-idx: s: pos: v: l: cur: pos1: none
-	mark: copy [] col: 0 cols: copy []
+	mark: make block! 5 col: 0 cols: make block! 5
 
 	;--- Parsing rules ---
 


### PR DESCRIPTION
Still more fixes on RTD. Currently nested style-paths are not allowed. Or rather, only innermost styles (except color) of nested style-paths end up in low-level data, like this:
```
view [rt: rich-text data [
    u/red ["red underline " i/s/b/gold ["italic strike bold underline gold"] " red underline"]
]]
```
[![rt-colors4-1](http://vooglaid.ee/red/rt-colors4-1.png)](http://vooglaid.ee/red/rt-colors4-1.png)

Let's make pop-color counters and pop stack "nested-conscious" by introducing two more stacks: one for `mark` and the other for color counters ([line 17](https://github.com/red/red/blob/master/modules/view/RTD.red#L17)):
```
mark: copy [] col: 0 cols: copy []
``` 

Then, use these on [lines 46 - 52](https://github.com/red/red/blob/master/modules/view/RTD.red#L45):
```
		| ahead path!
		  into [
			(col: 0 insert/only mark tail stack) some [					;@@ implement any-single
				(v: none)
				s: ['b | 'i | 'u | 's | word! if (tuple? attempt [v: get s/1])]
				(either v [col: col + 1 push-color v][push s/1])
			](insert cols col)
		  ]
		  nested (pop-all take mark)
```

and on line 105:
```
unless empty? cols [repeat i take cols [pop-color]]
```

After that the above snippet with nested style-paths shows like this:
[![rt-colors4-2](http://vooglaid.ee/red/rt-colors4-2.png)](http://vooglaid.ee/red/rt-colors4-2.png)
