### PR TITLE
FIX: issue #3855 (Syntax Error: invalid binary!)

### DIFF
--- a/environment/lexer.red
+++ b/environment/lexer.red
@@ -552,7 +552,7 @@ system/lexer: context [
 
 		base-2-rule: [
 			"2#{" (type: binary!) [
-				s: any [counted-newline | 8 [#"0" | #"1" ] | ws-no-count | comment-rule] e: #"}"
+				s: any [counted-newline | 4 8 [#"0" | #"1" ] | ws-no-count | comment-rule] e: #"}"
 				| (throw-error [binary! skip s -3])
 			] (base: 2)
 		]

--- a/lexer.r
+++ b/lexer.r
@@ -527,7 +527,7 @@ lexer: context [
 
 	base-2-rule: [
 		"2#{" (type: binary!) [
-			s: any [counted-newline | 8 [#"0" | #"1" ] | ws-no-count | comment-rule]
+			s: any [counted-newline | 4 8 [#"0" | #"1" ] | ws-no-count | comment-rule]
 			e: #"}" (base: 2)
 			| (pos: skip s -3 throw-error)
 		]


### PR DESCRIPTION
Red now can handle base-2 `binary!` notation with spaced-out half-bytes:
```red
>> 2#{1101 1110 1010 1101 1011 1110 1110 1111}
== #{DEADBEEF}
```
This makes sense in general (easier to read, allows for more free-form formatting suitable for a problem at hand), and also improves compatibility with R2 and R3.