### PR TITLE
FEAT: Added password flag to VID

### DIFF
--- a/modules/view/VID.red
+++ b/modules/view/VID.red
@@ -304,6 +304,7 @@ system/view/VID: context [
 				| 'options	  (add-option opts fetch-argument block! spec)
 				| 'loose	  (add-option opts [drag-on: 'down])
 				| 'all-over   (set-flag opts 'flags 'all-over)
+				| 'password   (set-flag opts 'flags 'password)
 				| 'hidden	  (opts/visible?: no)
 				| 'disabled	  (opts/enabled?: no)
 				| 'select	  (opts/selected: fetch-argument integer! spec)


### PR DESCRIPTION
This PR adds `password` flag to VID:

```
view [field password]
```

![image](https://user-images.githubusercontent.com/840604/55290570-6e9a6200-53dd-11e9-9c51-68c989d97b0f.png)
