### PR TITLE
FIX: get on object! doesn't return values-of object (regression)

### DIFF
--- a/environment/natives.red
+++ b/environment/natives.red
@@ -198,7 +198,7 @@ compose: make native! [[
 
 get: make native! [[
 		"Returns the value a word refers to"
-		word	[word! path!]
+		word	[word! path! object!]
 		/any  "If word has no value, return UNSET rather than causing an error"
 		/case "Use case-sensitive comparison (path only)"
 		return: [any-type!]

--- a/tests/source/units/object-test.red
+++ b/tests/source/units/object-test.red
@@ -2179,6 +2179,20 @@ Red [
 				
 ===end-group===
 
+===start-group=== "get"
+
+	--test-- "og1"
+		og1: make object! [a: 1 b: 2 c: "x"]
+		--assert equal? [1 2 "x"] get og1
+		--assert equal? [1 2 "x"] get :og1
+		--assert equal? [1 2 "x"] get/any :og1
+		--assert equal? [1 2 "x"] get/case :og1
+		--assert same? og1/c last get og1
+		--assert equal? 2 get 'og1/b
+		--assert empty? get object []
+
+===end-group===
+
 ===start-group=== "find & select"
 
 	--test-- "ofs"


### PR DESCRIPTION
This PR fixes the regression of using `get` on `object!` values that should return the values of the given object.

```
og1: make object! [a: 1 b: 2 c: "x"]
>> get :og1  ;before the PR
*** Script Error: get does not allow object! for its word argument

>> get :og1  ;after the PR
== [1 2 "x"]
```
