### PR TITLE
FIX: issues #1598, #2538, #3714, #3866, #3891

### DIFF
--- a/runtime/stack.reds
+++ b/runtime/stack.reds
@@ -258,7 +258,8 @@ stack: context [										;-- call stack
 
 		assert cbottom < ctop
 		ctop: ctop - 1
-		STACK_SET_FRAME
+		top: arguments + 1
+		arguments: ctop/prev
 		if acc-mode? [check-dyn-call]
 		
 		#if debug? = yes [if verbose > 1 [dump]]


### PR DESCRIPTION
Fixes #1598, fixes #2538, fixes #3714, fixes #3866, fixes #3891 
Oh yeah... right... also: fixes #3733, fixes #3773, fixes #3831, fixes #3876 
Removes the crash from #1055, though does not solve it.

Tests will go into the PR #3781 instead

***
This https://github.com/red/red/blob/bf1706adb3df97052bd486c476f61a4221e3654d/runtime/stack.reds#L256-L265
or more particularly this https://github.com/red/red/blob/bf1706adb3df97052bd486c476f61a4221e3654d/runtime/stack.reds#L55-L63
invoked from L150 (error/reduce) here https://github.com/red/red/blob/bf1706adb3df97052bd486c476f61a4221e3654d/runtime/datatypes/error.reds#L141-L155
was destroying the stack - flattening it and filling with trash

If you look at the code of STACK_SET_FRAME, it's obvious it's doing something nasty. Even the assumption that there was only a single argument in the last frame that should be kept is questionable, but the real killer assumption is that reaching of the bottom call frame is only possible upon startup, but not when unwinding.

I've patched `unwind`, but I'm unsure if `unroll-frames` (where this macro is also used) will also run into problems later. It would have been best if @dockimbel took a look.

***
`Red [] probe 3x4 // 1.1`
```
>issue-1598.exe
root size: 2166, root max: 4137, cycles: 0, before: 1088596, after: 1052556
root size: 2166, root max: 4137, cycles: 1, before: 1086940, after: 1085780
root size: 2166, root max: 4137, cycles: 2, before: 1086964, after: 1086964
*** Script Error: cannot compare 0x0 with 0
*** Where: <
*** Stack: mod
```
***
`Red [] probe system/console/size`
```
>issue-2538.exe
root size: 2166, root max: 4137, cycles: 0, before: 1088596, after: 1052556
root size: 2166, root max: 4137, cycles: 1, before: 1086940, after: 1085780
root size: 2166, root max: 4137, cycles: 2, before: 1086964, after: 1086964
*** Script Error: path none is not valid for none! type
*** Where: eval-path
*** Stack:
```
***
`Red [] probe system/view/metrics/dpi`
```
>issue-3714.exe
root size: 2168, root max: 4137, cycles: 0, before: 1088756, after: 1052716
root size: 2168, root max: 4137, cycles: 1, before: 1086924, after: 1085764
root size: 2168, root max: 4137, cycles: 2, before: 1086772, after: 1086772
*** Script Error: path none is not valid for none! type
*** Where: eval-path
*** Stack:
```
***
`Red [] probe system/view/screens/1/size`
```
>issue-3714a.exe
root size: 2167, root max: 4137, cycles: 0, before: 1088676, after: 1052636
root size: 2167, root max: 4137, cycles: 1, before: 1086948, after: 1085788
root size: 2167, root max: 4137, cycles: 2, before: 1086940, after: 1086940
*** Script Error: path none is not valid for none! type
*** Where: eval-path
*** Stack:
```
***
```
Red []
print mold/flat/part system/console 100
print mold/flat/part system/console/size 100
```
```
>issue-3714b.exe
root size: 2166, root max: 4137, cycles: 0, before: 1088596, after: 1052556
root size: 2166, root max: 4137, cycles: 1, before: 1086940, after: 1085780
root size: 2166, root max: 4137, cycles: 2, before: 1086964, after: 1086964
none
*** Script Error: path none is not valid for none! type
*** Where: eval-path
*** Stack:
```
***
`Red [] probe load "a<=>"`
```
>issue-3891.exe
root size: 2167, root max: 4138, cycles: 0, before: 1088636, after: 1052596
root size: 2167, root max: 4138, cycles: 1, before: 1086908, after: 1085748
root size: 2167, root max: 4138, cycles: 2, before: 1086900, after: 1086900
*** Syntax Error: invalid value at "<=>"
*** Where: do
*** Stack: load
```
***
```
Red [
]

my-context: context [
    do-something: routine [
        num     [integer!]
        return: [integer!]
        /local
        ret
    ] [
        ret: num + 1
        ret
    ]
]

?? my-context
print my-context/do-something 1
```
```
>issue-1055.exe
root size: 2172, root max: 4140, cycles: 0, before: 1088784, after: 1052980
root size: 2172, root max: 4140, cycles: 1, before: 1086880, after: 1085444
root size: 2172, root max: 4140, cycles: 2, before: 1086956, after: 1086956
my-context: make object! [
    do-something: routine [
        num [integer!]
        return: [integer!]
    ][
        ret: num + 1
        ret
    ]
]
2
```
***
`Red [] f: does [1] do [f/q]`
```
>issue-3733.exe
root size: 2170, root max: 4141, cycles: 0, before: 1088868, after: 1052828
root size: 2170, root max: 4141, cycles: 1, before: 1086948, after: 1085788
root size: 2170, root max: 4141, cycles: 2, before: 1086884, after: 1086884
*** Script Error: f has no refinement called q
*** Where: f
*** Stack: f
```
***
```
Red []
do [f: func [/q] bind [1] context []]
f/q
```
```
>issue-3733a.exe
root size: 2167, root max: 4138, cycles: 0, before: 1088852, after: 1052812
root size: 2167, root max: 4138, cycles: 1, before: 1086932, after: 1085772
root size: 2167, root max: 4138, cycles: 2, before: 1086868, after: 1086868
*** Script Error: path none is not valid for function! type
*** Where: eval-path
*** Stack:
```
***
```
Red []
#macro ctx: func [x] [context? x]
ctx ""
```
```
>console-view.exe issue-3773.red
*** Script Error: context? does not allow string! for its word argument
*** Where: context?
*** Stack: expand-directives expand unset?
```
***
```
Red []
#macro mc: func [x] [x]
probe quote (mc 'mc)
```
```
>console-view.exe issue-3773a.red
*** Script Error: mc is missing its x argument
*** Where: mc
*** Stack: expand-directives expand unset?
```
***
```
Red []
#macro mc: func [x] [x]
probe quote (mc :mc)
```
```
>console-view.exe issue-3773b.red
*** Script Error: x is missing its x argument
*** Where: x
*** Stack: expand-directives expand unset?
```
***
`Red [] repeat x none []`
```
>issue-3831.exe
root size: 2166, root max: 4137, cycles: 0, before: 1088596, after: 1052556
root size: 2166, root max: 4137, cycles: 1, before: 1086940, after: 1085780
root size: 2166, root max: 4137, cycles: 2, before: 1086964, after: 1086964
*** Script Error: repeat does not allow none! for its value argument
*** Where: repeat
*** Stack:
```
***
`Red [] loop none []`
```
>issue-3831a.exe
root size: 2166, root max: 4137, cycles: 0, before: 1088596, after: 1052556
root size: 2166, root max: 4137, cycles: 1, before: 1086940, after: 1085780
root size: 2166, root max: 4137, cycles: 2, before: 1086964, after: 1086964
*** Script Error: loop does not allow none! for its count argument
*** Where: loop
*** Stack:
```
***
```
Red []
count: 0.0
vec-size: 100.0
vec: make vector! [float! 64 100]
count: count + 1.0
print count
print vec/:count
val: (1.012345 * (count / vec-size))
print val
vec/:count: val
```
```
>issue-3876.exe
root size: 2171, root max: 4138, cycles: 0, before: 1088948, after: 1052868
root size: 2171, root max: 4138, cycles: 1, before: 1086932, after: 1085772
root size: 2171, root max: 4138, cycles: 2, before: 1086924, after: 1086924
1.0
none
0.01012345
*** Script Error: cannot set none in path none
*** Where: eval-set-path
*** Stack:
```