### PR TITLE
FIX: issue #3662 (allow to load 1-8 hexa to integer!)

### DIFF
--- a/environment/lexer.red
+++ b/environment/lexer.red
@@ -694,7 +694,7 @@ system/lexer: context [
 		sticky-word-rule: [								;-- protect from sticky words typos
 			ahead [integer-end | ws-no-count | end | (throw-error [type s])]
 		]
-		hexa-rule: [2 8 hexa e: #"h" ahead [integer-end | ws-no-count | end]]
+		hexa-rule: [1 8 hexa e: #"h" ahead [integer-end | ws-no-count | end]]
 
 		tuple-value-rule: [byte 2 11 [#"." byte] e: (type: tuple!)]
 

--- a/lexer.r
+++ b/lexer.r
@@ -265,7 +265,7 @@ lexer: context [
 	
 	slash-rule: [s: [slash opt slash] e:]
 	
-	hexa-rule: [2 8 hexa e: #"h" pos: [integer-end | ws-no-count | end ] :pos (type: integer!)]
+	hexa-rule: [1 8 hexa e: #"h" pos: [integer-end | ws-no-count | end ] :pos (type: integer!)]
 
 	sticky-word-rule: [								;-- protect from sticky words typos
 		mark: [integer-end | ws-no-count | end | (pos: s throw-error)] :mark
@@ -783,6 +783,9 @@ lexer: context [
 	]
 	
 	decode-hexa: func [s [string!]][
+		if odd? length? s [
+			insert s #"0"
+		]
 		to integer! debase/base s 16
 	]
 	

--- a/system/loader.r
+++ b/system/loader.r
@@ -207,7 +207,10 @@ loader: make-profilable context [
 				| [hex-delim | ws]
 				s: copy value some [hex-chars (c: c + 1)] #"h"	;-- literal hexadecimal support	
 				e: [hex-delim | ws-all | #";" to lf | end] (
-					either find [2 4 8] c [
+					either all [
+						c >= 1
+						c <= 8
+					][
 						e: change/part s to integer! to issue! value e
 					][
 						throw-error ["invalid hex literal:" copy/part s 40]

--- a/tests/source/compiler/lexer-test.r
+++ b/tests/source/compiler/lexer-test.r
@@ -248,6 +248,12 @@ do %../../../lexer.r
 		--assert "#{3D}" = mold second lexer/process src
 
 
+	--test-- "lexer-41"
+		src: {Red []
+			[1h 10h 100h 1000h 10000h 100000h 1000000h]
+		}
+		--assert "[1 16 256 4096 65536 1048576 16777216]" = mold second lexer/process src
+
 ===end-group===
 	
 ~~~end-file~~~

--- a/tests/source/units/load-test.red
+++ b/tests/source/units/load-test.red
@@ -407,4 +407,11 @@ Red [
 
 ===end-group===
 
+===start-group=== "load hex"
+	--test-- "load hex 1"
+		--assert 0 = 0h
+	--test-- "load hex 2"
+		--assert [1 16 256 4096 65536 1048576 16777216] = [1h 10h 100h 1000h 10000h 100000h 1000000h]
+===end-group===
+
 ~~~end-file~~~


### PR DESCRIPTION
treated `hexa` same for RS and Red