### PR TITLE
Add -nol and --no-launch flags for compiling consoles 

### DIFF
--- a/red.r
+++ b/red.r
@@ -438,7 +438,7 @@ redc: context [
 	run-console: func [
 		gui?	   [logic!]
 		debug?	 [logic!]
-		nol?     [logic!] 								;-- no launch
+		quiet?     [logic!] 							
 		/with file [string!]
 		/local 
 			opts result script filename exe console console-root files files2
@@ -526,7 +526,7 @@ redc: context [
 		]
 		exe: safe-to-local-file exe
 
-        if not nol? [
+        if not quiet? [
 			either gui? [
 				gui-sys-call exe any [all [file form-args file] ""]
 			][
@@ -733,7 +733,7 @@ redc: context [
 				| "--cli"						(gui?: no)
 				| "--no-compress"				(opts/redbin-compress?: no)
 				| "--catch"						;-- just pass-thru
-				| ["-nol" | "--no-launch"]   	(nol?: yes)
+				| "--quiet"   	                (quiet?: yes)
 			]
 			set filename skip (src: load-filename filename)
 		]		
@@ -810,7 +810,7 @@ redc: context [
 		unless src [
 			either encap? [
 				if load-lib? [build-compress-lib]
-				run-console gui? opts/debug? nol?
+				run-console gui? opts/debug? quiet?
 			][
 				return reduce [none none]
 			]

--- a/red.r
+++ b/red.r
@@ -436,8 +436,9 @@ redc: context [
 	]
 
 	run-console: func [
-		gui?	[logic!]
-		debug?	[logic!]
+		gui?	   [logic!]
+		debug?	 [logic!]
+		nol?     [logic!] 								;-- no launch
 		/with file [string!]
 		/local 
 			opts result script filename exe console console-root files files2
@@ -525,11 +526,13 @@ redc: context [
 		]
 		exe: safe-to-local-file exe
 
-		either gui? [
-			gui-sys-call exe any [all [file form-args file] ""]
-		][
-			if with [repend exe [" " form-args file]]
-			sys-call exe								;-- replace the buggy CALL native
+        if not nol? [
+			either gui? [
+				gui-sys-call exe any [all [file form-args file] ""]
+			][
+				if with [repend exe [" " form-args file]]
+				sys-call exe								;-- replace the buggy CALL native
+			]
 		]
 		quit/return 0
 	]
@@ -729,7 +732,8 @@ redc: context [
 				| "--no-runtime"				(opts/runtime?: no)		;@@ overridable by config!
 				| "--cli"						(gui?: no)
 				| "--no-compress"				(opts/redbin-compress?: no)
-				| "--catch"								;-- just pass-thru
+				| "--catch"						;-- just pass-thru
+				| ["-nol" | "--no-launch"]   	(nol?: yes)
 			]
 			set filename skip (src: load-filename filename)
 		]		
@@ -806,7 +810,7 @@ redc: context [
 		unless src [
 			either encap? [
 				if load-lib? [build-compress-lib]
-				run-console gui? opts/debug?
+				run-console gui? opts/debug? nol?
 			][
 				return reduce [none none]
 			]

--- a/red.r
+++ b/red.r
@@ -526,7 +526,7 @@ redc: context [
 		]
 		exe: safe-to-local-file exe
 
-        if not quiet? [
+        unless quiet? [
 			either gui? [
 				gui-sys-call exe any [all [file form-args file] ""]
 			][
@@ -686,7 +686,7 @@ redc: context [
 	parse-options: func [
 		args [string! none!]
 		/local src opts output target verbose filename config config-name base-path type
-		mode target? gui? cmd spec cmds ws ssp
+		mode target? gui? cmd spec cmds ws ssp quiet?
 	][
 		unless args [
 			if encap? [fetch-cmdline]					;-- Fetch real command-line in UTF8 format
@@ -700,7 +700,8 @@ redc: context [
 			libRedRT-update?: no
 		]
 		gui?: Windows?									;-- use GUI console by default on Windows
-
+        quiet?: no
+		
 		unless empty? args [
 			if cmd: select [
 				"clear" do-clear


### PR DESCRIPTION
Will prevent consoles from launching automatically after compilation.
Can be useful for admin scripts written in Red that keep Red binaries current, or for an upgrade feature that may be available in the future.