### PR TITLE
FIX: issues #3581, #2772, #1773

### DIFF
--- a/environment/console/engine.red
+++ b/environment/console/engine.red
@@ -48,19 +48,17 @@ system/console: context [
 				remove/part pos 1 + length? --catch		;-- remove extra space too
 			]
 
-			quote-arg: [{"} any [ahead [#"^""] break | skip] {"}]
-			normal-arg: complement charset space
-			rule: [quote-arg | normal-arg]
-			args: parse args [collect [any [keep copy value some rule | skip]]]
-			while [all [not tail? args find/match args/1 "--"]][args: next args] ;-- skip options
+			args: system/options/args
+			while [
+				all [
+					not tail? args
+					find/match args/1 "--"	 			;-- skip options
+					args/-1 <> "--"						;-- stop after "--"
+				]
+			] [ args: next args ]
 
 			unless tail? args [
-				file: args/1
-				if file/1 = dbl-quote [
-					remove file
-					remove back tail file
-				]
-				file: to-red-file file
+				file: to-red-file args/1
 				
 				either error? set/any 'src try [read file][
 					print src
@@ -68,13 +66,23 @@ system/console: context [
 					;quit/return -1
 				][
 					system/options/script: file
-					remove system/options/args
-					args: system/script/args
-					remove/part args any [
-						find/tail next args pick {" } args/1 = #"^""
-						tail args
+					remove/part system/options/args next args 	;-- remove options & script name
+					#either config/OS = 'Windows [=quote=: {"}][=quote=: {'}]
+					=quoted-switch=: [=quote= {--} s: thru [e: =quote= any ws | end]]
+					=normal-switch=: ["--" s: thru [e: some ws | end]]
+					parse system/script/args [
+						any ws args: any [							;-- skip switches
+							[ =quoted-switch= | =normal-switch= ]
+							args: not if (same? s e) 				;-- stop after "--"
+						]
 					]
-					trim/head args
+					#either config/OS = 'Windows [
+						parse args [any [=quote= thru [=quote= | end] | not ws skip] any ws args:]
+					][
+						;-- this relies on `get-cmdline-args` logic:
+						parse args [any [=quote= thru [=quote= | end] | "\'" | not ws skip] any ws args:]
+					]
+					remove/part head args args
 				]
 				path: first split-path file
 				if path <> %./ [change-dir path]

--- a/environment/functions.red
+++ b/environment/functions.red
@@ -691,42 +691,53 @@ extract-boot-args: function [
 ][
 	unless args: system/script/args [exit]				;-- non-executable case
 
-	;-- extract system/options/boot
-	either args/1 = dbl-quote [
-		until [args: next args args/1 <> dbl-quote]
-		system/options/boot: to-red-file copy/part args pos: find args dbl-quote
-		until [pos: next pos pos/1 <> dbl-quote]
+	at-arg2: none
+
+	#either config/OS = 'Windows [
+		;-- logic should mirror that of `split-tokens` in `red.r`
+
+		ws: charset " ^-" 								;-- according to MSDN "Parsing C++ Command-Line Arguments" article
+		split-mode: yes
+		system/options/boot: take system/options/args: collect [
+			arg-end: has [s' e'] [
+				unless same? s': s e': e [ 				;-- empty argument check
+					;-- remove heading and trailing quotes (if any), even if it results in an empty arg
+					if s/1 = #"^"" [s': next s]
+					if all [e/-1 = #"^""  not same? e s'] [e': back e]
+					keep copy/part s' e'
+				]
+			]
+			arg2-update: [if (at-arg2) | at-arg2:]
+			parse s: args [
+				some [e:
+					#"^"" (split-mode: not split-mode)
+				|	if (split-mode) some ws (arg-end) arg2-update s:
+				|	skip
+				] e: (arg-end) arg2-update
+			]
+		]
 	][
-		pos: either pos: find/tail args space [back pos][tail args]
-		system/options/boot: to-red-file copy/part args pos
-	]
-	;-- clean-up system/script/args
-	remove/part args: head args pos
-	
-	;-- set system/options/args
-	either empty? trim/head args [system/script/args: none][
-		unescape: quote (
-			if odd? len: offset? s e [len: len - 1]
-			e: skip e negate len / 2
-			e: remove/part s e
-		)
-		parse args: copy args [							;-- preprocess escape chars
-			any [
-				s: {'"} thru {"'} e: (s/1: #"{" e/-1: #"}")
-				| s: #"'" [to #"'" e: (s/1: #"{" e/1: #"}") | to end]
-				| s: some #"\" e: {"} unescape :e
-				  thru [s: some #"\" e: {"}] unescape :e
-				| skip
-			]
-		]
-		system/options/args: parse head args [			;-- tokenize and collect
-			collect some [[
-				some #"^"" keep copy s to #"^"" some #"^""
-				| #"{" keep copy s to #"}" skip
-				| keep copy s [to #" " | to end]] any #" "
+		;-- logic should be an inverse of `get-cmdline-args` as it is constructed there from *argv
+
+		ws: charset " ^-^/^M"
+		system/options/boot: take system/options/args: parse args [
+			collect some [
+				(buf: make string! 32) collect into buf any [
+					not ws [
+						#"'" keep to #"'" skip
+					|	"\'" keep (#"'")
+					|	keep skip
+					]
+				]
+				[some ws | end]
+				s: (at-arg2: any [at-arg2 s])
+				keep (buf)
 			]
 		]
 	]
+	remove/part args at-arg2 						;-- remove the program name
+
+	system/options/args
 ]
 
 collect: function [

--- a/runtime/utils.reds
+++ b/runtime/utils.reds
@@ -68,50 +68,38 @@ Red/System [
 			cnt		[integer!]
 			size	[integer!]
 			cp		[integer!]
-			offset	[integer!]
-			delim	[integer!]
+			quote 	[integer!]
 			end?	[logic!]
-			ws?		[logic!]
-			dq?		[logic!]
 	][
 		cnt: 0
 		size: 4'000									;-- enough?
+		quote: as-integer #"'"
 		str: string/rs-make-at ALLOC_TAIL(root) size
 		s: GET_BUFFER(str)
 		args: system/args-list
 		
 		until [
 			src: args/item
-			ws?: no
-			dq?: no
-			offset: string/rs-abs-length? str
-			
+
+			;-- see PR #3870 on quoting details
+			s: string/append-char s quote
 			until [
 				cnt: unicode/utf8-char-size? as-integer src/1
 				cp: unicode/decode-utf8-char src :cnt
-				switch cp [
-					#" "	[ws?: yes]
-					#"^""	[dq?: yes]
-					default [0]
+				either cp <> as-integer #"'" [
+					s: string/append-char s cp
+				][
+					s: string/append-char s quote
+					s: string/append-char s as-integer #"\"
+					s: string/append-char s quote
+					s: string/append-char s quote
 				]
-				s: string/append-char s cp
 				src: src + cnt
 				size: size - 1
 				any [src/1 = null-byte zero? size]
 			]
+			s: string/append-char s quote
 			
-			case [
-				ws? [
-					delim: as-integer either dq? [#"'"][#"^""]
-					s: string/insert-char s offset delim
-					s: string/append-char s delim
-				]
-				dq? [
-					s: string/insert-char s offset as-integer #"'"
-					s: string/append-char s delim  as-integer #"'"
-				]
-				true [0]
-			]
 			args: args + 1
 			end?: null? args/item
 			unless end? [s: string/append-char s as-integer #" "] ;-- add a space as separation


### PR DESCRIPTION
Fixes #3581, fixes #2772, fixes #1773

This PR implements simple but correct CLI argument quoting/unquoting mechanics:
- on Windows following the CMD.EXE logic (only double quotes)
- on other platforms using single quotes
- **update**: also the "--" command line switch that marks the end of switch processing

**References:**

https://unix.stackexchange.com/a/357932
https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
https://docs.microsoft.com/en-us/previous-versions//17w5ykft%28v=vs.85%29
https://github.com/red/red/issues/2772#issuecomment-440485682

**Tests**

I have only manually tested this using stuff I uploaded here: https://gitlab.com/hiiamboris/tests-files-3870
I don't have Rebol SDK (of course) so can't rebuild the `red` executable to see if it even builds. `red.r` compiler works for me, as well as compiled executables.
I'd like some Linux power user to skim thru the changed code, just in case.

*And what do we do about `red.exe`? Push it and if any issues arise patch them? Or will somebody with the SDK access try to rebuild it first?*

**Overview**

Argument flow structure according to my findings (maybe deserves a wiki page idk):
1) `red.r` is invoked from (encapped) Rebol with a script name and arguments (OS is determined at runtime)
2) `red.r` receives parsed `options/args` and (invalid - see below `*`) `script/args` from Rebol
3) `red.r` (on Windows only) in [`parse-options`](https://github.com/red/red/blob/8d712e4ba1b16e1b7a339006d1154aebc9cb7ce4/red.r#L683) replaces `script/args` from a WinAPI call `GetCommandLineW` and then replaces also `options/args` by parsing `script/args` with [`split-tokens`](https://github.com/red/red/blob/8d712e4ba1b16e1b7a339006d1154aebc9cb7ce4/red.r#L265)
4) `red.r` joins `options/args` with [`form-args`](https://github.com/red/red/blob/8d712e4ba1b16e1b7a339006d1154aebc9cb7ce4/red.r#L322) into a new command line string. Also [`form-args`](https://github.com/red/red/blob/8d712e4ba1b16e1b7a339006d1154aebc9cb7ce4/red.r#L322) inserts `--catch` into the command line head if it finds this flag before the script name
5) `red.r` passes this string as an argument list to the console executable
    - *nix: invoking shell (see [`system` source code](http://man7.org/tlpi/code/online/dist/procexec/system.c.html))
    - Windows: with a WinAPI call `_wsystem` or `ShellExecuteW` via [`sys-call` or `gui-sys-call`](https://github.com/red/red/blob/8d712e4ba1b16e1b7a339006d1154aebc9cb7ce4/red.r#L85)
6) shell (on *nix only) converts the command line passed to `system` call into an argument list `argv`
7) console is started, it's code is tailored to a specific OS at compile time
8) console calls `get-cmdline-args` (R/S) where it:
	[on Windows](https://github.com/red/red/blob/master/runtime/utils.reds#L15): receives a command line from `GetCommandLine` WinAPI call, stores in `script/args`
	[on *nix](https://github.com/red/red/blob/8d712e4ba1b16e1b7a339006d1154aebc9cb7ce4/runtime/utils.reds#L61): receives an `argv` list from R/S `system/args-list` (provided by the kernel)
		`argv` is then joined into a synthetic command line string (stored in `script/args`) and discarded
9) console calls [`extract-boot-args` (Red)](https://github.com/red/red/blob/8d712e4ba1b16e1b7a339006d1154aebc9cb7ce4/environment/functions.red#L689) where it parses `script/args` into `options/args` and `options/boot`, also removing the `boot` part from `script/args`
10) console calls [`read-argument` (Red)](https://github.com/red/red/blob/8d712e4ba1b16e1b7a339006d1154aebc9cb7ce4/environment/console/engine.red#L43) where it removes the `--catch` argument from both `options/args` and `script/args` (the intention of this flag in unclear, looks like it just suppresses the header message)

`*` Addendum for (2) - proof of command line invalidity on Windows (Rebol 276 and 278):
`1.r`:
```
	REBOL []
	? system/script/args
	? system/options/args
	input quit
```
```
> rebol 1.r "1 2" "3 4"
	SYSTEM/SCRIPT/ARGS is a string of value: "1 2 3 4"        <-- 4 args instead of 2
	SYSTEM/OPTIONS/ARGS is a block of value: ["1 2" "3 4"]
```

**Examples of the new behavior**

Any deviations from this table should be reported:
```
Arguments string       CMD & Windows Red           Red on other OS
-------------------------------------------------------------------------- 
""                     []                          []                     
''                     ['']                        []                     
a                      [a]                         [a]                     
a b                    [a] [b]                     [a] [b]                 
"a"                    [a]                         [a]                     
"a b"                  [a b]                       [a b]                   
"a" "b"                [a] [b]                     [a] [b]                 
"a""b"                 [a""b]                      [a""b]                  
a" "b                  [a" "b]                     [a" "b]                 
"a "b""                [a "b"]                     [a "b"]                 
"a"b                   [a"b]                       [a"b]                   
'a'                    ['a']                       [a]                     
'a' b 'c'              ['a'] [b] ['c']             [a] [b] [c]             
a'b                    [a'b]                       [a'b]                   
'a'\''b' \'c\'         ['a'\''b'] [\'c\']          [a'b] ['c']             
a " b "c" d " e"  f    [a] [ b "c" d ] [e"  f]     [a] [ b "c" d ] [e"  f] 
a " b "c" d " "e  f    [a] [ b "c" d ] [e  f]      [a] [ b "c" d ] [e  f]  
a\ "b:\c\d\" "e\f"     [a\] [b:\c\d\] [e\f]        [a\] [b:\c\d\] [e\f]    
```
