### PR TITLE
FIX: RECYCLE does not have a docstring #4033

### DIFF
--- a/environment/codecs/json/common.red
+++ b/environment/codecs/json/common.red
@@ -58,7 +58,7 @@ json-common: context [
     ]
     
 	translit: func [
-		"Tansliterate sub-strings in a string"
+		"Transliterate sub-strings in a string"
 		string [string!] "Input (modified)"
 		rule   [block! bitset!] "What to change"
 		xlat   [block! function!] "Translation table or function. MUST map a string! to a string!."

--- a/environment/natives.red
+++ b/environment/natives.red
@@ -892,8 +892,9 @@ decompress: make native! [[
 ]
 
 recycle: make native! [[
-		/on
-		/off
+		"Recycles unused memory"
+		/on		"Turns on garbage collector"
+		/off	"Turns off garbage collector"
 	]
 	#get-definition NAT_RECYCLE
 ]


### PR DESCRIPTION
Added docstring to `recycle`. Also fixed a very small typo in `translit` function.