### PR TITLE
Issue 3703

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -228,7 +228,7 @@ replace: function [
 		]
 		return series
 	]
-	if system/words/all [char? :pattern any-string? series] [
+	if system/words/all [any [char? :pattern tag? :pattern] any-string? series] [
 		pattern: form pattern
 	]
 	either system/words/all [any-string? :series block? :pattern] [

--- a/modules/view/view.red
+++ b/modules/view/view.red
@@ -684,10 +684,11 @@ do-events: function [
 	return: [logic! word!] "Returned value from last event"
 	/local result
 ][
-	win: last head system/view/screens/1/pane
-	unless win/state/4 [win/state/4: not no-wait]		;-- mark the window from which the event loop starts
-	set/any 'result system/view/platform/do-event-loop no-wait
-	:result
+	if win: last head system/view/screens/1/pane [
+		unless win/state/4 [win/state/4: not no-wait]		;-- mark the window from which the event loop starts
+		set/any 'result system/view/platform/do-event-loop no-wait
+		:result
+	]
 ]
 
 do-safe: func ["Internal Use Only" code [block!] /local result][

--- a/tests/source/environment/functions-test.red
+++ b/tests/source/environment/functions-test.red
@@ -207,6 +207,8 @@ Red [
 		--assert "abcc" = replace/all "abxx" "x" "c"
 		--assert [1 9 [2 3 4]] = replace [1 2 [2 3 4]] 2 9
 		--assert [1 9 [2 3 4]] = replace/all [1 2 [2 3 4]] 2 9
+		--assert "aaa bbb ccc" = replace "aaa <tag> ccc" <tag> "bbb"
+		--assert "aaa <bbb> ccc" = replace "aaa <tag> ccc" <tag> <bbb>
 		;--assert [1 9 [9 3 4]] = replace/deep [1 2 [2 3 4]] 2 9
 
 ===end-group===


### PR DESCRIPTION
This PR fixes the `replace` with a `tag!` value issue discussed [here](https://gitter.im/red/help?at=5c2e82bfbabbc178b2222348)

Other commits appear in this PR are already merged, so it is safe to merge. The reason explained here [GitHub pull request showing commits that are already in target branch
](https://stackoverflow.com/questions/16306012/github-pull-request-showing-commits-that-are-already-in-target-branch)