### PR TITLE
FIX: issue #3472 (Help text sometimes overflows to the next line)

### DIFF
--- a/environment/console/GUI/core.red
+++ b/environment/console/GUI/core.red
@@ -235,9 +235,9 @@ object [
 	update-cfg: func [font [object!] cfg [block!] /local sz][
 		box/font: font
 		max-lines: cfg/buffer-lines
-		box/text: "XX"
+		box/text: "XXXXXXXXXX"
 		sz: size-text box
-		char-width: 1 + sz/x / 2
+		char-width: sz/x + 1 * 0.1 						;-- +1 compensates for size-text rounding
 		box/tabs: tab-size * char-width
 		line-h: rich-text/line-height? box 1
 		box/line-spacing: line-h
@@ -249,7 +249,7 @@ object [
 	]
 
 	adjust-console-size: function [size [pair!]][
-		cols: size/x - pad-left / char-width
+		cols: to integer! size/x - 20 - pad-left / char-width		;-- -20 compensates for scrollbar
 		rows: size/y / line-h
 		system/console/size: as-pair cols rows
 	]

--- a/environment/console/help.red
+++ b/environment/console/help.red
@@ -20,7 +20,7 @@ help-ctx: context [
 	HELP_ARG_COL_SIZE: 12	; Minimum size of the function arg output column
 	HELP_TYPE_COL_SIZE: 12	; Minimum size of the datatype output column. 12 = "refinement!" + 1
 	HELP_COL_1_SIZE: 15		; Minimum size of the first output column
-	RT_MARGIN: 5			; How close we can get to the right console margin before we trim
+	RT_MARGIN: 1			; How close we can get to the right console margin before we trim
 	DENT_1: "    "			; So CLI and GUI consoles are consistent, WRT tab size
 	DENT_2: "        " 
 	NON_CONSOLE_SIZE: 120	; Where to truncate, if not running in a console
@@ -30,8 +30,13 @@ help-ctx: context [
 	
 	output-buffer: clear ""	; Where help-string output goes
 
-	_print: func [value][
-		_prin value
+	_print: function [value /fit][
+		_prin :value
+		if fit [
+			line-start: any [find/reverse/tail tail output-buffer newline  output-buffer]
+			width: any [all [system/console  max 1 system/console/size/x] NON_CONSOLE_SIZE]
+			ellipsize-at line-start width - RT_MARGIN
+		]
 		append output-buffer newline
 	]
 	_prin: func [value][
@@ -82,7 +87,7 @@ help-ctx: context [
 		len [integer!] "Max length"
 	][
 		if (length? str) > len [
-			append clear at str (len - 3) "..."
+			append clear skip str (len - 3) "..."
 		]
 		str
 	]
@@ -94,7 +99,7 @@ help-ctx: context [
 	; a `help` call in their script on the command line.
 	VAL_FORM_LIMIT: does [
 		either system/console [
-			max 0 system/console/size/x - HELP_TYPE_COL_SIZE - HELP_COL_1_SIZE - RT_MARGIN
+			max 0 system/console/size/x - HELP_COL_1_SIZE - RT_MARGIN
 		][
 			NON_CONSOLE_SIZE
 		]
@@ -338,13 +343,6 @@ help-ctx: context [
 		type [datatype!]
 		/local val
 	][
-		DOC_LIMIT: either system/console [
-			max 0 system/console/size/x - HELP_COL_1_SIZE - RT_MARGIN
-		][
-			NON_CONSOLE_SIZE
-		]
-		;DOC_LIMIT: system/console/size/x - HELP_COL_1_SIZE - RT_MARGIN
-		fmt-doc: func [str][either str [ellipsize-at str DOC_LIMIT][""]]
 		found-at-least-one?: no
 		foreach word words-of system/words [
 			col-1: rejoin [DENT_1 as-col-1 word]
@@ -352,7 +350,7 @@ help-ctx: context [
 			; Unset values make us jump through some /any hoops.
 			set/any 'val get/any word
 			if all [not unset? :val  type = type? :val  (found-at-least-one?: yes)] [
-				_print case [
+				_print/fit case [
 					;?? What else can we show that is useful for datatypes?
 					;	Can't reflect on datatypes, as R3 could to some extent.
 					;	We would have to build our own typeset-match funcs to
@@ -364,7 +362,7 @@ help-ctx: context [
 							[col-1]
 						]
 					]
-					any-function? :val [[col-1 DOC_SEP fmt-doc doc-string :val]]
+					any-function? :val [[col-1 DOC_SEP any [doc-string :val ""]]]
 					'else [[col-1 DEF_SEP form-value :val]]
 				]
 			]
@@ -463,7 +461,7 @@ help-ctx: context [
 
 		foreach map-word words-of map [
 			set/any 'value map/:map-word
-			_print [
+			_print/fit [
 				DENT_1 pad form map-word word-col-wd DEF_SEP as-type-col :value DEF_SEP
 				; Yes, we're checking against our output buffer for every value, even
 				; though it will only trigger for this context (help-ctx) and the 
@@ -493,7 +491,7 @@ help-ctx: context [
 
 		foreach obj-word words-of obj [
 			set/any 'value get/any obj-word
-			_print [
+			_print/fit [
 				DENT_1 pad form obj-word word-col-wd DEF_SEP as-type-col :value DEF_SEP
 				; Yes, we're checking against our output buffer for every value, even
 				; though it will only trigger for this context (help-ctx) and the 
@@ -543,10 +541,10 @@ help-ctx: context [
 					datatype? :value [show-datatype-help :value]
 					object? :value [show-object-help word]
 					map? :value [show-map-help word]
-					all [ref-given?  block? :value] [_print [word-is-value-str/only :word DEF_SEP form-value :value]]
+					all [ref-given?  block? :value] [_print/fit [word-is-value-str/only :word DEF_SEP form-value :value]]
 					image? :value [
-						either in system 'view [view [image value]][
-							_print form-value value
+						either all [in system 'view  :system/view] [view [image value]][
+							_print/fit form-value value
 						]
 					]
 					all [path? :word  object? :value][show-object-help word]
@@ -592,7 +590,7 @@ help-ctx: context [
 				all [spec  any-function? :val  find mold spec-of :val text]
 			][
 				found-at-least-one?: yes
-				_print [DENT_1 as-col-1 word  as-type-col :val  DEF_SEP  form-value :val]
+				_print/fit [DENT_1 as-col-1 word  as-type-col :val  DEF_SEP  form-value :val]
 			]
 		]
 		if not found-at-least-one? [

--- a/environment/console/help.red
+++ b/environment/console/help.red
@@ -113,7 +113,7 @@ help-ctx: context [
 	fmt: func [v /molded][
 		; Does it help to mold only part? Can't hurt I suppose.
 		if any [molded  not string? :v] [v: mold/flat/part :v VAL_FORM_LIMIT + 1]
-		ellipsize-at v VAL_FORM_LIMIT
+		:v
 	]
 	;!!
 	form-value: func [value [any-type!]][


### PR DESCRIPTION
Fixes #3472 

Tested on W7 (GUI+CLI) & Xubuntu (more test results are welcome)

Summary:
- `char-width` in gui console is changed to a float! for better arithmetic
- scrollbar is accounted for, albeit using a hardcoded 20 virtual pixels width
- `form-value` has no way to know at what column the value will be output (after 1 or 2 columns of text, or whether columns are of their minimum width or bigger, what separators were used) so I moved the ellipsizing code into `_print` which has a flag now that commands it to truncate the output
- basically every occurrence of `_print [... form-value ...]` became `_print/fit [... form-value ...]`
- improved `view` subsystem presence check (it wasn't working)

Yeah, I got pictures ☻

CLI:
![](https://i.gyazo.com/24a3c6925e2dce33edc10baaf2d9fd82.png)

GUI:
![](https://i.gyazo.com/346c57e5ec48bcb7cd38ceab86751f25.png)
![](https://i.gyazo.com/729b76d722dd290fdaf412fe508e8b31.png)