### PR TITLE
FIX: more complete patch for commit a7301b09 (PR #3870) fixing --catch

### DIFF
--- a/environment/console/engine.red
+++ b/environment/console/engine.red
@@ -71,8 +71,8 @@ system/console: context [
 					system/options/script: file
 					remove/part system/options/args next args 	;-- remove options & script name
 					#either config/OS = 'Windows [=quote=: {"}][=quote=: {'}]
-					=quoted-switch=: [s': =quote= {--} s: thru [e: =quote= any ws | end] e':]
-					=normal-switch=: [s': "--" s: thru [e: some ws | end] e':]
+					=quoted-switch=: [=quote= {--} s: thru [e: =quote= any ws | end]]
+					=normal-switch=: ["--" s: thru [e: some ws | end]]
 					parse system/script/args [
 						any ws args: any [							;-- skip switches
 							[ =quoted-switch= | =normal-switch= ]

--- a/environment/console/engine.red
+++ b/environment/console/engine.red
@@ -42,20 +42,23 @@ system/console: context [
 	
 	read-argument: function [/local value][
 		if args: system/script/args [
-			--catch: "--catch"
-			if system/console/catch?: make logic! pos: find args --catch [
-				remove find system/options/args --catch
-				remove/part pos 1 + length? --catch		;-- remove extra space too
-			]
 
 			args: system/options/args
+			--catch: "--catch"
 			while [
 				all [
 					not tail? args
 					find/match args/1 "--"	 			;-- skip options
 					args/-1 <> "--"						;-- stop after "--"
 				]
-			] [ args: next args ]
+			][
+				either --catch <> args/1 [
+					args: next args
+				][
+					remove args
+					system/console/catch?: yes
+				]
+			]
 
 			unless tail? args [
 				file: to-red-file args/1
@@ -68,8 +71,8 @@ system/console: context [
 					system/options/script: file
 					remove/part system/options/args next args 	;-- remove options & script name
 					#either config/OS = 'Windows [=quote=: {"}][=quote=: {'}]
-					=quoted-switch=: [=quote= {--} s: thru [e: =quote= any ws | end]]
-					=normal-switch=: ["--" s: thru [e: some ws | end]]
+					=quoted-switch=: [s': =quote= {--} s: thru [e: =quote= any ws | end] e':]
+					=normal-switch=: [s': "--" s: thru [e: some ws | end] e':]
 					parse system/script/args [
 						any ws args: any [							;-- skip switches
 							[ =quoted-switch= | =normal-switch= ]
@@ -82,7 +85,7 @@ system/console: context [
 						;-- this relies on `get-cmdline-args` logic:
 						parse args [any [=quote= thru [=quote= | end] | "\'" | not ws skip] any ws args:]
 					]
-					remove/part head args args
+					remove/part head args args 			;-- remove options & script name
 				]
 				path: first split-path file
 				if path <> %./ [change-dir path]


### PR DESCRIPTION
Fixes the `--catch` problem that arose from PR #3870 :point_up: [May 16, 2019 10:12 AM](https://gitter.im/red/bugs?at=5cdd0d517c363c75a7ea6aff)

Also rewrote the argument joining function to be more reliable (it was pretty quick and dirty).

Now it is tolerant to filename abuses.
This is the test output on W7 (with the meaning of each argument denoted; also notice the `>> q` when `--catch` flag got transferred to (and eaten by) the console executable):
```
          option option
> red.exe --cli --catch
--== Red 0.6.4 ==--
Type HELP for starting information.

>> q

          option    script
> red.exe --cli -- --catch
BOOT=[C:\ProgramData\Red\console-2019-5-16-42230.exe] SCRIPT=[--catch] ARGS=[]
    -> ARGLIST=

          option option     script
> red.exe --cli --catch -- --catch
BOOT=[C:\ProgramData\Red\console-2019-5-16-42230.exe] SCRIPT=[--catch] ARGS=[]
    -> ARGLIST=
>> q

          option  option      script
> red.exe --cli "--catch" -- "--catch"
BOOT=[C:\ProgramData\Red\console-2019-5-16-42230.exe] SCRIPT=[--catch] ARGS=[]
    -> ARGLIST=
>> q

          option   script  argument
> red.exe --cli -- --catch --catch
BOOT=[C:\ProgramData\Red\console-2019-5-16-42230.exe] SCRIPT=[--catch] ARGS=[--catch ]
    -> ARGLIST= [--catch]

          option option     script  argument
> red.exe --cli --catch -- --catch --catch
BOOT=[C:\ProgramData\Red\console-2019-5-16-42230.exe] SCRIPT=[--catch] ARGS=[--catch ]
    -> ARGLIST= [--catch]
>> q


          option    script   3 arguments
> red.exe --cli -- --catch -- --catch --catch
BOOT=[C:\ProgramData\Red\console-2019-5-16-42230.exe] SCRIPT=[--catch] ARGS=[-- --catch --catch ]
    -> ARGLIST= [--] [--catch] [--catch]

          option      script    3 arguments
> red.exe --cli "--" "--catch" "--" "--catch" "--catch"
BOOT=[C:\ProgramData\Red\console-2019-5-16-42230.exe] SCRIPT=[--catch] ARGS=["--" "--catch" "--catch" ]
    -> ARGLIST= [--] [--catch] [--catch]
```
And this is on Linux:
```
+ ./red --cli --catch
--== Red 0.6.4 ==-- 
Type HELP for starting information. 

>> q
+ ./red --cli -- --catch
BOOT=[/home/user/.red/console-2019-5-16-42380] SCRIPT=[--catch] ARGS=[]
    -> ARGLIST=

+ ./red --cli --catch -- --catch
BOOT=[/home/user/.red/console-2019-5-16-42380] SCRIPT=[--catch] ARGS=[]
    -> ARGLIST=
>> q

+ ./red --cli --catch -- --catch
BOOT=[/home/user/.red/console-2019-5-16-42380] SCRIPT=[--catch] ARGS=[]
    -> ARGLIST=
>> q

+ ./red --cli -- --catch --catch
BOOT=[/home/user/.red/console-2019-5-16-42380] SCRIPT=[--catch] ARGS=['--catch']
    -> ARGLIST= [--catch]

+ ./red --cli --catch -- --catch --catch
BOOT=[/home/user/.red/console-2019-5-16-42380] SCRIPT=[--catch] ARGS=['--catch']
    -> ARGLIST= [--catch]
>> q

+ ./red --cli -- --catch -- --catch --catch
BOOT=[/home/user/.red/console-2019-5-16-42380] SCRIPT=[--catch] ARGS=['--' '--catch' '--catch']
    -> ARGLIST= [--] [--catch] [--catch]

+ ./red --cli -- --catch -- --catch --catch
BOOT=[/home/user/.red/console-2019-5-16-42380] SCRIPT=[--catch] ARGS=['--' '--catch' '--catch']
    -> ARGLIST= [--] [--catch] [--catch]

```
