### PR TITLE
basic dupe check for reactivity

### DIFF
--- a/environment/reactivity.red
+++ b/environment/reactivity.red
@@ -52,6 +52,17 @@ system/reactivity: context [
 	eat-events?: yes
 	debug?: 	 no
 	source:		 []
+
+	add-relation: func [
+		obj [object!]
+		word [default!]
+		reaction [block! function!]
+		targets [set-word! block! none!]
+		/local new-rel
+	][
+		new-rel: reduce [obj :word :reaction targets]
+		unless find/same/skip relations new-rel 4 [append relations new-rel]
+	]
 	
 	eval: function [code [block!] /safe][
 		either safe [
@@ -198,7 +209,7 @@ system/reactivity: context [
 		parse reaction rule: [
 			any [
 				item: word! (
-					if find words item/1 [repend relations [obj item/1 reaction field]]
+					if find words item/1 [add-relation obj item/1 reaction field]
 				)
 				| set-path! | any-string!
 				| into rule
@@ -267,7 +278,7 @@ system/reactivity: context [
 							item: item/1
 							if pos: find objs item/1 [
 								obj: pick objects 1 + index? pos
-								repend relations [obj item/2 :reaction objects]
+								add-relation obj item/2 :reaction objects
 								unless later [eval objects]
 								found?: yes
 							]
@@ -319,7 +330,7 @@ system/reactivity: context [
 								in obj 'on-change*
 							][
 								part: part + 1
-								repend relations [obj item/:part reaction ctx]
+								add-relation obj item/:part reaction ctx
 								unless later [eval reaction]
 								found?: yes
 							]

--- a/tests/source/units/reactivity-test.red
+++ b/tests/source/units/reactivity-test.red
@@ -83,31 +83,37 @@ Red [
 
 	--test-- "rf-3" 	; same
 		clear-reactions
-		rf-3-r: make reactor! [a: b: 1  react [self/b: self/a * self/a * self/a]]
-		--assert 1 * 4 = length? system/reactivity/relations
-		--assert (rf-3-r/a: 2  rf-3-r/b = 8)
+		do [	; FIXME: workaround for #3797
+			rf-3-r: make reactor! [a: b: 1  react [self/b: self/a * self/a * self/a]]
+			--assert 1 * 4 = length? system/reactivity/relations
+			--assert (rf-3-r/a: 2  rf-3-r/b = 8)
+		]
 		unset [rf-3-r]
 
 	--test-- "rf-4"	; same
 		clear-reactions
-		rf-4-r: make reactor! [a: b: c: 1  react [self/c: self/a * self/a * self/b * self/b]]
-		--assert 2 * 4 = length? system/reactivity/relations
-		--assert (rf-4-r/a: 2  rf-4-r/c = 4)
-		--assert (rf-4-r/b: 2  rf-4-r/c = 16)
+		do [	; FIXME: workaround for #3797
+			rf-4-r: make reactor! [a: b: c: 1  react [self/c: self/a * self/a * self/b * self/b]]
+			--assert 2 * 4 = length? system/reactivity/relations
+			--assert (rf-4-r/a: 2  rf-4-r/c = 4)
+			--assert (rf-4-r/b: 2  rf-4-r/c = 16)
+		]
 		unset [rf-4-r]
 
 	--test-- "rf-5" 	; same
 		clear-reactions
-		rf-5-r: make reactor! [
-			a: b: c: d: 1
-			b: is [a + a] 											; +1
-			react [self/c: self/a * self/b * a * b]					; +2
-			react [self/d: self/a + self/b + self/c + a + b + c] 	; +3
+		do [	; FIXME: workaround for #3797
+			rf-5-r: make reactor! [
+				a: b: c: d: 1
+				b: is [a + a] 											; +1
+				react [self/c: self/a * self/b * a * b]					; +2
+				react [self/d: self/a + self/b + self/c + a + b + c] 	; +3
+			]
+			--assert 6 * 4 = length? system/reactivity/relations
+			--assert (rf-5-r/a: 2  rf-5-r/b = 4)
+			--assert rf-5-r/c = 64
+			--assert rf-5-r/d = (2 + 4 + 64 * 2)
 		]
-		--assert 6 * 4 = length? system/reactivity/relations
-		--assert (rf-5-r/a: 2  rf-5-r/b = 4)
-		--assert rf-5-r/c = 64
-		--assert rf-5-r/d = (2 + 4 + 64 * 2)
 		unset [rf-5-r]
 
 ===end-group===

--- a/tests/source/units/reactivity-test.red
+++ b/tests/source/units/reactivity-test.red
@@ -66,4 +66,50 @@ Red [
 
 ===end-group===
 
+===start-group=== "relations formation"
+
+	--test-- "rf-1" 	; sanity check
+		rf-1-r: make reactor! [a: 1 b: is [a * 2]]
+		--assert 0 < length? system/reactivity/relations
+		clear-reactions
+		--assert empty? system/reactivity/relations
+		unset [rf-1-r]
+
+	--test-- "rf-2" 	; shouldn't add duplicate relations
+		clear-reactions
+		rf-2-r: make reactor! [a: 1 b: is [a * a * a]]
+		--assert 1 * 4 = length? system/reactivity/relations
+		unset [rf-2-r]
+
+	--test-- "rf-3" 	; same
+		clear-reactions
+		rf-3-r: make reactor! [a: b: 1  react [self/b: self/a * self/a * self/a]]
+		--assert 1 * 4 = length? system/reactivity/relations
+		--assert (rf-3-r/a: 2  rf-3-r/b = 8)
+		unset [rf-3-r]
+
+	--test-- "rf-4"	; same
+		clear-reactions
+		rf-4-r: make reactor! [a: b: c: 1  react [self/c: self/a * self/a * self/b * self/b]]
+		--assert 2 * 4 = length? system/reactivity/relations
+		--assert (rf-4-r/a: 2  rf-4-r/c = 4)
+		--assert (rf-4-r/b: 2  rf-4-r/c = 16)
+		unset [rf-4-r]
+
+	--test-- "rf-5" 	; same
+		clear-reactions
+		rf-5-r: make reactor! [
+			a: b: c: d: 1
+			b: is [a + a] 											; +1
+			react [self/c: self/a * self/b * a * b]					; +2
+			react [self/d: self/a + self/b + self/c + a + b + c] 	; +3
+		]
+		--assert 6 * 4 = length? system/reactivity/relations
+		--assert (rf-5-r/a: 2  rf-5-r/b = 4)
+		--assert rf-5-r/c = 64
+		--assert rf-5-r/d = (2 + 4 + 64 * 2)
+		unset [rf-5-r]
+
+===end-group===
+
 ~~~end-file~~~


### PR DESCRIPTION
I was annoyed by this behavior:
```
r: make reactor! [set 'r self a: none react/later [print [r/a r/a r/a]]]
>> r/a: 1
1 1 1
1 1 1
1 1 1
== 1
```

New behavior:
```
>> r/a: 1
1 1 1
== 1
```