### PR TITLE
FIX: issue #3853 (charset function not implements binary! type for argument)

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -289,7 +289,7 @@ math: function [
 
 charset: func [
 	"Shortcut for `make bitset!`"
-	spec [block! integer! char! string!]
+	spec [block! integer! char! string! bitset! binary!]
 ][
 	make bitset! spec
 ]


### PR DESCRIPTION
`charset` now supports `bitset!` and `binary!` arguments, per [`bitset!` implmenentation](https://github.com/red/red/blob/master/runtime/datatypes/bitset.reds#L531).