### PR TITLE
FIX: Cannot give multiple flags in VID dialect

### DIFF
--- a/modules/view/view.red
+++ b/modules/view/view.red
@@ -118,7 +118,7 @@ set-flag: function [
 	value [any-type!]
 ][
 	either flags: face/:facet [
-		if word? flags [flags: reduce [flags]]
+		if word? flags [face/:facet: flags: reduce [flags]]
 		either block? flags [append flags value][set in face facet value]
 	][
 		set in face facet value


### PR DESCRIPTION
This PR fixes issue #3832 

```
>> view [fld: field all-over no-border do [? fld/flags]]
== FLD/FLAGS is a word! value.  all-over  ; << should be a block! [all-over no-border]
```
