### PR TITLE
FIX: issues #3369, #4088, #4087, #4085, #4083, #4078

### DIFF
--- a/compiler.r
+++ b/compiler.r
@@ -2420,13 +2420,15 @@ red: context [
 		insert-lf -5
 		insert-lf -7
 		emit-stack-reset
-		
+
+		emit [integer/push 0]		
 		emit-open-frame 'repeat
 		emit compose/deep [
 			while [
 				;-- set word 1 + get word
 				;-- TBD: set word next get word
-				(set-cnt) (cnt) + 1
+				(set-cnt) 1 + integer/get stack/arguments - 1	;-- fixes #3361
+				integer/make-at stack/arguments - 1 (cnt)
 				;-- (get word) < value
 				;-- TBD: not tail? get word
 				(cnt) <= (lim)

--- a/runtime/allocator.reds
+++ b/runtime/allocator.reds
@@ -895,7 +895,7 @@ alloc-series-buffer: func [
 		sz		 [integer!]
 		flag-big [integer!]
 ][
-	assert positive? usize
+	assert not negative? usize
 	size: round-to usize * unit size? cell!	;-- size aligned to cell! size
 
 	frame: memory/s-active

--- a/runtime/datatypes/series.reds
+++ b/runtime/datatypes/series.reds
@@ -43,6 +43,28 @@ _series: context [
 		(as byte-ptr! s/offset) + offset >= as byte-ptr! s/tail
 	]
 
+	trim-head: func [									;-- cuts the head if it's after the tail
+		ser 	[red-series!]
+		return:	[series!]
+		/local
+			s	[series!]
+			sz	[integer!]
+	][
+		s: GET_BUFFER(ser)
+		sz: (as-integer s/tail - s/offset) >> log-b GET_UNIT(s)
+		if ser/head > sz [ser/head: sz]
+		s
+	]
+
+	trim-head-into: func [								;-- cuts the head if it's after the tail, puts result into `new`
+		ser 	[red-series!]
+		new 	[red-series!]
+		return:	[series!]
+	][
+		copy-cell as cell! ser as cell! new
+		trim-head new
+	]
+
 	get-position: func [
 		base	   [integer!]
 		return:	   [integer!]
@@ -400,13 +422,15 @@ _series: context [
 			int	  [red-integer!]
 			hash  [red-hash!]
 			cell  [red-value!]
+			origin' [red-series! value]
+			target' [red-series! value]
 	][
-		s:    GET_BUFFER(origin)
+		s:    trim-head-into origin origin'
 		unit: GET_UNIT(s)
-		src: (as byte-ptr! s/offset) + (origin/head << (log-b unit))
+		src: (as byte-ptr! s/offset) + (origin'/head << (log-b unit))
 		tail: as byte-ptr! s/tail
 		if src = tail [return as red-value! target]
-		
+
 		part: unit
 		items: 1
 
@@ -420,15 +444,16 @@ _series: context [
 			part: part << (log-b unit)
 		]
 		
-		type1: TYPE_OF(origin)
-		either origin/node = target/node [				;-- same series case
-			dst: (as byte-ptr! s/offset) + (target/head << (log-b unit))
+		type1: TYPE_OF(origin')
+		either origin'/node = target/node [				;-- same series case
+			trim-head-into target target'
+			dst: (as byte-ptr! s/offset) + (target'/head << (log-b unit))
 			if src = dst [return as red-value! target]	;-- early exit if no move is required
 			if all [dst > src dst <> tail part > (as-integer tail - dst)][
 				return as red-value! origin
 			]
 			if dst > tail [dst: tail]					;-- avoid overflows if part is too big
-			ownership/check as red-value! target words/_move null origin/head items
+			ownership/check as red-value! target' words/_move null origin'/head items
 
 			temp: allocate part							;@@ suboptimal for unit < 16
 			copy-memory	temp src part
@@ -449,11 +474,11 @@ _series: context [
 			free temp
 
 			if type1 = TYPE_HASH [
-				hash: as red-hash! origin
-				_hashtable/move hash/table target/head origin/head items
+				hash: as red-hash! origin'
+				_hashtable/move hash/table target'/head origin'/head items
 			]
 
-			index: target/head - items
+			index: target'/head - items
 		][												;-- different series case
 			type2: TYPE_OF(target)
 			if any [
@@ -462,9 +487,9 @@ _series: context [
 			][
 				fire [TO_ERROR(script move-bad) datatype/push type1 datatype/push type2]
 			]
-			ownership/check as red-value! target words/_move null origin/head items
+			ownership/check as red-value! target words/_move null origin'/head items
 			
-			s2:    GET_BUFFER(target)
+			s2: trim-head-into target target'
 			unit2: GET_UNIT(s2)
 			if unit <> unit2 [
 				if any [
@@ -475,13 +500,13 @@ _series: context [
 				][
 					fire [TO_ERROR(script move-bad) datatype/push type1 datatype/push type2]
 				]
-				string/move-chars as red-string! origin as red-string! target part
+				string/move-chars as red-string! origin' as red-string! target' part
 				return as red-value! target
 			]
 			;-- make enough space in target
 			size: as-integer (as byte-ptr! s2/tail) + part - as byte-ptr! s2/offset
 			if size > s2/size [s2: expand-series s2 size * 2]
-			dst: (as byte-ptr! s2/offset) + (target/head << (log-b unit))
+			dst: (as byte-ptr! s2/offset) + (target'/head << (log-b unit))
 			
 			;-- slide target series to right from insertion position
 			move-memory dst + part dst as-integer (as byte-ptr! s2/tail) - dst
@@ -495,12 +520,12 @@ _series: context [
 			s/tail: as cell! tail - part
 
 			if type1 = TYPE_HASH [
-				hash: as red-hash! origin
+				hash: as red-hash! origin'
 				part: (as-integer s/tail - s/offset) >> 4 - hash/head
 				_hashtable/refresh hash/table 0 - items hash/head + items part yes
 			]
 			if type2 = TYPE_HASH [
-				hash: as red-hash! target
+				hash: as red-hash! target'
 				part: (as-integer s2/tail - dst) >> 4 - items - hash/head
 				_hashtable/refresh hash/table items hash/head part yes
 				cell: as red-value! dst
@@ -509,9 +534,11 @@ _series: context [
 					cell: cell + 1
 				]
 			]
-			index: target/head
+			index: target'/head
 		]
-		ownership/check as red-value! target words/_moved null index items
+		ownership/check as red-value! target' words/_moved null index items
+		target/node: target'/node
+		; origin/node: origin'/node
 		as red-value! origin
 	]
 	
@@ -523,43 +550,54 @@ _series: context [
 		dup-arg  [red-value!]
 		return:	 [red-series!]
 		/local
-			s		[series!]
-			s2		[series!]
-			part	[integer!]
-			items	[integer!]
-			unit	[integer!]
-			size	[integer!]
-			type	[integer!]
-			head	[integer!]
-			src		[byte-ptr!]
-			tail	[byte-ptr!]
-			p		[byte-ptr!]
-			cell	[red-value!]
-			limit	[red-value!]
-			int		[red-integer!]
-			ser2	[red-series!]
-			hash	[red-hash!]
-			table	[node!]
-			values? [logic!]
-			neg?	[logic!]
-			part?	[logic!]
-			blk?	[logic!]
-			self?	[logic!]
-			added	[integer!]
-			n		[integer!]
-			cnt		[integer!]
+			s			[series!]
+			s2			[series!]
+			part		[integer!]
+			items		[integer!]
+			unit		[integer!]
+			unit2		[integer!]
+			bytes1		[integer!]
+			bytes2		[integer!]
+			shift		[integer!]
+			trail		[integer!]
+			shift-bytes	[integer!]
+			trail-bytes	[integer!]
+			size		[integer!]
+			new-size	[integer!]
+			new-part	[integer!]
+			n			[integer!]
+			left		[integer!]
+			type		[integer!]
+			head		[integer!]
+			src			[byte-ptr!]
+			dst			[byte-ptr!]
+			cell		[red-value!]
+			limit		[red-value!]
+			int			[red-integer!]
+			ser2		[red-series!]
+			ser2'		[red-series! value]					;-- temp alias with head <= tail
+			hash		[red-hash!]
+			table		[node!]
+			values? 	[logic!]
+			neg?		[logic!]
+			part?		[logic!]
+			blk?		[logic!]
+			self?		[logic!]
+			divided?	[logic!]
+			cnt			[integer!]
 	][
 		cnt: 1
 		if OPTION?(dup-arg) [
 			int: as red-integer! dup-arg
 			cnt: int/value
-			if cnt < 1 [return ser]
+			if cnt < 0 [cnt: 0]
 		]
+		part?: OPTION?(part-arg)
+		if all [not part? zero? cnt] [return ser]
 
-		neg?: no self?: no
-		s:    GET_BUFFER(ser)
-		unit: GET_UNIT(s)
-		unit: log-b unit
+		self?: no
+		s: trim-head ser
+		unit: log-b GET_UNIT(s)
 		head: ser/head
 		size: (as-integer s/tail - s/offset) >> unit
 
@@ -568,36 +606,37 @@ _series: context [
 
 		ser2: as red-series! value
 		values?: either all [only? blk?][no][
-			n: TYPE_OF(value)
-			self?: all [type = n ser/node = ser2/node]	;-- ser and value are the same series
-			ANY_BLOCK?(n)
+			left: TYPE_OF(value)
+			self?: ser/node = ser2/node					;-- ser and value are the same series
+			ANY_BLOCK?(left)
 		]
 
 		items: either any [self? values?][
-			s2: GET_BUFFER(ser2)
-			cell: as cell! (as byte-ptr! s2/offset) + (ser2/head << unit)
-			get-length ser2 no
+			s2: trim-head-into ser2 ser2'
+			unit2: log-b GET_UNIT(s2)
+			cell: as cell! (as byte-ptr! s2/offset) + (ser2'/head << unit2)
+			get-length ser2' no
 		][
 			cell: value
 			1
 		]
 		limit: cell + items
 
-		part: items
-		part?: OPTION?(part-arg)
-		either part? [
+		part: items * cnt
+		if part? [
 			part: either TYPE_OF(part-arg) = TYPE_INTEGER [
 				int: as red-integer! part-arg
 				int/value
 			][
 				ser2: as red-series! part-arg
 				unless all [
-					TYPE_OF(ser2) = TYPE_OF(ser)	;-- handles ANY-STRING!
+					TYPE_OF(ser2) = TYPE_OF(ser)		;-- handles ANY-STRING!
 					ser2/node = ser/node
 				][
 					ERR_INVALID_REFINEMENT_ARG(refinements/_part part-arg)
 				]
-				ser2/head - head
+				trim-head-into ser2 ser2'
+				ser2'/head - head
 			]
 			if negative? part [
 				part: 0 - part
@@ -605,110 +644,129 @@ _series: context [
 				ser/head: head
 				neg?: yes
 			]
-			size: size - head
-			if part > size [part: size]
-		][size: size - head]
+		]
+		left: size - head
+		if part > left [part: left]
+
+		if all [
+			zero? part
+			limit = cell
+		][return ser]									;-- early exit if nothing to change
 
 		either any [blk? self?][
-			n: either part? [part][items * cnt]
-			if n > size [n: size]
-			ownership/check as red-value! ser words/_change null head n
-
-			added: either part? [items - part][items - size]
-			added: added << unit
-			n: (as-integer (s/tail - s/offset)) + added
-			if n > s/size [s: expand-series s n * 2]
-
-			src: (as byte-ptr! s/offset) + (head << unit)
-			tail: as byte-ptr! s/tail
-			either part? [
-				size: size - part
-				move-memory
-					src + (items << unit)
-					src + (part << unit)
-					size << unit
-				s/tail: as cell! tail + added
+			new-part: items * cnt
+			new-size: size - part + new-part
+			n: new-size << unit
+			ownership/check as red-value! ser words/_change null head part
+			if n > s/size [s: expand-series s n << 1]
+			dst: (as byte-ptr! s/offset) + (head << unit)
+			src: as byte-ptr! cell
+			bytes1: part << unit
+			bytes2: items << unit
+			if zero? cnt [bytes2: 0]
+			trail: left - part
+			shift: items * cnt - part
+			trail-bytes: trail << unit
+			shift-bytes: shift << unit
+			either shift <= 0 [
+				if bytes2 > 0 [move-memory dst src bytes2]						;-- items -> part (possible overlap)
+				if trail > 0 [
+					move-memory dst + (bytes2 * cnt) dst + bytes1 trail-bytes	;-- contract the trail (possible overlap)
+				]
 			][
-				if added > 0 [s/tail: as cell! tail + added]
-			]
-			copy-memory src as byte-ptr! cell items << unit
-
-			if type = TYPE_HASH [
-				n: items * cnt
-				added: either part? [n - part][n - size]
-				hash: as red-hash! ser
-				table: hash/table
-				either part? [
-					_hashtable/refresh table added head + part size yes
-					n: either added < 0 [part + added][part]
+				divided?: no
+				if trail > 0 [													;-- at least 1 item remains after the part; move it to the right
+					move-memory dst + (bytes2 * cnt) dst + bytes1 trail-bytes	;-- move the trail (possible overlap)
+					divided?: all [												;-- src becomes divided into 2 segments by the expansion
+						self?
+						trail > shift											;-- if there's an intersection between the *new trail* and *items*
+					]
+				]
+				assert bytes2 > 0
+				either divided? [
+					move-memory dst src bytes1											;-- fill the part (possible overlap)
+					move-memory dst + bytes1 src + bytes1 + shift-bytes shift-bytes		;-- fill the gap after part (possible overlap)
 				][
-					if n > size [n: size]
+					move-memory dst src bytes2											;-- move the `items` (possible overlap)
 				]
-				_hashtable/clear table head n
 			]
+			s/tail: as cell! (as byte-ptr! s/offset) + (new-size << unit)
+			;@@ FIXME: THAT DOESN'T WORK:
+			; if type = TYPE_HASH [
+			; 	hash: as red-hash! ser
+			; 	table: hash/table
+			; 	if part > 0 [_hashtable/clear table head part]							;-- forget the old part
+			; 	if trail > 0 [_hashtable/refresh table shift head + part trail yes]		;-- shift the trail
+			; 	if size > new-size [_hashtable/clear table new-size size - new-size]	;-- forget the now past tail items
+			; ]
 		][
-			tail: as byte-ptr! s/tail
-			src: (as byte-ptr! s/offset) + (head << unit)
 			if part? [
-				added: part << unit
-				move-memory src src + added (as-integer tail - src) - added
-				s/tail: as cell! tail - added
+				dst: (as byte-ptr! s/offset) + (head << unit)
+				bytes1: part << unit
+				trail-bytes: left - part << unit
+				;-- don't know the size of the formed items yet; change-range will decide
+				;@@ FIXME: this is sub-optimal for long trails
+				if all [trail-bytes > 0 part > 0] [
+					move-memory dst dst + bytes1 trail-bytes
+					s/tail: as cell! dst + trail-bytes
+				]
 			]
-			items: switch type [
-				TYPE_BINARY [
-					binary/change-range as red-binary! ser cell limit part?
+			if cnt > 0 [
+				items: switch type [
+					TYPE_BINARY [
+						binary/change-range as red-binary! ser cell limit part?
+					]
+					TYPE_VECTOR [
+						vector/change-range as red-vector! ser cell limit part?
+					]
+					default [								;-- ANY-STRING!
+						string/change-range as red-string! ser cell limit part?
+					]
 				]
-				TYPE_VECTOR [
-					vector/change-range as red-vector! ser cell limit part?
+			]
+			new-part: items * cnt
+			if all [cnt > 1 items > 0] [
+				s: GET_BUFFER(ser)
+				unit: log-b GET_UNIT(s)
+				size: (as-integer s/tail - s/offset) >> unit
+				either part? [
+					new-size: size + new-part - items		;-- shrunk it before ^^
+				][
+					new-size: head + new-part				;-- the part to be overridden
+					if new-size < size [new-size: size]
 				]
-				default [					;-- ANY-STRING!
-					string/change-range as red-string! ser cell limit part?
-				]
+				n: new-size << unit
+				if n > s/size [s: expand-series s n << 1]
+				s/tail: as cell! (as byte-ptr! s/offset) + n
 			]
 		]
 
-		if cnt > 1 [						;-- /dup
-			s: GET_BUFFER(ser)
-			unit: GET_UNIT(s)
-			unit: log-b unit
+		if all [cnt > 1 items > 0] [					;-- /dup
 			src: (as byte-ptr! s/offset) + (head << unit)
-			tail: as byte-ptr! s/tail
-			
-			added: items << unit
-			n: added * cnt
-			n: either part? [n - added][as-integer src + n - tail]
-			size: (as-integer tail - as byte-ptr! s/offset) + n
-			if size > s/size [
-				s: expand-series s size * 2
-				src: (as byte-ptr! s/offset) + (head << unit)
-				tail: as byte-ptr! s/tail
-			]
-
-			src: src + added
-			if part? [
-				move-memory src + n src as-integer tail - src
-			]
-			if n > 0 [s/tail: as cell! tail + n]
-
-			items: items * cnt
-			p: src
-			src: src - added
-			until [
-				copy-memory p src added
-				p: p + added
-				cnt: cnt - 1
-				cnt = 1
+			bytes2: items << unit
+			dst: src + bytes2
+			loop cnt - 1 [
+				copy-memory dst src bytes2
+				dst: dst + bytes2
 			]
 		]
+		; if type = TYPE_HASH [
+		; 	hash: as red-hash! ser
+		; 	table: hash/table
+		; 	cell: as cell! s/offset + head
+		; 	loop new-part [_hashtable/put table cell  cell: cell + 1]		;-- insert the items
+		; ]
+
+		;@@ FIXME: temporary solution - reinsert everything after the head:
 		if type = TYPE_HASH [
-			cell: s/offset + head
-			loop items [
-				_hashtable/put table cell
-				cell: cell + 1
-			]
+			hash: as red-hash! ser
+			table: hash/table
+			_hashtable/clear table head size - head
+			cell: as cell! s/offset + head
+			loop new-size - head [_hashtable/put table cell  cell: cell + 1]
 		]
-		ser/head: head + items
-		ownership/check as red-value! ser words/_changed null head items
+		ownership/check as red-value! ser words/_changed null head new-part
+		ser/head: head + new-part											;-- set head after the change
 		ser
 	]
 
@@ -914,7 +972,10 @@ _series: context [
 			items: part
 			part: part << (log-b unit)
 		][
+			part: ser/head								;-- preserve the head
 			items: get-length ser no
+			ser/head: part
+			part: 0
 		]
 		
 		hash?: TYPE_OF(ser) = TYPE_HASH
@@ -956,100 +1017,116 @@ _series: context [
 			s		[series!]
 			buffer	[series!]
 			node	[node!]
+			head	[integer!]
 			unit	[integer!]
 			part	[integer!]
 			bytes	[integer!]
 			size	[integer!]
 			hash	[red-hash!]
 			part2	[integer!]
+			ser'	[red-series! value]
+			part-arg'	[red-value! value]
 	][
 		#if debug? = yes [if verbose > 0 [print-line "series/take"]]
-
-		size: get-length ser no
-		if size <= 0 [									;-- early exit if nothing to take
-			set-type as cell! ser TYPE_NONE
-			return as red-value! ser
-		]
-		s:    GET_BUFFER(ser)
+		s: trim-head-into ser ser'
+		head: ser'/head
+		size: get-length ser' yes
 		unit: GET_UNIT(s)
 		part: 1
 		part2: 1
 
-		if OPTION?(part-arg) [
-			part: either TYPE_OF(part-arg) = TYPE_INTEGER [
+		either OPTION?(part-arg) [
+			either TYPE_OF(part-arg) = TYPE_INTEGER [
 				int: as red-integer! part-arg
-				int/value
+				part: int/value
+				if last? [								;-- integer /last/part counts from the tail
+					if part < 0 [part: 0]
+					head: size - part
+					if head < 0 [head: 0]
+				]
 			][
-				ser2: as red-series! part-arg
+				ser2: as red-series! part-arg'
+				trim-head-into as red-series! part-arg as red-series! part-arg'
 				unless all [
 					TYPE_OF(ser2) = TYPE_OF(ser)		;-- handles ANY-STRING!
 					ser2/node = ser/node
 				][
 					ERR_INVALID_REFINEMENT_ARG(refinements/_part part-arg)
 				]
-				either ser2/head < ser/head [0][
-					either last? [size - (ser2/head - ser/head)][ser2/head - ser/head]
+				part: ser2/head - head
+				if all [
+					last?								;-- series /last/part takes everything after the biggest of ends
+					part > 0
+				][										;-- set head to the biggest end
+					head: head + part
+					if head > size [head: size]
 				]
 			]
 			part2: part
-			if negative? part [
-				size: ser/head
-				part: either last? [1][0 - part]
+			either last? [
+				part: size - head
+			][
+				if part < 0 [
+					part: 0 - part
+					head: head - part
+					if head < 0 [
+						part: part + head
+						head: 0
+					]
+				]
+				if part > (size - head) [part: size - head]
 			]
-			if part > size [part: size]
-			if zero? part [part: 1]
+		][;; either OPTION?(part-arg)
+			if head >= size [							;-- early exit if nothing to take (and part = 1)
+				set-type as cell! ser TYPE_NONE
+				return as red-value! ser
+			]
+			if last? [head: size - 1]
 		]
 
 		bytes:	part << (log-b unit)
 		node: 	alloc-bytes bytes
-		s:      GET_BUFFER(ser)
+		s:      GET_BUFFER(ser')
 		buffer: as series! node/value
 		buffer/flags: s/flags							;@@ filter flags?
+		tail: as byte-ptr! s/tail
 
 		ser2: as red-series! stack/push*
 		ser2/header: TYPE_OF(ser)
-		ser2/extra:  either TYPE_OF(ser) = TYPE_VECTOR [ser/extra][0]
+		ser2/extra:  either TYPE_OF(ser) = TYPE_VECTOR [ser'/extra][0]
 		ser2/node:  node
 		ser2/head:  0
 
-		ownership/check as red-value! ser words/_take null ser/head part2
+		ownership/check as red-value! ser' words/_take null head part2
 
-		offset: (as byte-ptr! s/offset) + (ser/head << (log-b unit))
-		tail: as byte-ptr! s/tail
-		either positive? part2 [
-			if last? [
-				offset: tail - bytes
-				s/tail: as cell! offset
-			]
-		][
-			if any [last? part > ser/head][return as red-value! ser2]
-			offset: offset - bytes
-		]
+		offset: (as byte-ptr! s/offset) + (head << (log-b unit))
 		copy-memory
 			as byte-ptr! buffer/offset
 			offset
 			bytes
 		buffer/tail: as cell! (as byte-ptr! buffer/offset) + bytes
 
-		unless last? [
+		unless head + part >= size [
 			move-memory
 				offset
 				offset + bytes
 				as-integer tail - offset - bytes
-			s/tail: as cell! tail - bytes
 		]
+		s/tail: as cell! tail - bytes
 
+		ser'/head: head
 		if TYPE_OF(ser) = TYPE_HASH [
-			unit: either last? [size][ser/head + part]
-			hash: as red-hash! ser
-			_hashtable/refresh hash/table 0 - part unit size - unit yes
+			hash: as red-hash! ser'
+			_hashtable/refresh hash/table 0 - part ser'/head + part size - ser'/head - part yes
 			hash: as red-hash! ser2
 			hash/header: TYPE_BLOCK		;-- set to TYPE_BLOCK so we don't mark hash/table
 			hash/table: _hashtable/init part ser2 HASH_TABLE_HASH 1
 			hash/header: TYPE_HASH
 		]
 		
-		ownership/check as red-value! ser words/_taken null ser/head 0
+		ownership/check as red-value! ser' words/_taken null ser'/head 0
+		ser/node: ser'/node								;-- could have been relocated
+
 		as red-value! ser2
 	]
 
@@ -1070,12 +1147,12 @@ _series: context [
 		s1:    GET_BUFFER(ser1)
 		unit1: GET_UNIT(s1)
 		head1: (as byte-ptr! s1/offset) + (ser1/head << (log-b unit1))
-		if head1 = as byte-ptr! s1/tail [return ser1]				;-- early exit if nothing to swap
+		if head1 >= as byte-ptr! s1/tail [return ser1]				;-- early exit if nothing to swap
 
 		s2:    GET_BUFFER(ser2)
 		unit2: GET_UNIT(s2)
 		head2: (as byte-ptr! s2/offset) + (ser2/head << (log-b unit2))
-		if head2 = as byte-ptr! s2/tail [return ser1]				;-- early exit if nothing to swap
+		if head2 >= as byte-ptr! s2/tail [return ser1]				;-- early exit if nothing to swap
 
 		char1: string/get-char head1 unit1
 		char2: string/get-char head2 unit2

--- a/runtime/hashtable.reds
+++ b/runtime/hashtable.reds
@@ -1071,6 +1071,7 @@ _hashtable: context [
 		/local s [series!] h [hashtable!] flags [int-ptr!] i [integer!]
 			ii [integer!] sh [integer!] indexes [int-ptr!]
 	][
+		assert size >= 0
 		if zero? size [exit]
 		s: as series! node/value
 		h: as hashtable! s/offset
@@ -1109,6 +1110,7 @@ _hashtable: context [
 			n [integer!] keys [int-ptr!] index [int-ptr!] part [integer!]
 			flags [int-ptr!] ii [integer!] sh [integer!]
 	][
+		assert size >= 0
 		s: as series! node/value
 		h: as hashtable! s/offset
 		assert h/indexes <> null

--- a/tests/source/units/loop-test.red
+++ b/tests/source/units/loop-test.red
@@ -220,6 +220,18 @@ Red [
     ]
     issue427-f
   --assert 15 = issue427-acc
+
+  --test-- "issue #3361"
+  		s3361: copy []
+		f3361: func [n /local i] [
+			repeat i 3 [
+				repend s3361 [n i]
+				all [i = 1 n = 1 f3361 2]
+				all [i = 2 n = 2 f3361 3]
+			]
+		]
+		f3361 1
+		--assert s3361 = [1 1  2 1 2 2  3 1 3 2 3 3  2 3  1 2 1 3]
   
 ===end-group===
     

--- a/tests/source/units/series-test.red
+++ b/tests/source/units/series-test.red
@@ -8,6 +8,7 @@ Red [
 ]
 
 #include  %../../../quick-test/quick-test.red
+; qt-verbose: yes
 
 ~~~start-file~~~ "series"
 
@@ -133,6 +134,15 @@ Red [
   	--assert 1 = first back next make hash! [1 2 3 4 5]
   --test-- "series-back-13"
  	 --assert 1 = first back next next #{00010203}
+
+    --test-- "series-back-14"                           ;-- issue #3369
+        a: "12345678"
+        b: skip a 6
+        remove/part a 4
+        --assert 7 = index? b
+        --assert 6 = index? back b
+        --assert 5 = index? back back b
+
 ===end-group===
 
 ===start-group=== "tail"
@@ -148,6 +158,14 @@ Red [
   	--assert none = pick tail hs-ser-2 1
   --test-- "series-tail-5"
   	--assert #{02} = back tail #{0102}
+
+    --test-- "series-tail-6"                            ;-- issue #3369
+        a: "12345678"
+        b: skip a 6
+        remove/part a 4
+        --assert 7 = index? b
+        --assert 5 = index? tail b
+
 ===end-group===
 
 ===start-group=== "pick"
@@ -239,6 +257,105 @@ Red [
   	sp26-b: [4 7 9 [11] test /ref 'red]
   	--assert 'red = pick sp26-b 7
   	
+===end-group===
+
+===start-group=== "series-equal"
+
+  --test-- "series-equal-1"
+  --assert [] = []
+  
+  --test-- "series-equal-2"
+    se2-b: []
+  --assert [] = se2-b
+  
+  --test-- "series-equal-3"
+    se3-b: []
+  --assert se3-b = []
+  
+  --test-- "series-equal-4"
+    se4-b: [1]
+  --assert se4-b = [1]
+  
+  --test-- "series-equal-5"
+    se5-b: ["abcde"]
+  --assert se5-b = ["abcde"]
+
+  --test-- "series-equal-6"
+  --assert #{} = #{}
+
+  --test-- "series-equal-7"
+  --assert #{01} = next #{0001}
+
+  --test-- "series-equal-8"
+  --assert (make hash! []) = make hash! []
+
+  --test-- "series-equal-9"
+  --assert (make hash! [a 2 b 4]) = make hash! [a 2 b 4]
+
+  --test-- "series-equal-10"
+    se10-h: make hash! []
+    append se10-h [a 2 b 4]
+  --assert se10-h = make hash! [a 2 b 4]
+
+    --test-- "series-equal-11"                          ;-- issue #3369
+        a: "12345678"
+        b: skip a 6
+        remove/part a 4
+        --assert a = "5678"
+        --assert "5678" = a
+        --assert b = ""
+        --assert b == ""
+        --assert "" = b
+        --assert "" == b
+        --assert (index? b) <> (index? tail a)
+        --assert not same? b tail a
+        --assert not same? tail a b
+        --assert 7 = index? b
+
+    --test-- "series-equal-12"                          ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        --assert a = [5 6 7 8]
+        --assert [5 6 7 8] = a
+        --assert b = []
+        --assert b == []
+        --assert [] = b
+        --assert [] == b
+        --assert (index? b) <> (index? tail a)
+        --assert not same? b tail a
+        --assert not same? tail a b
+
+    --test-- "series-equal-13"                          ;-- issue #3369
+        a: #{01 02 03 04 05 06 07 08}
+        b: skip a 6
+        remove/part a 4
+        --assert a = #{05 06 07 08}
+        --assert #{05 06 07 08} = a
+        --assert b = #{}
+        --assert b == #{}
+        --assert #{} = b
+        --assert #{} == b
+        --assert (index? b) <> (index? tail a)
+        --assert not same? b tail a
+        --assert not same? tail a b
+        --assert 7 = index? b
+
+    --test-- "series-equal-14"                          ;-- issue #3369
+        a: make vector! [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        --assert a = make vector! [5 6 7 8]
+        --assert (make vector! [5 6 7 8]) = a
+        --assert b = make vector! []
+        --assert b == make vector! []
+        --assert (make vector! []) = b
+        --assert (make vector! []) == b
+        --assert (index? b) <> (index? tail a)
+        --assert not same? b tail a
+        --assert not same? tail a b
+        --assert 7 = index? b
+
 ===end-group===
 
 ===start-group=== "select"
@@ -400,6 +517,103 @@ Red [
   --assert #{C3A9} = append/part #{} "ébc" 2
   --assert #{C3A96263} = append #{} "ébc"
 
+    --test-- "series-append-27"                         ;-- issue #3369
+        a: "12345678"
+        b: skip a 6
+        remove/part a 4
+        append a "999"
+        --assert a = "5678999"
+        --assert b = "9"
+
+    --test-- "series-append-28"                         ;-- issue #3369
+        a: "12345678"
+        b: skip a 6
+        remove/part a 4
+        append/part a a b
+        --assert a = "56785678"
+        --assert b = "78"
+
+    --test-- "series-append-29"                         ;-- issue #3369
+        a: "12345678"
+        b: skip a 6
+        remove/part a 4
+        append/part a b a
+        --assert a = "5678"
+        --assert b = ""
+
+    --test-- "series-append-30"                         ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        append a [9 9 9]
+        --assert a = [5 6 7 8 9 9 9]
+        --assert b = [9]
+
+    --test-- "series-append-31"                         ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        append/part a a b
+        --assert a = [5 6 7 8 5 6 7 8]
+        --assert b = [7 8]
+
+    --test-- "series-append-32"                         ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        append/part a b a
+        --assert a = [5 6 7 8]
+        --assert b = []
+
+    --test-- "series-append-33"                         ;-- issue #3369
+        a: to-binary [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        append a [9 9 9]
+        --assert a = to-binary [5 6 7 8 9 9 9]
+        --assert b = to-binary [9]
+
+    --test-- "series-append-34"                         ;-- issue #3369
+        a: to-binary [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        append/part a a b
+        --assert a = to-binary [5 6 7 8 5 6 7 8]
+        --assert b = to-binary [7 8]
+
+    --test-- "series-append-35"                         ;-- issue #3369
+        a: to-binary [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        append/part a b a
+        --assert a = to-binary [5 6 7 8]
+        --assert b = to-binary []
+
+    --test-- "series-append-36"                         ;-- issue #3369
+        a: make vector! [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        append a [9 9 9]
+        --assert a = make vector! [5 6 7 8 9 9 9]
+        --assert b = make vector! [9]
+
+    ;@@ FIXME: no vector support
+    ; --test-- "series-append-37"
+    ;     a: make vector! [1 2 3 4 5 6 7 8]
+    ;     b: skip a 6
+    ;     remove/part a 4
+    ;     append/part a a b
+    ;     --assert a = make vector! [5 6 7 8 5 6 7 8]
+    ;     --assert b = make vector! [7 8]
+
+    ; --test-- "series-append-38"
+    ;     a: make vector! [1 2 3 4 5 6 7 8]
+    ;     b: skip a 6
+    ;     remove/part a 4
+    ;     append/part a b a
+    ;     --assert a = make vector! [5 6 7 8]
+    ;     --assert b = make vector! []
+
 ===end-group===
 
 ===start-group=== "series-put"
@@ -417,51 +631,66 @@ Red [
     put sp-3 'b 3
   --assert sp-3 = make hash! [a 1 b 3]
 
+    --test-- "series-put-4"                             ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        put b 1 'x
+        --assert a = [5 6 7 8 1 x]
+        --assert b = []
+        put b 1 'x
+        --assert a = [5 6 7 8 1 x 1 x]
+        --assert b = [1 x]
+        put b 1 'y
+        --assert a = [5 6 7 8 1 x 1 y]
+        --assert b = [1 y]
+
+    --test-- "series-put-5"                             ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        put a 5 'x
+        --assert a = [5 x 7 8]
+        --assert b = []
+        put a 1 'y
+        --assert a = [5 x 7 8 1 y]
+        --assert b = []
+        put a 'y 'z
+        --assert a = [5 x 7 8 1 y z]
+        --assert b = [z]
+
+    --test-- "series-put-6"                             ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        put b 1 'x
+        --assert a = make hash! [5 6 7 8 1 x]
+        --assert b = make hash! []
+        put b 1 'x
+        --assert a = make hash! [5 6 7 8 1 x 1 x]
+        --assert b = make hash! [1 x]
+        put b 1 'y
+        --assert a = make hash! [5 6 7 8 1 x 1 y]
+        --assert b = make hash! [1 y]
+
+    --test-- "series-put-7"                             ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        put a 5 'x
+        --assert a = make hash! [5 x 7 8]
+        --assert b = make hash! []
+        put a 1 'y
+        --assert a = make hash! [5 x 7 8 1 y]
+        --assert b = make hash! []
+        put a 'y 'z
+        --assert a = make hash! [5 x 7 8 1 y z]
+        --assert b = make hash! [z]
+
   --test-- "series-put-issue 3567"
 	v: [a 1 c]
 	put v 'c 3
 	--assert v = [a 1 c 3]
-===end-group===
-
-===start-group=== "series-equal"
-
-  --test-- "series-equal-1"
-  --assert [] = []
-  
-  --test-- "series-equal-2"
-    se2-b: []
-  --assert [] = se2-b
-  
-  --test-- "series-equal-3"
-    se3-b: []
-  --assert se3-b = []
-  
-  --test-- "series-equal-4"
-    se4-b: [1]
-  --assert se4-b = [1]
-  
-  --test-- "series-equal-5"
-    se5-b: ["abcde"]
-  --assert se5-b = ["abcde"]
-
-  --test-- "series-equal-6"
-  --assert #{} = #{}
-
-  --test-- "series-equal-7"
-  --assert #{01} = next #{0001}
-
-  --test-- "series-equal-8"
-  --assert (make hash! []) = make hash! []
-
-  --test-- "series-equal-9"
-  --assert (make hash! [a 2 b 4]) = make hash! [a 2 b 4]
-
-  --test-- "series-equal-10"
-    se10-h: make hash! []
-    append se10-h [a 2 b 4]
-  --assert se10-h = make hash! [a 2 b 4]
-
-  
 ===end-group===
 
 ===start-group=== "series-find"
@@ -789,7 +1018,38 @@ Red [
 		put sf-105 'a 1
 		--assert (make hash! [a 1]) = find sf-105 'a
 
+    --test-- "series-find-106"                          ;-- issue #3369
+        a: "12345678"
+        b: skip a 6
+        c: tail a
+        remove/part a 4
+        --assert none? find b "7"
+        --assert none? find/part b "7" c
+        --assert none? find/part c "7" b
+        --assert not none? find/part a "7" b
 		
+    --test-- "series-find-107"                          ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        c: tail a
+        remove/part a 4
+        --assert none? find b [7]
+        --assert none? find/part b [7] c
+        --assert none? find/part c [7] b
+        --assert not none? find/part a [7] b
+
+    ;@@ FIXME: #4091
+    ; --test-- "series-find-108"                          ;-- issue #3369
+    ;     a: make hash! [1 2 3 4 5 6 7 8]
+    ;     b: skip a 6
+    ;     c: tail a
+    ;     remove/part a 4
+    ;     --assert     none? probe find b make hash! [7]
+    ;     --assert not none? probe find a make hash! [7]
+    ;     --assert     none? probe find/part b make hash! [7] c
+    ;     --assert     none? probe find/part c make hash! [7] b
+    ;     --assert not none? probe find/part a make hash! [7] b
+        
 ===end-group===
 
 ===start-group=== "remove"
@@ -833,6 +1093,25 @@ Red [
 		blk: [a 1 1 b 2 2 c 3 3]
 		--assert [a 1 1 c 3 3] =  remove/key/part blk 'b 2
 
+    --test-- "remove-blk-10"                            ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: c': skip a 6
+        d: tail a
+        remove/part a 4
+        --assert same? c remove c'                      ;-- docstring says "returns on the same index"
+        --assert a = [5 6 7 8]
+        --assert c = []
+        --assert 7 = index? remove/part c d
+        --assert a = [5 6 7 8]
+        --assert c = []
+        --assert 3 = index? remove/part b c
+        --assert a = [5 6]
+        --assert b = []
+        --assert 7 = index? remove/part c a
+        --assert a = [5 6]
+        --assert b = []
+
 	--test-- "remove-hash-1"
 		hs-remove-1: make hash! [a 2 3]
 		--assert (make hash! [2 3]) = remove hs-remove-1
@@ -865,6 +1144,25 @@ Red [
 	--test-- "remove-hash-7"
 		hs: make hash! [a 1 1 b 2 2 c 3 3]
 		--assert (make hash! [a 1 1 c 3 3]) =  remove/key/part hs 'b 2
+
+    --test-- "remove-hash-8"                            ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: c': skip a 6
+        d: tail a
+        remove/part a 4
+        --assert same? c remove c'                      ;-- docstring says "returns on the same index"
+        --assert a = make hash! [5 6 7 8]
+        --assert c = make hash! []
+        --assert 7 = index? remove/part c d
+        --assert a = make hash! [5 6 7 8]
+        --assert c = make hash! []
+        --assert 3 = index? remove/part b c
+        --assert a = make hash! [5 6]
+        --assert b = make hash! []
+        --assert 7 = index? remove/part c a
+        --assert a = make hash! [5 6]
+        --assert b = make hash! []
 
 	--test-- "remove-str-1"
 		a: "123"
@@ -902,6 +1200,25 @@ Red [
 		--assert "" = remove back tail a
 		--assert "str12" = head a
 
+    --test-- "remove-str-9"                             ;-- issue #3369
+        a: "12345678"
+        b: skip a 2
+        c: c': skip a 6
+        d: tail a
+        remove/part a 4
+        --assert same? c remove c'                      ;-- docstring says "returns on the same index"
+        --assert a = "5678"
+        --assert c = ""
+        --assert 7 = index? remove/part c d
+        --assert a = "5678"
+        --assert c = ""
+        --assert 3 = index? remove/part b c
+        --assert a = "56"
+        --assert b = ""
+        --assert 7 = index? remove/part c a
+        --assert a = "56"
+        --assert b = ""
+
 	--test-- "remove-bin-1"
 		b: #{00010203}
 		--assert #{010203} = remove b
@@ -911,6 +1228,44 @@ Red [
 		--assert #{000203} = head remove next #{00010203}
 	--test-- "remove-bin-4"
 		--assert #{0003} = head remove/part next #{00010203} 2
+
+    --test-- "remove-bin-5"                             ;-- issue #3369
+        a: to-binary [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: c': skip a 6
+        d: tail a
+        remove/part a 4
+        --assert same? c remove c'                      ;-- docstring says "returns on the same index"
+        --assert a = to-binary [5 6 7 8]
+        --assert c = to-binary []
+        --assert 7 = index? remove/part c d
+        --assert a = to-binary [5 6 7 8]
+        --assert c = to-binary []
+        --assert 3 = index? remove/part b c
+        --assert a = to-binary [5 6]
+        --assert b = to-binary []
+        --assert 7 = index? remove/part c a
+        --assert a = to-binary [5 6]
+        --assert b = to-binary []
+
+    --test-- "remove-vec-1"                             ;-- issue #3369
+        a: make vector! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: c': skip a 6
+        d: tail a
+        remove/part a 4
+        --assert same? c remove c'                      ;-- docstring says "returns on the same index"
+        --assert a = make vector! [5 6 7 8]
+        --assert c = make vector! []
+        --assert 7 = index? remove/part c d
+        --assert a = make vector! [5 6 7 8]
+        --assert c = make vector! []
+        --assert 3 = index? remove/part b c
+        --assert a = make vector! [5 6]
+        --assert b = make vector! []
+        --assert 7 = index? remove/part c a
+        --assert a = make vector! [5 6]
+        --assert b = make vector! []
 
 ===end-group===
 
@@ -966,6 +1321,19 @@ Red [
 		--assert empty? clear #{0102}
 	--test-- "clear-12"
 		--assert #{01} = head clear next #{010203}
+
+    --test-- "clear-13"                                 ;-- issue #3369
+        a: "12345678"
+        b: skip a 2
+        c: skip b 4
+        --assert 3 = index? clear b
+        --assert 3 = index? b
+        --assert 7 = index? clear c
+        --assert 7 = index? c
+        --assert a = "12"
+        --assert b = ""
+        --assert c = ""
+
 ===end-group===
 
 ===start-group=== "at"
@@ -1017,21 +1385,63 @@ Red [
 		code: [print "Hello"]
 		--assert 'print = first replace code "Hello" "Cheers"
 		--assert "Cheers" = second code
-	--test-- "replace-str"
+
+    --test-- "replace-block-2"                          ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        --assert [] = replace/all b 7 9
+        --assert [5 6 7 8] = a
+        --assert [5 6 9 8] = replace/all a 7 9
+
+    --test-- "replace-hash-1"                           ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        --assert (make hash! []) = replace/all b 7 9
+        --assert (make hash! [5 6 7 8]) = a
+        --assert (make hash! [5 6 9 8]) = replace/all a 7 9
+
+    --test-- "replace-vector-1"                         ;-- issue #3369
+        a: make vector! [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        --assert (make vector! []) = replace/all b 7 9
+        --assert (make vector! [5 6 7 8]) = a
+        --assert (make vector! [5 6 9 8]) = replace/all a 7 9
+
+	--test-- "replace-str-1"
 		--assert "Xbab" = replace "abab" #"a" #"X"
 		--assert "XbXb" = replace/all "abab" #"a" #"X"
 		--assert "Xab" = replace "abab" "ab" "X"
 		--assert "abab" = replace/all "abab" #"a" #"a"
 
-	--test-- "replace-bin"
+    --test-- "replace-str-2"                            ;-- issue #3369
+        a: "12345678"
+        b: skip a 6
+        remove/part a 4
+        --assert "" = replace/all b "7" "9"
+        --assert "5678" = a
+        --assert "5698" = replace/all a "7" "9"
+        ; --assert "5998" = replace/all a 6 9
+    
+	--test-- "replace-bin-1"
 		--assert #{FF0201} = replace #{010201} #{01} #{FF}
 		--assert #{FF02FF} = replace/all #{010201} #{01} #{FF}
 		--assert #{FF03}   = replace #{010203} #{0102} #{FF}
 		--assert #{FFFFFF03} = replace #{010203} #{0102} #{FFFFFF}
 
+    --test-- "replace-bin-2"                            ;-- issue #3369
+        a: to-binary [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        --assert #{} = replace/all b #{07} #{09}
+        --assert (to-binary [5 6 7 8]) = a
+        --assert (to-binary [5 6 9 8]) = replace/all a #{07} #{09}
+
 	--test-- "replace-bitset-issue-#3132"
 		--assert "s" = replace/all "test" charset [#"t" #"e"] ""
-	
+
 ===end-group===
 
 ===start-group=== "max/min"			;-- have some overlap with lesser tests
@@ -1079,6 +1489,22 @@ Red [
 		s: "abcdef"
 		p: next next next s
 		--assert "cbadef" = reverse/part s p
+
+    --test-- "reverse-str-6"                            ;-- issue #3369
+        a: "12345678"
+        b: skip a 2
+        c: c': skip a 6
+        remove/part a 4
+        --assert 7 = index? reverse c                   ;-- docstring says "returns at same position"
+        --assert same? c' reverse c
+        --assert c = ""
+        --assert a = "5678"
+        --assert "87" = reverse b
+        --assert a = "5687"
+        --assert "78" = reverse/part b c
+        --assert 7 = index? c
+        --assert 3 = index? b
+        --assert a = "5678"
 
 	--test-- "reverse-file-1"			;-- inherit from string!
 		--assert %321cba = reverse/part %abc123 6
@@ -1162,10 +1588,77 @@ Red [
 		--assert b = c: take/deep a
 		--assert b <> remove c
 
-	--test-- "take-blk-5"
+	--test-- "take-blk-10"
 		a: [1 2 3]
 		--assert [1 2 3] = take/part a 22
 		--assert [] = a
+
+    --test-- "take-blk-11"                              ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert none? take c
+        --assert [] = take/part c d
+        --assert [] = take/part d c
+        --assert none? take/last c
+        --assert [7 8] = take/part c b
+        --assert 7 = index? c
+        --assert [] = take/part b c
+        --assert [5 6 7 8] = append a [7 8]
+        --assert [7 8] = take/part b c
+        --assert [5 6] = a
+        --assert 6 = take/last a
+
+    --test-- "take-blk-12"                              ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert [] = take/part/last c d
+        --assert [] = take/part/last d c
+        --assert [] = take/part/last b c
+        --assert [] = take/part/last c b
+        --assert [] = take/part/last a d
+        --assert [] = take/part/last d a
+        --assert [7 8] = take/part/last b a
+        --assert [5 6 7 8] = append a [7 8]
+        --assert [7 8] = take/part/last a b
+        --assert [5 6 7 8] = append a [7 8]
+        --assert [7 8] = take/part/last a 2
+        --assert [5 6 7 8] = append a [7 8]
+        --assert [7 8] = take/part/last c 2
+        --assert [] = take/part/last c 0
+        --assert [] = take/part/last c -2
+        --assert [] = take/part/last b -2
+        --assert [] = take/part/last a -2
+        --assert 7 = index? c
+
+    --test-- "take-blk-13"                              ;-- issue #4078
+        --assert [     ] = take/part      s: [1 2 3]    -1
+        --assert [1    ] = take/part skip s: [1 2 3] 1  -1
+        --assert [2    ] = take/part skip s: [1 2 3] 2  -1
+        --assert [3    ] = take/part skip s: [1 2 3] 3  -1
+        --assert [1    ] = take/part skip s: [1 2 3] 1  -2
+        --assert [1 2  ] = take/part skip s: [1 2 3] 2  -2
+        --assert [2 3  ] = take/part skip s: [1 2 3] 3  -2
+        --assert [1    ] = take/part skip s: [1 2 3] 1  -3
+        --assert [1 2  ] = take/part skip s: [1 2 3] 2  -3
+        --assert [1 2 3] = take/part skip s: [1 2 3] 3  -3
+        --assert [1    ] = take/part      s: [1 2 3]    skip s 1
+        --assert [1    ] = take/part skip s: [1 2 3] 1       s
+        --assert [2    ] = take/part skip s: [1 2 3] 1  skip s 2
+        --assert [2    ] = take/part skip s: [1 2 3] 2  skip s 1
+        --assert [3    ] = take/part skip s: [1 2 3] 2  skip s 3
+        --assert [3    ] = take/part skip s: [1 2 3] 3  skip s 2
+        --assert [1 2  ] = take/part      s: [1 2 3]    skip s 2
+        --assert [1 2  ] = take/part skip s: [1 2 3] 2       s
+        --assert [2 3  ] = take/part skip s: [1 2 3] 1  skip s 3
+        --assert [2 3  ] = take/part skip s: [1 2 3] 3  skip s 1
+        --assert [1 2 3] = take/part      s: [1 2 3]    skip s 3
+        --assert [1 2 3] = take/part skip s: [1 2 3] 3       s
 
 	--test-- "take-str-1"
 		a: "123"
@@ -1215,6 +1708,72 @@ Red [
 		--assert "123" = take/part a 22
 		--assert "" = a
 
+    --test-- "take-str-11"                              ;-- issue #3369
+        a: "12345678"
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert none? take c
+        --assert "" = take/part c d
+        --assert "" = take/part d c
+        --assert none? take/last c
+        --assert "78" = take/part c b
+        --assert 7 = index? c
+        --assert "5678" = append a "78"
+        --assert "78" = take/part b c
+        --assert "56" = a
+        --assert #"6" = take/last a
+
+    --test-- "take-str-12"                              ;-- issue #3369
+        a: "12345678"
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert "" = take/part/last c d
+        --assert "" = take/part/last d c
+        --assert "" = take/part/last b c
+        --assert "" = take/part/last c b
+        --assert "" = take/part/last a d
+        --assert "" = take/part/last d a
+        --assert "78" = take/part/last b a
+        --assert "5678" = append a "78"
+        --assert "78" = take/part/last a b
+        --assert "5678" = append a "78"
+        --assert "78" = take/part/last a 2
+        --assert "5678" = append a "78"
+        --assert "78" = take/part/last c 2
+        --assert "" = take/part/last c 0
+        --assert "" = take/part/last c -2
+        --assert "" = take/part/last b -2
+        --assert "" = take/part/last a -2
+        --assert 7 = index? c
+
+    --test-- "take-str-13"                              ;-- issue #4078
+        --assert ""    = take/part      s: "123"    -1
+        --assert "1"   = take/part skip s: "123" 1  -1
+        --assert "2"   = take/part skip s: "123" 2  -1
+        --assert "3"   = take/part skip s: "123" 3  -1
+        --assert "1"   = take/part skip s: "123" 1  -2
+        --assert "12"  = take/part skip s: "123" 2  -2
+        --assert "23"  = take/part skip s: "123" 3  -2
+        --assert "1"   = take/part skip s: "123" 1  -3
+        --assert "12"  = take/part skip s: "123" 2  -3
+        --assert "123" = take/part skip s: "123" 3  -3
+        --assert "1"   = take/part      s: "123"    skip s 1
+        --assert "1"   = take/part skip s: "123" 1       s
+        --assert "2"   = take/part skip s: "123" 1  skip s 2
+        --assert "2"   = take/part skip s: "123" 2  skip s 1
+        --assert "3"   = take/part skip s: "123" 2  skip s 3
+        --assert "3"   = take/part skip s: "123" 3  skip s 2
+        --assert "12"  = take/part      s: "123"    skip s 2
+        --assert "12"  = take/part skip s: "123" 2       s
+        --assert "23"  = take/part skip s: "123" 1  skip s 3
+        --assert "23"  = take/part skip s: "123" 3  skip s 1
+        --assert "123" = take/part      s: "123"    skip s 3
+        --assert "123" = take/part skip s: "123" 3       s
+
 	--test-- "take-hash-1"
 		h: make hash! [1 2 3]
 		--assert 1 = take h
@@ -1230,6 +1789,78 @@ Red [
 		h: make hash! [1 2 3]
 		--assert 2 = take next h
 		--assert 3 = select h 1
+
+    --test-- "take-hash-4"
+        a: make hash! [1 2 3]
+        --assert none? take tail a
+        --assert (make hash! []) = take/part tail a tail a
+
+    --test-- "take-hash-5"                              ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert none? take c
+        --assert (make hash! []) = take/part c d
+        --assert (make hash! []) = take/part d c
+        --assert none? take/last c
+        --assert (make hash! [7 8]) = take/part c b
+        --assert 7 = index? c
+        --assert (make hash! [5 6 7 8]) = append a make hash! [7 8]
+        --assert (make hash! [7 8]) = take/part b c
+        --assert (make hash! [5 6]) = a
+        --assert 6 = take/last a
+        --assert (make hash! [5]) = a
+
+    --test-- "take-hash-6"                              ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert (make hash! []) = take/part/last c d
+        --assert (make hash! []) = take/part/last d c
+        --assert (make hash! []) = take/part/last b c
+        --assert (make hash! []) = take/part/last c b
+        --assert (make hash! []) = take/part/last a d
+        --assert (make hash! []) = take/part/last d a
+        --assert (make hash! [7 8]) = take/part/last b a
+        --assert (make hash! [5 6 7 8]) = append a make hash! [7 8]
+        --assert (make hash! [7 8]) = take/part/last a b
+        --assert (make hash! [5 6 7 8]) = append a make hash! [7 8]
+        --assert (make hash! [7 8]) = take/part/last a 2
+        --assert (make hash! [5 6 7 8]) = append a make hash! [7 8]
+        --assert (make hash! [7 8]) = take/part/last c 2
+        --assert (make hash! []) = take/part/last c 0
+        --assert (make hash! []) = take/part/last c -2
+        --assert (make hash! []) = take/part/last b -2
+        --assert (make hash! []) = take/part/last a -2
+        --assert 7 = index? c
+
+    --test-- "take-hash-7"                              ;-- issue #4078
+        --assert (make hash! [     ]) = take/part      s: make hash! [1 2 3]    -1
+        --assert (make hash! [1    ]) = take/part skip s: make hash! [1 2 3] 1  -1
+        --assert (make hash! [2    ]) = take/part skip s: make hash! [1 2 3] 2  -1
+        --assert (make hash! [3    ]) = take/part skip s: make hash! [1 2 3] 3  -1
+        --assert (make hash! [1    ]) = take/part skip s: make hash! [1 2 3] 1  -2
+        --assert (make hash! [1 2  ]) = take/part skip s: make hash! [1 2 3] 2  -2
+        --assert (make hash! [2 3  ]) = take/part skip s: make hash! [1 2 3] 3  -2
+        --assert (make hash! [1    ]) = take/part skip s: make hash! [1 2 3] 1  -3
+        --assert (make hash! [1 2  ]) = take/part skip s: make hash! [1 2 3] 2  -3
+        --assert (make hash! [1 2 3]) = take/part skip s: make hash! [1 2 3] 3  -3
+        --assert (make hash! [1    ]) = take/part      s: make hash! [1 2 3]    skip s 1
+        --assert (make hash! [1    ]) = take/part skip s: make hash! [1 2 3] 1       s
+        --assert (make hash! [2    ]) = take/part skip s: make hash! [1 2 3] 1  skip s 2
+        --assert (make hash! [2    ]) = take/part skip s: make hash! [1 2 3] 2  skip s 1
+        --assert (make hash! [3    ]) = take/part skip s: make hash! [1 2 3] 2  skip s 3
+        --assert (make hash! [3    ]) = take/part skip s: make hash! [1 2 3] 3  skip s 2
+        --assert (make hash! [1 2  ]) = take/part      s: make hash! [1 2 3]    skip s 2
+        --assert (make hash! [1 2  ]) = take/part skip s: make hash! [1 2 3] 2       s
+        --assert (make hash! [2 3  ]) = take/part skip s: make hash! [1 2 3] 1  skip s 3
+        --assert (make hash! [2 3  ]) = take/part skip s: make hash! [1 2 3] 3  skip s 1
+        --assert (make hash! [1 2 3]) = take/part      s: make hash! [1 2 3]    skip s 3
+        --assert (make hash! [1 2 3]) = take/part skip s: make hash! [1 2 3] 3       s
 
 	--test-- "take-bin-1"
 		b: #{0102}
@@ -1274,6 +1905,93 @@ Red [
 		--assert #{0203} = take/part/last b next b
 		--assert #{01} = b
 
+    --test-- "take-bin-10"                              ;-- issue #3369
+        a: make binary! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert none? take c
+        --assert (make binary! []) = take/part c d
+        --assert (make binary! []) = take/part d c
+        --assert none? take/last c
+        --assert (make binary! [7 8]) = take/part c b
+        --assert 7 = index? c
+        --assert (make binary! [5 6 7 8]) = append a make binary! [7 8]
+        --assert (make binary! [7 8]) = take/part b c
+        --assert (make binary! [5 6]) = a
+        --assert 6 = take/last a
+        --assert (make binary! [5]) = a
+
+    --test-- "take-bin-11"                              ;-- issue #3369
+        a: make binary! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert (make binary! []) = take/part/last c d
+        --assert (make binary! []) = take/part/last d c
+        --assert (make binary! []) = take/part/last b c
+        --assert (make binary! []) = take/part/last c b
+        --assert (make binary! []) = take/part/last a d
+        --assert (make binary! []) = take/part/last d a
+        --assert (make binary! [7 8]) = take/part/last b a
+        --assert (make binary! [5 6 7 8]) = append a make binary! [7 8]
+        --assert (make binary! [7 8]) = take/part/last a b
+        --assert (make binary! [5 6 7 8]) = append a make binary! [7 8]
+        --assert (make binary! [7 8]) = take/part/last a 2
+        --assert (make binary! [5 6 7 8]) = append a make binary! [7 8]
+        --assert (make binary! [7 8]) = take/part/last c 2
+        --assert (make binary! []) = take/part/last c 0
+        --assert (make binary! []) = take/part/last c -2
+        --assert (make binary! []) = take/part/last b -2
+        --assert (make binary! []) = take/part/last a -2
+        --assert 7 = index? c
+
+    ;@@ FIXME: no vector support
+    ; --test-- "take-vector-1"
+    ;     a: make vector! [1 2 3 4 5 6 7 8]
+    ;     b: skip a 2
+    ;     c: skip a 6
+    ;     d: tail a
+    ;     remove/part a 4
+    ;     --assert none? take c
+    ;     --assert none? take/part c d
+    ;     --assert none? take/part d c
+    ;     --assert none? take/last c
+    ;     --assert none? take/part c b
+    ;     --assert 7 = index? c
+    ;     --assert (make vector! [5 6 7 8]) = append a make vector! [7 8]
+    ;     --assert (make vector! [7 8]) = take/part b c
+    ;     --assert (make vector! [5 6]) = a
+    ;     --assert 6 = take/last a
+    ;     --assert (make vector! [5]) = a
+
+    ; --test-- "take-vector-2"
+    ;     a: make vector! [1 2 3 4 5 6 7 8]
+    ;     b: skip a 2
+    ;     c: skip a 6
+    ;     d: tail a
+    ;     remove/part a 4
+    ;     --assert (make vector! []) = take/part/last c d
+    ;     --assert (make vector! []) = take/part/last d c
+    ;     --assert (make vector! []) = take/part/last b c
+    ;     --assert (make vector! []) = take/part/last c b
+    ;     --assert (make vector! []) = take/part/last a d
+    ;     --assert (make vector! []) = take/part/last d a
+    ;     --assert (make vector! [7 8]) = take/part/last b a
+    ;     --assert (make vector! [5 6 7 8]) = append a make vector! [7 8]
+    ;     --assert (make vector! [7 8]) = take/part/last a b
+    ;     --assert (make vector! [5 6 7 8]) = append a make vector! [7 8]
+    ;     --assert (make vector! [7 8]) = take/part/last a 2
+    ;     --assert (make vector! [5 6 7 8]) = append a make vector! [7 8]
+    ;     --assert (make vector! [7 8]) = take/part/last c 2
+    ;     --assert (make vector! []) = take/part/last c 0
+    ;     --assert (make vector! []) = take/part/last c -2
+    ;     --assert (make vector! []) = take/part/last b -2
+    ;     --assert (make vector! []) = take/part/last a -2
+    ;     --assert 7 = index? c
+
 ===end-group===
 
 ===start-group=== "swap"
@@ -1298,6 +2016,19 @@ Red [
 	--test-- "swap-str-4"
 		--assert "123" = swap "123" ""
 
+    --test-- "swap-str-5"                               ;-- issue #3369
+        a: "12345678"
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert "" = swap c d
+        --assert "" = swap c b
+        --assert "5678" = swap a c
+        --assert "5678" = swap a d
+        --assert   "58" = swap b a
+        --assert "5678" = swap a b
+
 	--test-- "swap-blk-1"
 		a: [1 2]
 		b: [a b]
@@ -1315,6 +2046,19 @@ Red [
 	--test-- "swap-blk-3"
 		--assert [1 a] = swap [1 a] []
 
+    --test-- "swap-blk-4"                               ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert [] = swap c d
+        --assert [] = swap c b
+        --assert [5 6 7 8] = swap a c
+        --assert [5 6 7 8] = swap a d
+        --assert     [5 8] = swap b a
+        --assert [5 6 7 8] = swap a b
+
 	--test-- "swap-hash-1"
 		a: make hash! [1 2]
 		b: make hash! [a b]
@@ -1322,13 +2066,53 @@ Red [
 		--assert 2 = a/a
 		--assert 'b = select b 1
 
-	--test-- "swap-bin"
+    --test-- "swap-hash-2"                              ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert (make hash! []) = swap c d
+        --assert (make hash! []) = swap c b
+        --assert (make hash! [5 6 7 8]) = swap a c
+        --assert (make hash! [5 6 7 8]) = swap a d
+        --assert (make hash!     [5 8]) = swap b a
+        --assert (make hash! [5 6 7 8]) = swap a b
+
+	--test-- "swap-bin-1"
 		a: #{0102}
 		b: #{0304}					;-- 𠃌 = #"^(200CC)"
 		--assert #{0302} = swap a b
 		--assert #{0302} = a
 		--assert #{0104} = b
 		--assert #{0104} = swap b #{}
+
+    --test-- "swap-bin-2"                               ;-- issue #3369
+        a: make binary! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert (make binary! []) = swap c d
+        --assert (make binary! []) = swap c b
+        --assert (make binary! [5 6 7 8]) = swap a c
+        --assert (make binary! [5 6 7 8]) = swap a d
+        --assert (make binary!     [5 8]) = swap b a
+        --assert (make binary! [5 6 7 8]) = swap a b
+
+    ;@@FIXME: no vector support
+    ; --test-- "swap-vector-1"
+    ;     a: make vector! [1 2 3 4 5 6 7 8]
+    ;     b: skip a 2
+    ;     c: skip a 6
+    ;     d: tail a
+    ;     remove/part a 4
+    ;     --assert (make vector! []) = swap c d
+    ;     --assert (make vector! []) = swap c b
+    ;     --assert (make vector! [5 6 7 8]) = swap a c
+    ;     --assert (make vector! [5 6 7 8]) = swap a d
+    ;     --assert (make vector!     [5 8]) = swap b a
+    ;     --assert (make vector! [5 6 7 8]) = swap a b
 
 ===end-group===
 
@@ -1370,8 +2154,50 @@ Red [
 	--test-- "trim-str-11"
 		--assert "    ^-1^/    b2^-  ^/  c3  ^/  ^/^/" = trim/with copy mstr 97
 
+    --test-- "trim-str-12"                              ;-- issue #3369
+        a: " 2 4 6 8"
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert ""   = trim d
+        --assert ""   = trim c
+        --assert "8"  = trim b
+        --assert 3    = index? b
+        --assert " 68"= a
+        --assert "68" = trim a
+        --assert "68" = a
+
+    --test-- "trim-str-13"                              ;-- issue #3369
+        a: " 2 4 6 8"
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert ""   = trim/with d "1234"
+        --assert 9    = index? d
+        --assert " 6 8" = trim/with a c
+        --assert " 6 8" = a
+        --assert 7    = index? c
+        --assert "46" = trim/with "468" b
+        --assert 3    = index? b
+
 	--test-- "trim-block-1"
 		--assert [1 2] = trim [#[none] 1 #[none] 2 #[none]]
+
+    --test-- "trim-block-2"                             ;-- issue #3369
+        a: reduce [none 2 none 4 none 6 none 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert []   = trim d
+        --assert []   = trim c
+        --assert [8]  = trim b
+        --assert 3    = index? b
+        --assert [#[none] 6 8] = a
+        --assert [6 8] = trim a
+        --assert [6 8] = a
 
 	--test-- "trim-bin-1"
 		--assert #{} = trim #{00}
@@ -1384,6 +2210,35 @@ Red [
 
 	--test-- "trim-bin-4"
 		--assert #{00001234} = trim/tail #{000012340000}
+
+    --test-- "trim-bin-5"                               ;-- issue #3369
+        a: #{00 02 00 04 00 06 00 08}
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert #{}   = trim d
+        --assert #{}   = trim c
+        --assert #{08} = trim b
+        --assert 3     = index? b
+        --assert #{000608} = a
+        --assert #{0608}   = trim a
+        --assert #{0608}   = a
+
+    --test-- "trim-bin-6"                               ;-- issue #3369
+        a: #{00 02 00 04 00 06 00 08}
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert #{}  = trim/with d #{0a0b0c0d}
+        --assert 9    = index? d
+        --assert #{00060008} = trim/with a c
+        --assert #{00060008} = a
+        --assert 7    = index? c
+        --assert #{0406} = trim/with #{040608} b
+        --assert 3    = index? b
+
 ===end-group===
 
 ===start-group=== "sort"
@@ -1407,6 +2262,39 @@ Red [
 		--assert "1cd2ab3ef4gh" = sort/skip a 3
 		--assert "12abcd3ef4gh" = sort/part a 6
 		--assert "34efgh" = sort/part skip a 6 tail a
+
+    --test-- "sort-str-5"                               ;-- issue #3369
+        a: "12345678"
+        b: skip a 2
+        c: skip a 6
+        remove/part a 4
+        --assert "" = sort c
+        --assert 7 = index? c
+        --assert "87"   = sort/reverse b
+        --assert "5687" = a
+        --assert "8765" = sort/reverse a
+        --assert "56"   = sort/part c b
+        --assert "65"   = sort/part/reverse b c
+        --assert "7865" = sort/part b -2
+        --assert "7865" = a
+
+    --test-- "sort-str-6"                               ;-- issue #4083
+        --assert "4321" = sort/part skip s: "4321" -100 s
+        --assert "4321" = sort/part skip s: "4321" 0 s
+        --assert "4321" = sort/part skip s: "4321" 1 s
+        --assert "3421" = sort/part skip s: "4321" 2 s
+        --assert "2341" = sort/part skip s: "4321" 3 s
+        --assert "1234" = sort/part skip s: "4321" 4 s
+        --assert "1234" = sort/part skip s: "4321" 100 s
+
+    --test-- "sort-str-7"                               ;-- issue #4083
+        --assert   "12" = sort/part skip s: "4321" 2 100
+        --assert   "12" = sort/part skip s: "4321" 2 2
+        --assert   "21" = sort/part skip s: "4321" 2 1
+        --assert   "21" = sort/part skip s: "4321" 2 0
+        --assert  "321" = sort/part skip s: "4321" 2 -1
+        --assert "3421" = sort/part skip s: "4321" 2 -2
+        --assert "3421" = sort/part skip s: "4321" 2 -100
 
 	--test-- "sort-blk-1"
 		a: [bc 799 ab2 42 bb1 321.3 "Mo" "Curly" "Larry" -24 0 321.8] 
@@ -1448,6 +2336,90 @@ Red [
 		--assert [1 2 3 4 5 6] = sort/compare [1 2 3 4 5 6] func [a b] [a < b]
 		--assert [6 5 4 3 2 1] = sort/compare [1 2 3 4 5 6] func [a b] [a > b]
 		
+    --test-- "sort-blk-5"                               ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        remove/part a 4
+        --assert [] = sort c
+        --assert 7 = index? c
+        --assert [8 7]     = sort/reverse b
+        --assert [5 6 8 7] = a
+        --assert [8 7 6 5] = sort/reverse a
+        --assert [5 6]     = sort/part c b
+        --assert [6 5]     = sort/part/reverse b c
+        --assert 3 = index? b
+        --assert [7 8 6 5] = sort/part b -2
+        --assert [7 8 6 5] = a
+
+    --test-- "sort-blk-6"                               ;-- issue #4083
+        --assert [4 3 2 1] = sort/part skip s: [4 3 2 1] -100 s
+        --assert [4 3 2 1] = sort/part skip s: [4 3 2 1] 0 s
+        --assert [4 3 2 1] = sort/part skip s: [4 3 2 1] 1 s
+        --assert [3 4 2 1] = sort/part skip s: [4 3 2 1] 2 s
+        --assert [2 3 4 1] = sort/part skip s: [4 3 2 1] 3 s
+        --assert [1 2 3 4] = sort/part skip s: [4 3 2 1] 4 s
+        --assert [1 2 3 4] = sort/part skip s: [4 3 2 1] 100 s
+
+    --test-- "sort-blk-7"                               ;-- issue #4083
+        --assert [    1 2] = sort/part skip s: [4 3 2 1] 2 100
+        --assert [    1 2] = sort/part skip s: [4 3 2 1] 2 2
+        --assert [    2 1] = sort/part skip s: [4 3 2 1] 2 1
+        --assert [    2 1] = sort/part skip s: [4 3 2 1] 2 0
+        --assert [  3 2 1] = sort/part skip s: [4 3 2 1] 2 -1
+        --assert [3 4 2 1] = sort/part skip s: [4 3 2 1] 2 -2
+        --assert [3 4 2 1] = sort/part skip s: [4 3 2 1] 2 -100
+
+    --test-- "sort-hash-1"                              ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        remove/part a 4
+        --assert (make hash! []) = sort c
+        --assert 7 = index? c
+        --assert (make hash! [8 7]    ) = sort/reverse b
+        --assert (make hash! [5 6 8 7]) = a
+        --assert (make hash! [8 7 6 5]) = sort/reverse a
+        --assert (make hash! [5 6]    ) = sort/part c b
+        --assert (make hash! [6 5]    ) = sort/part/reverse b c
+        --assert 3 = index? b
+        --assert (make hash! [7 8 6 5]) = sort/part b -2
+        --assert (make hash! [7 8 6 5]) = a
+
+    --test-- "sort-hash-2"                              ;-- issue #4083
+        --assert (make hash! [4 3 2 1]) = sort/part skip s: make hash! [4 3 2 1] -100 s
+        --assert (make hash! [4 3 2 1]) = sort/part skip s: make hash! [4 3 2 1] 0 s
+        --assert (make hash! [4 3 2 1]) = sort/part skip s: make hash! [4 3 2 1] 1 s
+        --assert (make hash! [3 4 2 1]) = sort/part skip s: make hash! [4 3 2 1] 2 s
+        --assert (make hash! [2 3 4 1]) = sort/part skip s: make hash! [4 3 2 1] 3 s
+        --assert (make hash! [1 2 3 4]) = sort/part skip s: make hash! [4 3 2 1] 4 s
+        --assert (make hash! [1 2 3 4]) = sort/part skip s: make hash! [4 3 2 1] 100 s
+
+    --test-- "sort-hash-3"                              ;-- issue #4083
+        --assert (make hash! [    1 2]) = sort/part skip s: make hash! [4 3 2 1] 2 100
+        --assert (make hash! [    1 2]) = sort/part skip s: make hash! [4 3 2 1] 2 2
+        --assert (make hash! [    2 1]) = sort/part skip s: make hash! [4 3 2 1] 2 1
+        --assert (make hash! [    2 1]) = sort/part skip s: make hash! [4 3 2 1] 2 0
+        --assert (make hash! [  3 2 1]) = sort/part skip s: make hash! [4 3 2 1] 2 -1
+        --assert (make hash! [3 4 2 1]) = sort/part skip s: make hash! [4 3 2 1] 2 -2
+        --assert (make hash! [3 4 2 1]) = sort/part skip s: make hash! [4 3 2 1] 2 -100
+
+    --test-- "sort-vector-1"                            ;-- issue #3369
+        a: make vector! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        remove/part a 4
+        --assert (make vector! []) = sort c
+        --assert 7 = index? c
+        --assert (make vector! [8 7]    ) = sort/reverse b
+        --assert (make vector! [5 6 8 7]) = a
+        --assert (make vector! [8 7 6 5]) = sort/reverse a
+        --assert (make vector! [5 6]    ) = sort/part c b
+        --assert (make vector! [6 5]    ) = sort/part/reverse b c
+        --assert 3 = index? b
+        --assert (make vector! [7 8 6 5]) = sort/part b -2
+        --assert (make vector! [7 8 6 5]) = a
+
 ===end-group===
 
 ===start-group=== "path access"	
@@ -1484,15 +2456,63 @@ Red [
 
 ===start-group=== "set operations"	
 
-	--test-- "set-op-blk"
-		a: [1 3 2 4]
-		b: [3 4 5 4 6]
-		--assert [3 4 5 6]		= unique b
-		--assert [1 3 2 4 5 6]	= union a b
-		--assert [3 4]			= intersect a b
-		--assert [1 2 5 6]		= difference a b
-		--assert [1 2]			= exclude a b
-		--assert [5 6]			= exclude b a
+    --test-- "set-op-blk"
+        a: [1 3 2 4]
+        b: [3 4 5 4 6]
+        --assert [3 4 5 6]      = unique b
+        --assert [1 3 2 4 5 6]  = union a b
+        --assert [3 4]          = intersect a b
+        --assert [1 2 5 6]      = difference a b
+        --assert [1 2]          = exclude a b
+        --assert [5 6]          = exclude b a
+
+    --test-- "set-op-blk-2"
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        remove/part a 4
+        --assert []        = unique c
+        --assert [7 8]     = unique b
+        --assert [5 6 7 8] = unique a
+        --assert [5 6 7 8] = union a b
+        --assert [7 8]     = union c b
+        --assert [7 8]     = intersect a b
+        --assert [7 8]     = intersect b a
+        --assert [5 6]     = difference a b
+        --assert [5 6]     = difference b a
+        --assert [5 6]     = exclude a b
+        --assert []        = exclude b a
+
+    ;@@ FIXME: #4086
+    ; --test-- "set-op-hash-1"
+    ;     a: make hash! [5 6 7 8]
+    ;     b: skip a 2
+    ;     --assert (make hash! [7 8]    ) = unique b
+    ;     --assert (make hash! [5 6 7 8]) = unique a
+    ;     --assert (make hash! [5 6 7 8]) = union a b
+    ;     --assert (make hash! [7 8]    ) = intersect a b
+    ;     --assert (make hash! [7 8]    ) = intersect b a
+    ;     --assert (make hash! [5 6]    ) = difference a b
+    ;     --assert (make hash! [5 6]    ) = difference b a
+    ;     --assert (make hash! [5 6]    ) = exclude a b
+    ;     --assert (make hash! []       ) = exclude b a
+
+    ; --test-- "set-op-hash-2"
+    ;     a: make hash! [1 2 3 4 5 6 7 8]
+    ;     b: skip a 2
+    ;     c: skip a 6
+    ;     remove/part a 4
+    ;     --assert (make hash! []       ) = unique c
+    ;     --assert (make hash! [7 8]    ) = unique b
+    ;     --assert (make hash! [5 6 7 8]) = unique a
+    ;     --assert (make hash! [5 6 7 8]) = union a b
+    ;     --assert (make hash! [7 8]    ) = union c b
+    ;     --assert (make hash! [7 8]    ) = intersect a b
+    ;     --assert (make hash! [7 8]    ) = intersect b a
+    ;     --assert (make hash! [5 6]    ) = difference a b
+    ;     --assert (make hash! [5 6]    ) = difference b a
+    ;     --assert (make hash! [5 6]    ) = exclude a b
+    ;     --assert (make hash! []       ) = exclude b a
 
 	--test-- "set-op-str"
 		a: "CBAD"
@@ -1503,6 +2523,31 @@ Red [
 		--assert "BAEF"		= difference a b
 		--assert "BA"		= exclude a b
 		--assert "EF"		= exclude b a
+
+    --test-- "set-op-str-2"
+        --assert "" = intersect "" "a"
+        --assert "" = unique ""
+        --assert "" = union "" ""
+        --assert "" = intersect "" ""
+        --assert "" = difference "" ""
+        --assert "" = exclude "" ""
+
+    --test-- "set-op-str-3"
+        a: "12345678"
+        b: skip a 2
+        c: skip a 6
+        remove/part a 4
+        --assert ""     = unique c
+        --assert "78"   = unique b
+        --assert "5678" = unique a
+        --assert "5678" = union a b
+        --assert "78"   = union c b
+        --assert "78"   = intersect a b
+        --assert "78"   = intersect b a
+        --assert "56"   = difference a b
+        --assert "56"   = difference b a
+        --assert "56"   = exclude a b
+        --assert ""     = exclude b a
 
 	--test-- "set-op-bitset"
 		a: make bitset! [1 2 3 4]
@@ -1537,10 +2582,12 @@ Red [
 		blk1: change blk 6
 		--assert [2 3] = blk1
 		--assert 6 = first blk
+        --assert [6 2 3] = blk
 	--test-- "change-blk-2"
 		blk2: change blk1 [a b]
 		--assert empty? blk2
 		--assert 'a = first blk1
+        --assert [6 a b] = blk
 	--test-- "change-blk-3"
 		blk3: change blk1 [9 8 7 6 5 4 3]
 		--assert empty? blk3
@@ -1734,6 +2781,97 @@ Red [
 		--assert 5 = length? blk
 		--assert 'x = first blk
 
+    --test-- "change/part-blk-5"                        ;-- issue #4087
+        --assert []      = change/part b: [] b b
+        --assert [1 2 3] = change/part b: [1 2 3] tail b b
+        --assert [1 2 3] = b
+
+    --test-- "change/part-blk-6"                        ;-- issue #4088
+        --assert [1 2 3] = change/part b: [1 2 3] next b b
+        --assert [2 3 1 2 3] = b
+        --assert [2 3 1 2 3] = change/part b next b b
+        --assert [3 1 2 3 2 3 1 2 3] = b
+
+    --test-- "change/part-blk-7"                        ;-- issue #4088
+        --assert [3] = change/part next b: [1 2 3] b skip b 2
+        --assert [1 1 2 3 3] = b
+        --assert [5] = change/part next b: [1 2 3 4 5] skip b 3 skip b 4
+        --assert [1 4 5 5] = b
+
+    --test-- "change/part-blk-8"                        ;-- issue #4088
+        a: [x . . . . . . x]
+        --assert [. . . x] = change/part (skip a 2) a 2
+        --assert [x . x . . . . . . x . . . x] = a
+    --test-- "change/part-blk-9"                        ;-- issue #4088
+        a: [x . . . . . . x]
+        --assert [. . . . . x] = change/part a a 2
+        --assert [x . . . . . . x . . . . . x] = a
+    --test-- "change/part-blk-10"                       ;-- issue #4088
+        a: [x . . . . . . x]
+        --assert [. . . x] = change/part (skip a 2) as path! a 2
+        --assert [x . x . . . . . . x . . . x] = a
+    --test-- "change/part-blk-11"                       ;-- issue #4088
+        a: [x . . . . . . x]
+        --assert [. . . . . x] = change/part a as path! a 2
+        --assert [x . . . . . . x . . . . . x] = a
+
+    --test-- "change/part-blk-12"                       ;-- issue #4088
+        a: [x . . . . x]
+        --assert [. x] = change/part/dup (skip a 2) a 2 2
+        --assert [x . x . . . . x x . . . . x . x] = a
+    --test-- "change/part-blk-13"                       ;-- issue #4088
+        a: [x . . . . x]
+        --assert [. . . x] = change/part/dup a a 2 2
+        --assert [x . . . . x x . . . . x . . . x] = a
+    --test-- "change/part-blk-14"                       ;-- issue #4088
+        a: [x . . . . x]
+        --assert [. x] = change/part/dup (skip a 2) as path! a 2 2
+        --assert [x . x . . . . x x . . . . x . x] = a
+    --test-- "change/part-blk-15"                       ;-- issue #4088
+        a: [x . . . . x]
+        --assert [. . . x] = change/part/dup a as path! a 2 2
+        --assert [x . . . . x x . . . . x . . . x] = a
+
+    --test-- "change/part-blk-16"                       ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert []            = change/part c b 2
+        --assert [7 8 7 8]     = b
+        --assert [5 6 7 8 7 8] = a
+        --assert []            = change/part skip b 2 c 20
+        --assert [7 8]         = b
+        --assert [5 6 7 8]     = a
+        --assert []            = change/part c b b
+        --assert [7 8]         = b
+        --assert [5 6 7 8]     = a
+
+    --test-- "change/part-blk-17"                       ;-- issue #3369
+        a: [0 0 1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 6
+        --assert []                = change/part/dup c b 2 2
+        --assert [7 8 7 8 7 8]     = b
+        --assert [5 6 7 8 7 8 7 8] = a
+        --assert []                = change/part/dup skip b 2 d 20 300
+        --assert [7 8]             = b
+        --assert [5 6 7 8]         = a
+        --assert []                = change/part/dup c b b 3
+        --assert [7 8 7 8 7 8]     = b
+        --assert [5 6 7 8 7 8 7 8] = a
+
+    --test-- "change/part-blk-18"                       ;-- issue #4088
+        --assert [e]   = change/part/dup s: [a b c d e] [!] 4 0
+        --assert [e]   = s
+        --assert [e]   = change/part/dup s: [a b c d e] [!] 4 -1
+        --assert [e]   = s
+        --assert [e]   = change/part/dup skip s: [a b c d e] 4 [!] -3 0
+        --assert [a e] = s
+
 	--test-- "change/part-str-1"
 		str: "1234"
 		str1: change/part str #"x" 3
@@ -1757,6 +2895,97 @@ Red [
 		--assert val = first str3
 		--assert 5 = length? str
 		--assert #"x" = first str
+
+    --test-- "change/part-str-5"                        ;-- issue #4087
+        --assert ""    = change/part s: "" s s
+        --assert "123" = change/part s: "123" tail s s
+        --assert "123" = s
+
+    --test-- "change/part-str-6"                        ;-- issue #4088
+        --assert "123" = change/part s: "123" next s s
+        --assert "23123" = s
+        --assert "23123" = change/part s next s s
+        --assert "312323123" = s
+
+    --test-- "change/part-str-7"                        ;-- issue #4088
+        --assert "3" = change/part next s: "123" s skip s 2
+        --assert "11233" = s
+        --assert "5" = change/part next s: "12345" skip s 3 skip s 4
+        --assert "1455" = s
+
+    --test-- "change/part-str-8"                        ;-- issue #4088
+        a: "[......]"
+        --assert "...]" = change/part (skip a 2) a 2
+        --assert "[.[......]...]" = a
+    --test-- "change/part-str-9"                        ;-- issue #4088
+        a: "[......]"
+        --assert ".....]" = change/part a a 2
+        --assert "[......].....]" = a
+    --test-- "change/part-str-10"                       ;-- issue #4088
+        a: "[......]"
+        --assert "...]" = change/part (skip a 2) as file! a 2
+        --assert "[.[......]...]" = a
+    --test-- "change/part-str-11"                       ;-- issue #4088
+        a: "[......]"
+        --assert ".....]" = change/part a as file! a 2
+        --assert "[......].....]" = a
+
+    --test-- "change/part-str-12"                       ;-- issue #4088
+        a: "[....]"
+        --assert ".]" = change/part/dup (skip a 2) a 2 2
+        --assert "[.[....][....].]" = a
+    --test-- "change/part-str-13"                       ;-- issue #4088
+        a: "[....]"
+        --assert "...]" = change/part/dup a a 2 2
+        --assert "[....][....]...]" = a
+    --test-- "change/part-str-14"                       ;-- issue #4088
+        a: "[....]"
+        --assert ".]" = change/part/dup (skip a 2) as file! a 2 2
+        --assert "[.[....][....].]" = a
+    --test-- "change/part-str-15"                       ;-- issue #4088
+        a: "[....]"
+        --assert "...]" = change/part/dup a as file! a 2 2
+        --assert "[....][....]...]" = a
+
+    --test-- "change/part-str-16"                       ;-- issue #3369
+        a: "12345678"
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert "" = change/part c b 2
+        --assert "7878" = b
+        --assert "567878" = a
+        --assert "" = change/part skip b 2 c 20
+        --assert "78" = b
+        --assert "5678" = a
+        --assert "" = change/part c b b
+        --assert "78" = b
+        --assert "5678" = a
+
+    --test-- "change/part-str-17"                       ;-- issue #3369
+        a: "0012345678"
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 6
+        --assert "" = change/part/dup c b 2 2
+        --assert "787878" = b
+        --assert "56787878" = a
+        --assert "" = change/part/dup skip b 2 d 20 300
+        --assert "78" = b
+        --assert "5678" = a
+        --assert "" = change/part/dup c b b 3
+        --assert "787878" = b
+        --assert "56787878" = a
+
+    --test-- "change/part-str-18"                       ;-- issue #4088
+        --assert "e" = change/part/dup s: "abcde" "!" 4 0
+        --assert "e" = s
+        --assert "e" = change/part/dup s: "abcde" "!" 4 -1
+        --assert "e" = s
+        --assert "e" = change/part/dup skip s: "abcde" 4 "!" -3 0
+        --assert "ae" = s
 
 	--test-- "change/part-bin-1"
 		bin: #{12345678}
@@ -1793,6 +3022,83 @@ Red [
 		--assert none = select hs 'x
 		--assert 'y = select hs 'p
 		--assert 3  = select hs 2
+
+    --test-- "change/part-hash-3"                       ;-- issue #4087
+        --assert (make hash! []     ) = change/part b: make hash! [] b b
+        --assert (make hash! [1 2 3]) = change/part b: make hash! [1 2 3] tail b b
+        --assert (make hash! [1 2 3]) = b
+
+    ;@@ FIXME: hash table troubles
+    ; --test-- "change/part-hash-4"                       ;-- issue #4088
+    ;     --assert (make hash! [1 2 3]) = probe change/part b: make hash! [1 2 3] next b b
+    ;     --assert (make hash! [2 3 1 2 3]) = probe b
+    ;     --assert (make hash! [2 3 1 2 3]) = probe change/part b next b b
+    ;     --assert (make hash! [3 1 2 3 2 3 1 2 3]) = probe b
+
+    --test-- "change/part-hash-5"                       ;-- issue #4088
+        --assert (make hash! [3]) = change/part next b: make hash! [1 2 3] b skip b 2
+        --assert (make hash! [1 1 2 3 3]) = b
+        --assert (make hash! [5]) = change/part next b: make hash! [1 2 3 4 5] skip b 3 skip b 4
+        --assert (make hash! [1 4 5 5]) = b
+
+    --test-- "change/part-hash-6"                        ;-- issue #4088
+        a: make hash! [x . . . . . . x]
+        --assert (make hash! [. . . x]) = change/part (skip a 2) a 2
+        --assert (make hash! [x . x . . . . . . x . . . x]) = a
+    --test-- "change/part-hash-7"                        ;-- issue #4088
+        a: make hash! [x . . . . . . x]
+        --assert (make hash! [. . . . . x]) = change/part a a 2
+        --assert (make hash! [x . . . . . . x . . . . . x]) = a
+
+    --test-- "change/part-hash-8"                       ;-- issue #4088
+        a: make hash! [x . . . . x]
+        --assert (make hash! [. x]) = change/part/dup (skip a 2) a 2 2
+        --assert (make hash! [x . x . . . . x x . . . . x . x]) = a
+    --test-- "change/part-hash-9"                       ;-- issue #4088
+        a: make hash! [x . . . . x]
+        --assert (make hash! [. . . x]) = change/part/dup a a 2 2
+        --assert (make hash! [x . . . . x x . . . . x . . . x]) = a
+
+    --test-- "change/part-hash-10"                      ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert (make hash! []           ) = change/part c b 2
+        --assert (make hash! [7 8 7 8]    ) = b
+        --assert (make hash! [5 6 7 8 7 8]) = a
+        --assert (make hash! []           ) = change/part skip b 2 c 20
+        --assert (make hash! [7 8]        ) = b
+        --assert (make hash! [5 6 7 8]    ) = a
+        --assert (make hash! []           ) = change/part c b b
+        --assert (make hash! [7 8]        ) = b
+        --assert (make hash! [5 6 7 8]    ) = a
+
+    --test-- "change/part-hash-11"                      ;-- issue #3369
+        a: make hash! [0 0 1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 6
+        --assert (make hash! []               ) = change/part/dup c b 2 2
+        --assert (make hash! [7 8 7 8 7 8]    ) = b
+        --assert (make hash! [5 6 7 8 7 8 7 8]) = a
+        --assert (make hash! []               ) = change/part/dup skip b 2 d 20 300
+        --assert (make hash! [7 8]            ) = b
+        --assert (make hash! [5 6 7 8]        ) = a
+        --assert (make hash! []               ) = change/part/dup c b b 3
+        --assert (make hash! [7 8 7 8 7 8]    ) = b
+        --assert (make hash! [5 6 7 8 7 8 7 8]) = a
+
+    --test-- "change/part-hash-12"                       ;-- issue #4088
+        --assert (make hash! [e]  ) = change/part/dup s: make hash! [a b c d e] [!] 4 0
+        --assert (make hash! [e]  ) = s
+        --assert (make hash! [e]  ) = change/part/dup s: make hash! [a b c d e] [!] 4 -1
+        --assert (make hash! [e]  ) = s
+        --assert (make hash! [e]  ) = change/part/dup skip s: make hash! [a b c d e] 4 make hash! [!] -3 0
+        --assert (make hash! [a e]) = s
+
 ===end-group===
 
 ===start-group=== "copy"
@@ -1807,7 +3113,7 @@ Red [
 		c2-a: next c2-a
 		--assert not equal? c2-a c2-b
 
-	--test-- "copy-3"
+	--test-- "copy-3"                                   ;-- issue #3369
 		a: "12345678"
 		b: skip a 6
 		c: tail a
@@ -1833,6 +3139,61 @@ Red [
 		--assert empty? copy/part a -4
 		--assert "3456" = copy/part b -4
 		--assert "123456" = copy/part b -10
+
+    --test-- "copy-5"                                   ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        c: tail a
+        d: skip a 2
+        remove/part a 4
+        --assert [5 6 7 8] = a
+        --assert empty? b
+        --assert empty? copy b
+        --assert empty? c
+        --assert empty? copy c
+        --assert [7 8] = d
+        --assert [7 8] = copy d
+        --assert [7 8] = copy/part d b
+        --assert [7 8] = copy/part b d
+        clear a
+        --assert empty? d
+        --assert empty? copy d
+        --assert empty? copy/part d b
+
+    --test-- "copy-6"
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        --assert empty? copy/part a -4
+        --assert [3 4 5 6] = copy/part b -4
+        --assert [1 2 3 4 5 6] = copy/part b -10
+
+    --test-- "copy-7"                                   ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        c: tail a
+        d: skip a 2
+        remove/part a 4
+        --assert (make hash! [5 6 7 8]) = a
+        --assert empty? b
+        --assert empty? copy b
+        --assert empty? c
+        --assert empty? copy c
+        --assert (make hash! [7 8]) = d
+        --assert (make hash! [7 8]) = copy d
+        --assert (make hash! [7 8]) = copy/part d b
+        --assert (make hash! [7 8]) = copy/part b d
+        clear a
+        --assert empty? d
+        --assert empty? copy d
+        --assert empty? copy/part d b
+
+    --test-- "copy-8"
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        --assert empty? copy/part a -4
+        --assert (make hash! [3 4 5 6]) = copy/part b -4
+        --assert (make hash! [1 2 3 4 5 6]) = copy/part b -10
+
 ===end-group===
 
 ===start-group=== "random"


### PR DESCRIPTION

Do not merge this yet!


Fixes #3369 , fixes #4078 , fixes #4083 , fixes #4085 , fixes #4087 , fixes #4088 

This PR fixes numerous crashes in series-related functions, and includes a total rewrite of `change` and `take`. Lots of tests included.

Series funcs behavior now follows [the one I outlined in red/red](https://gitter.im/red/red?at=5da5b83b870fa33a4df7e0b7) in all edge cases. How it all works is seen from the tests, so I'm not duping it here.

`next`, `skip`, `at` I do not plan to modify until we agree on some sort of series model.
`take/last/part` behavior is unchanged, only fixed, although I'm not happy with it ([reasons](https://gitter.im/red/red?at=5da5861f809de9699f3ec707))

**Status**

A bit more work is required:
- `move` func has no tests at all, and it's very unintuitive
- I didn't test select/pick/random/min/max yet

@qtxie perhaps can you lend me a hand in fixing `change/part-hash-4` test? It's a baaad one.


