### PR TITLE
Fix for #2438

### DIFF
--- a/environment/lexer.red
+++ b/environment/lexer.red
@@ -943,7 +943,7 @@ system/lexer: context [
 		]
 
 		one-value: [any ws pos: literal-value pos: to end opt wrong-end]
-		any-value: [pos: any [some ws | literal-value]]
+		any-value: [pos: any [some ws | literal-value e: if (not same? pos e)]]
 		red-rules: [any-value any ws opt wrong-end]
 
 		if pre-load [do [pre-load src length]]

--- a/tests/source/units/load-test.red
+++ b/tests/source/units/load-test.red
@@ -297,6 +297,20 @@ Red [
 
 ===end-group===
 
+
+===start-group=== "load issue #2438"
+
+	--test-- "load a<=>"
+		--assert error? res: try [load "a<=>"]
+		--assert to logic! find/match form res {*** Syntax Error: invalid value at "<=>"^/*** Where:}
+
+	--test-- "load a</=>"
+		--assert not error? res: try [load "a</=>"]
+		--assert word? :res/1
+		--assert tag?  :res/2
+
+===end-group===
+
 ===start-group=== "load issue #3717"
 	--test-- "load ) 1"
 		--assert error? res: try [load ")"]


### PR DESCRIPTION
Fixes #2438

Issue arose from [symbol-rule](https://github.com/red/red/blob/c80ba51d8d1575a6b492c905d3d29570340073a8/lexer.r#L177) always succeeding without advancing the output. It relied on [tag-rule](https://github.com/red/red/blob/c80ba51d8d1575a6b492c905d3d29570340073a8/lexer.r#L517) to accept the input but the latter rejected it, and so it went on.

I did not extend or narrow lexical scope any rules, just added a check for input advancement. And tests.

```
>> load "a<=>"                          
*** Syntax Error: invalid value at "<=>"
*** Where: do                           
*** Stack: load                         
                                        
>> load "a</=>"                         
== [a </=>]                             
>> load "a<=/>"                         
== a<=/>                                
>> load "a</=/>"                        
== [a </=/>]                            
>> load ""
== []     
```