### PR TITLE
Gtk: fix issue with escaping on rich-text used by gui-console

### DIFF
--- a/modules/view/backends/gtk3/events.reds
+++ b/modules/view/backends/gtk3/events.reds
@@ -852,6 +852,10 @@ connect-common-events: function [
 		if respond-mouse? widget ON_WHEEL [
 			;; DEBUG: if debug-connect? DEBUG_CONNECT_COMMON [print [ "connect-common-events ON_WHEEL: " get-symbol-name sym "->" widget lf]]
 			gtk_widget_add_events widget GDK_SCROLL_MASK
+			if container-type? sym [
+				;; Bubbling does not work for rich-text so delegation to the parent with EVT_DISPATCH
+				connect-container-events widget "scroll-event"
+			]
 			gobj_signal_connect(widget "scroll-event" :widget-scroll-event face/ctx)
 		]
 

--- a/modules/view/backends/gtk3/gtk.reds
+++ b/modules/view/backends/gtk3/gtk.reds
@@ -819,6 +819,11 @@ GPtrArray!: alias struct! [
 		g_string_new: "g_string_new" [
 			return:		[GString!]
 		]
+		g_string_new_len: "g_string_new_len" [
+			text		[c-string!]
+			len 		[integer!]
+			return:		[GString!]
+		]
 		g_string_sized_new: "g_string_sized_new" [
 			dfl_size 	[integer!]
 			return:		[GString!]

--- a/modules/view/backends/gtk3/para.reds
+++ b/modules/view/backends/gtk3/para.reds
@@ -200,7 +200,7 @@ get-para-flags: func [
 			
 			h-def: left
 			
-			if all [wrap? type = text][
+			if all[wrap? type <> field][
 				flags: 00010000h						;-- SS_ENDELLIPSIS
 			]
 		]


### PR DESCRIPTION
Escaping was made too early in the code. No more need to have a simplified escaping function so `g-markup-escape-text` is removed in favor of the original `g_markup_escape_text`. IMHO, the only problem that can occur is that styles only work when tags are embedded. This can be improved later...