### PR TITLE
FIX: issues #2047 (PRINT weirdness), #2393 (Recursive `print` issue)

### DIFF
--- a/tests/source/compiler/print-test.r
+++ b/tests/source/compiler/print-test.r
@@ -48,5 +48,31 @@ REBOL [
     	--assert-printed? "*test7* 开会"
     	--assert-printed? "*test8* str12"
     	--assert none = find qt/output "*test6* Heo wordd"
+
+    --test-- "Red print 2 - unset values #901"
+        --compile-and-run-this-red {
+            print [1 () 2]
+        }
+        --assert qt/output = "1  2^/"
+
+    --test-- "Red recursive print 1"
+        --compile-and-run-this-red {
+            print [1 print [2 print [3 3] 2] 1]
+        }
+        --assert qt/output = "3 3^/2  2^/1  1^/"
+
+    --test-- "Red recursive print 2"
+        --compile-and-run-this-red {
+            prin [1 prin [2 prin [3 3] 2] 1]
+        }
+        --assert qt/output = "3 32  21  1"
+
+    --test-- "Red recursive print 3"
+        --compile-and-run-this-red {
+            prin [1 print [2 prin [3 print 4 3] 2] 1]
+        }
+        --assert qt/output = "4^/3  32  2^/1  1"
+
+    ;-- TODO: print from CLI and GUI console should be also tested somehow
   
 ~~~end-file~~~ 


### PR DESCRIPTION
Fixes #2047, fixes #2393
(so much boring stack trickery involved, makes me sick to even look at the code)

Test script:
```
print [1 2 print [ 5 ]]
print [1 2 print 5 ]
print print 5
print [1 2 prin 5]
prin [1 2 print 5]
x: 1  prin[prin[prin[prin[prin[prin[prin[x: x + 1]]]]]]]
print [1 2 prin [5 6]]
print [1 2 prin [5 6] 3]
print [1 print [2 print [3 3] 2] 1]
prin [1 prin [2 prin [3 3] 2] 1]
prin [1 prin [2 print [3 3] 2] 1]  
prin [1 print [2 prin [3 3] 2] 1]  
print [1 prin [2 prin [3 3] 2] 1]  
```


**CLI**
```
>> print [1 2 print [ 5 ]]
5
1 2
>> print [1 2 print 5 ]
5
1 2
>> print print 5
5

>> print [1 2 prin 5]
51 2
>> prin [1 2 print 5]
5
1 2
>> x: 1  prin[prin[prin[prin[prin[prin[prin[x: x + 1]]]]]]]
2
>> print [1 2 prin [5 6]]
5 61 2
>> print [1 2 prin [5 6] 3]
5 61 2  3
>> print [1 print [2 print [3 3] 2] 1]
3 3
2  2
1  1
>> prin [1 prin [2 prin [3 3] 2] 1]
3 32  21  1
>> prin [1 prin [2 print [3 3] 2] 1]
3 3
2  21  1
>> prin [1 print [2 prin [3 3] 2] 1]
3 32  2
1  1
>> print [1 prin [2 prin [3 3] 2] 1]
3 32  21  1
```

**GUI** (printing into the end of input line is not my doing - should I open a separate ticket for that?)
```
>> print [1 2 print [ 5 ]]
5
1 2 
>> print [1 2 print 5 ]
5
1 2 
>> print print 5
5

>> print [1 2 prin 5]
51 2 
>> prin [1 2 print 5]
5
1 2 
>> x: 1  prin[prin[prin[prin[prin[prin[prin[x: x + 1]]]]]]]2
>> print [1 2 prin [5 6]]5 61 2 
>> print [1 2 prin [5 6] 3]
5 61 2  3
>> print [1 print [2 print [3 3] 2] 1]
3 3
2  2
1  1
>> prin [1 prin [2 prin [3 3] 2] 1]
3 32  21  1
>> prin [1 prin [2 print [3 3] 2] 1]  3 3
2  21  1
>> prin [1 print [2 prin [3 3] 2] 1]  3 32  2
1  1
>> print [1 prin [2 prin [3 3] 2] 1]  
3 32  21  1
```

**Compiled (-r) - harder to follow ☺ yet correct**:
```
5
1 2
5
1 2
5

51 2
5
1 2 25 61 2
5 61 2  3
3 3
2  2
1  1
3 32  21  13 3
2  21  13 32  2
1  13 32  21  1
```
