### PR TITLE
FIX: issue #3270 (Panel face with set text facet fills with black)

### DIFF
--- a/modules/view/backends/windows/base.reds
+++ b/modules/view/backends/windows/base.reds
@@ -132,6 +132,7 @@ render-base: func [
 	if all [
 		group-box <> type
 		window <> type
+		panel <> type
 		render-text values hWnd hDC :rc null null
 	][
 		res: true


### PR DESCRIPTION
I believe `panel` face was not designed to display any "text" on it directly. It kinda worked using same code that does so for a `base`, but `base` with `color: none` does not paint it's background so it never did for the panel. Thus I disabled it. As a consequence the background is now painted by DefWindowProc even when it has a "text" facet assigned.

An alternative would be to redraw the panel manually using `base` code, but specifying a default window color, and *then* draw a text on it.

Let me know if I judged correctly.