### PR TITLE
FIX: #4079 replace on strings should work with non-formed arguments

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -237,6 +237,7 @@ replace: function [
 		any [not any-string? :pattern tag? :pattern]
 		any-string? series
 		not block? :pattern
+		not bitset? :pattern
 	] [
 		pattern: form pattern
 	]

--- a/environment/functions.red
+++ b/environment/functions.red
@@ -233,7 +233,11 @@ replace: function [
 		]
 		return series
 	]
-	if system/words/all [any [char? :pattern tag? :pattern] any-string? series] [
+	if system/words/all [
+		any [not any-string? :pattern tag? :pattern]
+		any-string? series
+		not block? :pattern
+	] [
 		pattern: form pattern
 	]
 	either system/words/all [any-string? :series block? :pattern] [

--- a/tests/source/units/replace-test.red
+++ b/tests/source/units/replace-test.red
@@ -26,6 +26,8 @@ Red [
 	--test-- "replace-11"	--assert %file.ext = replace %file.sub.ext ".sub." #"."
 	--test-- "replace-12"	--assert "abra-abra" = replace "abracadabra" "cad" #"-"
 	--test-- "replace-13"	--assert "abra-c-adabra" = replace "abracadabra" #"c" "-c-"
+	--test-- "replace-14"	--assert "x23" = replace "123" 1 "x"
+	--test-- "replace-15"	--assert "xbc" = replace "abc" quote a: "x"
 
 ===end-group===
 


### PR DESCRIPTION
With this PR, Red's `replace` function becomes more compatible with R2 by supporting below forms:

```
replace "123" 1 "x" ; == "x23"
replace "abc" quote a: "x" ; == "xbc"
```