### PR TITLE
FIX: issues #3087, #3678, part of #3333

### DIFF
--- a/environment/console/CLI/input.red
+++ b/environment/console/CLI/input.red
@@ -18,7 +18,7 @@ Red [
 unless system/console [
 	system/console: context [
 		history: make block! 200
-		size: 0x0
+		size: 80x50										;-- default size for dump/help funcs
 	]
 ]
 ;; End patch
@@ -85,6 +85,7 @@ unless system/console [
 
 		init-globals: func [][
 			saved-line: string/rs-make-at ALLOC_TAIL(root) 1
+			get-window-size
 		]
 
 		widechar?: func [

--- a/environment/console/CLI/win32.reds
+++ b/environment/console/CLI/win32.reds
@@ -260,13 +260,17 @@ get-window-size: func [
 		size    [red-pair!]
 ][
 	info: declare screenbuf-info!
+	size: as red-pair! #get system/console/size
+	size/x: 80											;-- set defaults when working with stdout
+	size/y: 50											;   as many output funcs rely on it
+	columns: size/x
+	rows: size/y
 	if zero? GetConsoleScreenBufferInfo stdout as-integer info [return -1]
 	x-y: info/Size
 	columns: FIRST_WORD(x-y)
 	rows: SECOND_WORD(x-y)
-	size: as red-pair! #get system/console/size
-	size/x: SECOND_WORD(info/top-right) - SECOND_WORD(info/attr-left) 
-	size/y: FIRST_WORD(info/bottom-maxWidth) - FIRST_WORD(info/top-right)
+	size/x: SECOND_WORD(info/top-right) - SECOND_WORD(info/attr-left) + 1
+	size/y: FIRST_WORD(info/bottom-maxWidth) - FIRST_WORD(info/top-right) + 1
 	if columns <= 0 [size/x: 80 columns: 80 return -1]
 	x-y: info/Position
 	base-y: SECOND_WORD(x-y)


### PR DESCRIPTION
Fixes #3087, fixes #3678, together with PR #3884 fixes #3333 

1.red: `Red [] b: [1] ? b` (#3678)
2.red (#3333):
```
Red []
r: make reactor! [a: 1 b: is [a * 2] c: 0]
react/link func [x y][x/c: y/a * 3] [r r]
dump-reactions
```
3.red (#3087):
```
Red []
print system/console/size
ask "Press enter"
print system/console/size
```
Output:
```
>red --cli 1.red
B is a block! value.  length: 1  [1]

>red --cli 1.red | more
B is a block! value.  length: 1  [1]

>red --cli 2.red
1:---
  Source: object [a b c]
   Field: a
  Action: [a * 2]
  Target: b
2:---
  Source: object [a b c]
   Field: a
  Action: func [x y][x/c: y/a * 3]
    Args: [object [a: 1 b: 2 c: 3] object [a: 1 b: 2 c: 3]]

>red --cli 2.red | more
(same as previous)

>red --cli 3.red
213x48
Press enter
213x48

>red --cli 3.red | more
80x50

80x50
```

Unfortunately, not auto testable:
- console behavior is not covered by quick-test
- @PeterWAWood is against any unchecked output in tests
- compiled code crashes due some malformed imports when I include console files from `--compile-and-run-this-red`
