### PR TITLE
Gtk: Fix issue about bad caret position for gui-console when big font

### DIFF
--- a/environment/console/GUI/gui-console.red
+++ b/environment/console/GUI/gui-console.red
@@ -214,6 +214,7 @@ gui-console-ctx: context [
 		console/init
 		load-cfg
 		win/visible?: yes
+		#if config/OS = 'Linux [terminal/update-cfg font none]
 
 		svs: system/view/screens/1
 		svs/pane: next svs/pane				;-- proctect itself from unview/all

--- a/modules/view/backends/gtk3/gtk.reds
+++ b/modules/view/backends/gtk3/gtk.reds
@@ -1138,6 +1138,10 @@ GPtrArray!: alias struct! [
 			argc		[int-ptr!]
 			argv		[handle!]
 		]
+		gdk_init: "gdk_init" [
+			argc		[int-ptr!]
+			argv		[handle!]
+		]
 		gtk_main: "gtk_main" []
 		gtk_main_quit: "gtk_main_quit" []
 		gtk_main_iteration: "gtk_main_iteration" [


### PR DESCRIPTION
`update-cfg font none` is called too early on Linux/GTK. This fixes the issue since called after `win/visible?: yes` which updates properly the font handler for the first time and required by `update-cfg font none` to update properly the caret at first.