### PR TITLE
FIX: issue #3869

### DIFF
--- a/runtime/call.reds
+++ b/runtime/call.reds
@@ -327,18 +327,20 @@ ext-process: context [
 			
 			either shell? [
 				len: (1 + platform/lstrlen as byte-ptr! cmd) * 2
-				cmdstr: make-c-string (14 + len)
-				copy-memory as byte-ptr! cmdstr as byte-ptr! #u16 "cmd /c " 14
-				copy-memory as byte-ptr! cmdstr + 14 as byte-ptr! cmd len
+				cmdstr: make-c-string (24 + len)
+				copy-memory as byte-ptr! cmdstr as byte-ptr! #u16 {cmd /s /c "} 22
+				copy-memory as byte-ptr! cmdstr + 22 as byte-ptr! cmd len
+				copy-memory as byte-ptr! cmdstr + len - 4 as byte-ptr! #u16 {"} 2
 			][
 				cmdstr: cmd
 			]
 			unless platform/CreateProcessW null cmdstr null null inherit 0 null null :s-inf :p-inf [
 				either 2 = platform/GetLastError [		;-- ERROR_FILE_NOT_FOUND
 					len: (1 + platform/lstrlen as byte-ptr! cmd) * 2
-					cmdstr: make-c-string (14 + len)
-					copy-memory as byte-ptr! cmdstr as byte-ptr! #u16 "cmd /c " 14
-					copy-memory as byte-ptr! cmdstr + 14 as byte-ptr! cmd len
+					cmdstr: make-c-string (24 + len)
+					copy-memory as byte-ptr! cmdstr as byte-ptr! #u16 {cmd /s /c "} 22
+					copy-memory as byte-ptr! cmdstr + 22 as byte-ptr! cmd len
+					copy-memory as byte-ptr! cmdstr + len - 4 as byte-ptr! #u16 {"} 2
 					shell?: yes							;-- force /shell mode and try again
 					win-shell?: yes
 					


### PR DESCRIPTION
Fixes #3869 

Adds `cmd /s /c` to a `/shell` call and wraps the command line in double quotes, fixing this scenario:
```
>> call/wait/shell/console {"prog ram" "" 1 "2 3"}    ;) adding /shell breaks everything
"prog" is not recognized as an internal or external command, operable program or batch file.
== 1
```

Another scenario
```
>> call/wait/console {prog ram "" 1 "2 3"}     ;) NO idea why this works - it should run `prog`
[prog ram] ["" 1 "2 3"]
    -> [] [1] [2 3]
== 0
```
is not Red's fault, but a result of MS [CreateProcessW being smart](https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessw) (how uncommon for those guys):
>  If you are using a long file name that contains a space, use quoted strings to indicate where the file name ends and the arguments begin; otherwise, the file name is ambiguous. For example, consider the string "c:\program files\sub dir\program name". This string can be interpreted in a number of ways. The system tries to interpret the possibilities in the following order:
c:\program.exe c:\program files\sub.exe c:\program files\sub dir\program.exe c:\program files\sub dir\program name.exe