### PR TITLE
3739 fix

### DIFF
--- a/environment/reactivity.red
+++ b/environment/reactivity.red
@@ -104,12 +104,14 @@ system/reactivity: context [
 						q: tail queue
 						until [
 							q: skip q': q -4
-							unless q/4 [ 				;-- reaction was not executed yet?
+							either q/4 [ 				;-- was already executed?
+								clear q 				;-- allow requeueing of it
+							][
 								eval-reaction q/1 :q/2 q/3
-								either tail? q' [
-									clear q
+								either tail? q' [ 		;-- queue wasn't extended
+									clear q 			;-- allow requeueing
 								][
-									q/4: yes
+									q/4: yes 			;-- mark as executed
 									q: tail queue 		;-- jump to recently queued reactions
 								]
 							]

--- a/tests/source/units/regression-test-red.red
+++ b/tests/source/units/regression-test-red.red
@@ -2435,7 +2435,7 @@ b}
 ===end-group===
 
 
-===start-group=== "regressions #2001 - #3000"
+===start-group=== "regressions #2001+"
 
 	true?: func [value] [not not value]
 
@@ -2742,8 +2742,29 @@ b}
 		unset 'true?
 
 	--test-- "#3603"
-		bu: reduce [()]
-		--assert bu = back change block: [] do/next block 'rest
+		bu3603: reduce [()]
+		rest3603: none
+		--assert bu3603 = back change block3603: [] do/next block3603 'rest3603
+
+	--test-- "#3739"
+		reactor3739: func [spec] [make deep-reactor! spec]
+		s3739: reactor3739 [started: no]
+		a3739: reactor3739 [x: none]
+		b3739: reactor3739 [x: none y: none]
+		success3739: no
+		react [
+			if s3739/started [
+				a3739/x: copy "NEW-VALUE!"
+				b3739/y: copy "junk"
+			]
+		]
+		react [ if b3739/x <> a3739/x [ b3739/x: copy a3739/x ] ]
+		react [ if all [b3739/x = "NEW-VALUE!" b3739/y = "junk"] [success3739: yes] ]
+		s3739/started: yes
+
+		--assert success3739
+		unset [s3739 a3739 b3739 success3739 reactor3739]
+
 
 ===end-group===
 


### PR DESCRIPTION
Fixes #3731, fixes #3739 
I moved the stack into queue and allow reactions to be re-queued if everything that was queued after them was processed:

Example queue buildup:
```
(on change event)
queue: [R1]
(R1 added 2 more reactions)
queue: [R1 R2 R3]
(R3 didn't add anything)
queue: [R1 R2]
(R2 added R3 again)
queue: [R1 R2 R3]
(R3 didn't add anything)
queue: [R1 R2]
(R1 and R2 were already processed)
queue: []
(finished)
```

This approach both prevents deadlocking (e.g. R1->R2->R3->R1... scenario) and allows more flexible reaction graphs to be processed.
