### PR TITLE
FIX: issues #3369, #4088, #4087, #4085, #4083, #4078, #4913

### DIFF
--- a/modules/view/backends/windows/comdlgs.reds
+++ b/modules/view/backends/windows/comdlgs.reds
@@ -21,6 +21,7 @@ file-filter-to-str: func [
 		val [red-value!]
 		end [red-value!]
 		str [red-string!]
+		typ [integer!]
 ][
 	s: GET_BUFFER(filter)
 	val: s/offset + filter/head
@@ -29,6 +30,10 @@ file-filter-to-str: func [
 
 	str: string/make-at stack/push* 16 UCS-2
 	while [val < end][
+		typ: TYPE_OF(val)
+		unless any [typ = TYPE_STRING typ = TYPE_FILE][
+			fire [TO_ERROR(script invalid-arg) val]
+		]
 		string/concatenate str as red-string! val -1 0 yes no
 		string/append-char GET_BUFFER(str) 0
 		val: val + 1

--- a/runtime/allocator.reds
+++ b/runtime/allocator.reds
@@ -158,7 +158,7 @@ fill: func [
 	
 	unless aligned? [						;-- postprocess unaligned ending
 		cnt: (as-integer end) and 3	
-		while [cnt > 0][end/cnt: byte cnt: cnt - 1]
+		while [cnt > 0][p/cnt: byte cnt: cnt - 1]
 	]
 	MEMGUARD_BACK
 ]

--- a/runtime/allocator.reds
+++ b/runtime/allocator.reds
@@ -1086,8 +1086,8 @@ free-series: func [
 	assert not null? (as byte-ptr! node/value)
 	
 	series: as series-buffer! node/value
-	assert not zero? (series/flags and not series-in-use) ;-- ensure that 'used bit is set
-	series/flags: series/flags and series-free-mask		  ;-- clear 'used bit (enough to free the series)
+	assert not zero? (series/flags and series-in-use)	;-- ensure that 'used bit is set
+	series/flags: series/flags and series-free-mask		;-- clear 'used bit (enough to free the series)
 	
 	if frame/heap = as series-buffer! (		;-- test if series is on top of heap
 		(as byte-ptr! node/value) +  series/size + size? series-buffer!
@@ -1126,7 +1126,7 @@ expand-series: func [
 
 	node: series/node
 	new: alloc-series-buffer new-sz / units units 0
-	series: as series-buffer! node/value
+	assert series = as series-buffer! node/value
 	big?: new/flags and flag-series-big <> 0
 	
 	node/value: as-integer new		;-- link node to new series buffer
@@ -1145,8 +1145,8 @@ expand-series: func [
 		as byte-ptr! series/offset
 		series/size
 	
-	assert not zero? (series/flags and not series-in-use) ;-- ensure that 'used bit is set
-	series/flags: series/flags xor series-in-use		  ;-- clear 'used bit (enough to free the series)	
+	assert not zero? (series/flags and series-in-use)	;-- ensure that 'used bit is set
+	series/flags: series/flags xor series-in-use		;-- clear 'used bit (enough to free the series)	
 	new	
 ]
 

--- a/runtime/allocator.reds
+++ b/runtime/allocator.reds
@@ -895,7 +895,7 @@ alloc-series-buffer: func [
 		sz		 [integer!]
 		flag-big [integer!]
 ][
-	assert positive? usize
+	assert not negative? usize
 	size: round-to usize * unit size? cell!	;-- size aligned to cell! size
 
 	frame: memory/s-active

--- a/runtime/allocator.reds
+++ b/runtime/allocator.reds
@@ -140,7 +140,10 @@ fill: func [
 	MEMGUARD_ADDRANGE2(p end)
 	cnt: (as-integer p) and 3
 	unless zero? cnt [						;-- preprocess unaligned beginning
-		while [cnt > 0][p/cnt: byte cnt: cnt - 1]
+		while [cnt > 0][
+			MEMGUARD_PCHK( (p + cnt - 1) )
+			p/cnt: byte cnt: cnt - 1
+		]
 		p: as byte-ptr! (as-integer p) + 4 and -4
 	]
 	
@@ -153,13 +156,19 @@ fill: func [
 			byte4: as-integer byte
 			(byte4 << 24) or (byte4 << 16) or (byte4 << 8) or byte4
 		]
-		while [p4 < tail][p4/value: byte4 p4: p4 + 1] ;-- zero fill target region using 32-bit accesses
+		while [p4 < tail][	 				;-- zero fill target region using 32-bit accesses
+			MEMGUARD_PCHK(p4)
+			p4/value: byte4 p4: p4 + 1
+		]
 	]
 	
 	unless aligned? [						;-- postprocess unaligned ending
 		cnt: (as-integer end) and 3
 		p: as byte-ptr! p4
-		while [cnt > 0][p/cnt: byte cnt: cnt - 1]
+		while [cnt > 0][
+			MEMGUARD_PCHK( (p + cnt - 1) )
+			p/cnt: byte cnt: cnt - 1
+		]
 	]
 	MEMGUARD_BACK
 ]

--- a/runtime/allocator.reds
+++ b/runtime/allocator.reds
@@ -157,7 +157,8 @@ fill: func [
 	]
 	
 	unless aligned? [						;-- postprocess unaligned ending
-		cnt: (as-integer end) and 3	
+		cnt: (as-integer end) and 3
+		p: as byte-ptr! p4
 		while [cnt > 0][p/cnt: byte cnt: cnt - 1]
 	]
 	MEMGUARD_BACK

--- a/runtime/allocator.reds
+++ b/runtime/allocator.reds
@@ -15,6 +15,8 @@ Red/System [
 	COLLECTOR_RELEASE						;-- will release empty frames to OS
 ]
 
+#define SERIES_BUFFER_PADDING	4
+
 int-array!: alias struct! [ptr [int-ptr!]]
 
 ;-- cell header bits layout --
@@ -459,7 +461,7 @@ update-series: func [
 		s/node/value: as-integer s			;-- update the node pointer to the new series address
 		s/offset: as cell! (as byte-ptr! s/offset) - offset	;-- update offset and tail pointers
 		s/tail:   as cell! (as byte-ptr! s/tail) - offset
-		s: as series! (as byte-ptr! s + 1) + s/size
+		s: as series! (as byte-ptr! s + 1) + s/size + SERIES_BUFFER_PADDING
 		tail <= as byte-ptr! s
 	]
 ]
@@ -499,7 +501,7 @@ compact-series-frame: func [
 			;probe ["search live from: " s]
 			free-node s/node
 			while [							;-- search for a live series
-				s: as series! (as byte-ptr! s + 1) + s/size
+				s: as series! (as byte-ptr! s + 1) + s/size + SERIES_BUFFER_PADDING
 				tail?: s >= heap
 				mark?: s/flags and flag-gc-mark <> 0
 				not any [mark? tail?]
@@ -513,7 +515,7 @@ compact-series-frame: func [
 			;probe ["search gap from: " s]
 			until [							;-- search for a gap
 				s/flags: s/flags and not flag-gc-mark	;-- clear mark flag
-				s: as series! (as byte-ptr! s + 1) + s/size
+				s: as series! (as byte-ptr! s + 1) + s/size + SERIES_BUFFER_PADDING
 				tail?: s >= heap
 				any [s/flags and flag-gc-mark = 0 tail?]
 			]
@@ -531,7 +533,7 @@ compact-series-frame: func [
 				
 				if refs < tail [			;-- update pointers on native stack
 					while [all [refs < tail (as byte-ptr! refs/1) < src]][refs: refs + 2]
-					while [all [refs < tail (as byte-ptr! refs/1) <= (src + size)]][
+					while [all [refs < tail (as byte-ptr! refs/1) < (src + size)]][
 						ptr: as int-ptr! refs/2
 						ptr/value: ptr/value - delta
 						refs: refs + 2
@@ -599,7 +601,7 @@ cross-compact-frame: func [
 			if dst = null [dst: as byte-ptr! s]
 			free-node s/node
 			while [							;-- search for a live series
-				s: as series! (as byte-ptr! s + 1) + s/size
+				s: as series! (as byte-ptr! s + 1) + s/size + SERIES_BUFFER_PADDING
 				tail?: s >= heap
 				mark?: s/flags and flag-gc-mark <> 0
 				not any [mark? tail?]
@@ -613,9 +615,9 @@ cross-compact-frame: func [
 			until [							;-- search for a gap
 				s/flags: s/flags and not flag-gc-mark	;-- clear mark flag
 				size2: size
-				size: size + s/size + size? series-buffer!
+				size: SERIES_BUFFER_PADDING + size + s/size + size? series-buffer!
 				ss: s						;-- save previous series pointer
-				s: as series! (as byte-ptr! s + 1) + s/size
+				s: as series! (as byte-ptr! s + 1) + s/size + SERIES_BUFFER_PADDING
 				tail?: s >= heap
 				any [
 					all [cross? size >= free-sz]
@@ -663,7 +665,7 @@ cross-compact-frame: func [
 				update-series as series! dst2 delta size
 				if refs < tail [			;-- update pointers on native stack
 					while [all [refs < tail (as byte-ptr! refs/1) < src]][refs: refs + 2]
-					while [all [refs < tail (as byte-ptr! refs/1) <= (src + size)]][
+					while [all [refs < tail (as byte-ptr! refs/1) < (src + size)]][
 						ptr: as int-ptr! refs/2
 						ptr/value: ptr/value - delta
 						refs: refs + 2
@@ -693,7 +695,7 @@ in-range?: func [
 ][
 	frm: memory/s-head
 	until [
-		if all [(as int-ptr! frm + 1) <= p p <= as int-ptr! frm/tail][return yes]
+		if all [(as int-ptr! frm + 1) <= p p < as int-ptr! frm/tail][return yes]
 		frm: frm/next
 		frm = null
 	]
@@ -838,7 +840,7 @@ collect-frames: func [
 		until [
 			either s/flags and flag-gc-mark = 0 [prin "x "][prin "o "]
 			probe [s ": unit=" GET_UNIT(s) " size=" s/size]
-			s: as series! (as byte-ptr! s + 1) + s/size
+			s: as series! (as byte-ptr! s + 1) + s/size + SERIES_BUFFER_PADDING
 			s >= heap
 		]
 
@@ -875,7 +877,7 @@ collect-frames: func [
 				dump4 s
 				halt
 			]
-			s: as series! (as byte-ptr! s + 1) + s/size
+			s: as series! (as byte-ptr! s + 1) + s/size + SERIES_BUFFER_PADDING
 		]
 
 	]
@@ -913,7 +915,9 @@ alloc-series-buffer: func [
 	size: round-to usize * unit size? cell!	;-- size aligned to cell! size
 
 	frame: memory/s-active
-	sz: size + size? series-buffer!			;-- add series header size
+	;-- add series header size + (extra padding 4 bytes)
+	;-- extra space between two adjacent series-buffer!s (ensure s1/tail <> s2)
+	sz: SERIES_BUFFER_PADDING + size + size? series-buffer!
 	flag-big: 0
 	
 	either sz >= memory/s-max [				;-- alloc a big frame if too big for series frames
@@ -1104,7 +1108,7 @@ free-series: func [
 	series/flags: series/flags and series-free-mask		;-- clear 'used bit (enough to free the series)
 	
 	if frame/heap = as series-buffer! (		;-- test if series is on top of heap
-		(as byte-ptr! node/value) +  series/size + size? series-buffer!
+		(as byte-ptr! series) + SERIES_BUFFER_PADDING + series/size + size? series-buffer!
 	) [
 		frame/heap: series					;-- cheap collecting of last allocated series
 	]

--- a/runtime/datatypes/binary.reds
+++ b/runtime/datatypes/binary.reds
@@ -180,7 +180,7 @@ binary: context [
 			as-integer (as byte-ptr! s/tail) - p
 		s/tail: as cell! (as byte-ptr! s/tail) + part
 
-		copy-memory p data part
+		move-memory p data part
 		p
 	]
 
@@ -204,7 +204,7 @@ binary: context [
 			p: (as byte-ptr! s/offset) + bin/head + offset
 		]
 
-		copy-memory p data part
+		move-memory p data part
 
 		if p + part > (as byte-ptr! s/tail) [s/tail: as cell! p + part]
 		p

--- a/runtime/datatypes/binary.reds
+++ b/runtime/datatypes/binary.reds
@@ -274,6 +274,8 @@ binary: context [
 			end		[byte-ptr!]
 			type	[integer!]
 			same?	[logic!]
+			bin1'	[red-binary! value]
+			bin2'	[red-binary! value]
 	][
 		type: TYPE_OF(bin2)
 		if all [
@@ -291,10 +293,11 @@ binary: context [
 			any [op = COMP_EQUAL op = COMP_FIND op = COMP_STRICT_EQUAL op = COMP_NOT_EQUAL]
 		][return 0]
 
-		s1: GET_BUFFER(bin1)
-		s2: GET_BUFFER(bin2)
-		len1: rs-length? bin1
-		len2: rs-length? bin2
+		;@@ FIXME: temporary solution - to avoid rs-length? destroying the `head` of bin1-2
+		s1: _series/trim-head-into as red-series! bin1 as red-series! bin1'
+		s2: _series/trim-head-into as red-series! bin2 as red-series! bin2'
+		len1: rs-length? bin1'
+		len2: rs-length? bin2'
 		end: as byte-ptr! s2/tail
 
 		either match? [
@@ -315,8 +318,8 @@ binary: context [
 			]
 		]
 
-		p1: (as byte-ptr! s1/offset) + bin1/head
-		p2: (as byte-ptr! s2/offset) + bin2/head
+		p1: (as byte-ptr! s1/offset) + bin1'/head
+		p2: (as byte-ptr! s2/offset) + bin2'/head
 
 		while [all [p2 < end p1/1 = p2/1]][
 			p1: p1 + 1

--- a/runtime/datatypes/block.reds
+++ b/runtime/datatypes/block.reds
@@ -1114,8 +1114,8 @@ block: context [
 				copy-cell value slot
 				if hash? [_hashtable/put hash/table slot]
 			]
-			ownership/check as red-value! blk words/_put slot blk/head + 1 1
 			MEMGUARD_BACK
+			ownership/check as red-value! blk words/_put slot blk/head + 1 1
 		]
 		value
 	]
@@ -1356,8 +1356,8 @@ block: context [
 			_sort/qsort     as byte-ptr! head len width op flags cmp
 		]
 		collector/active?: saved
-		ownership/check as red-value! blk words/_sort null blk/head 0
 		MEMGUARD_BACK
+		ownership/check as red-value! blk words/_sort null blk/head 0
 		blk
 	]
 		
@@ -1518,7 +1518,6 @@ block: context [
 				cell: cell + 1
 			]
 		]
-		ownership/check as red-value! blk' action value index part
 		
 		either append? [blk/head: 0][
 			blk'/head: blk'/head + slots
@@ -1529,6 +1528,8 @@ block: context [
 			if blk/head < blk'/head [blk/head: blk'/head]
 		]
 		MEMGUARD_BACK
+
+		ownership/check as red-value! blk' action value index part
 		as red-value! blk
 	]
 
@@ -1637,10 +1638,10 @@ block: context [
 			_hashtable/delete hash/table as red-value! h2
 			_hashtable/put hash/table as red-value! h2
 		]
+		MEMGUARD_BACK
+
 		ownership/check as red-value! blk1 words/_swap null blk1/head 1
 		ownership/check as red-value! blk2 words/_swap null blk2/head 1
-
-		MEMGUARD_BACK
 		blk1
 	]
 
@@ -1678,8 +1679,8 @@ block: context [
 			value: value + 1
 		]
 		if s/tail > cur [s/tail: cur]
-		ownership/check as red-value! blk words/_trim null blk/head 0
 		MEMGUARD_BACK
+		ownership/check as red-value! blk words/_trim null blk/head 0
 		as red-series! blk
 	]
 

--- a/runtime/datatypes/common.reds
+++ b/runtime/datatypes/common.reds
@@ -80,8 +80,8 @@ alloc-tail-unit: func [
 	]
 	
 	p: as byte-ptr! s/tail
-	;-- ensure that cell is within series upper boundary
-	assert p < ((as byte-ptr! s + 1) + s/size)
+	;-- ensure that unit is within series upper boundary
+	assert p + unit <= ((as byte-ptr! s + 1) + s/size)
 	
 	s/tail: as cell! p + unit							;-- move tail to next unit slot
 	p
@@ -93,6 +93,7 @@ copy-cell: func [
 	return: [red-value!]
 ][
 	if src = dst [return dst]
+	MEMGUARD_UNCHECKED
 	copy-memory											;@@ optimize for 16 bytes copying
 		as byte-ptr! dst
 		as byte-ptr! src
@@ -119,6 +120,7 @@ copy-part: func [		;-- copy part of the series!
 	buf: as series! new/value
 	buf/flags: s/flags and not flag-series-owned
 	offset: offset << (log-b unit)
+	MEMGUARD_UNCHECKED
 	copy-memory
 		as byte-ptr! buf/offset
 		(as byte-ptr! s/offset) + offset

--- a/runtime/datatypes/common.reds
+++ b/runtime/datatypes/common.reds
@@ -181,7 +181,8 @@ fire: func [
 	arg1: null
 	arg2: null
 	arg3: null
-	
+
+	MEMGUARD_RESET										;-- otherwise it'll crash it most certainly
 	count: count - 2
 	unless zero? count [
 		arg1: as red-value! list/3

--- a/runtime/datatypes/object.reds
+++ b/runtime/datatypes/object.reds
@@ -1289,6 +1289,7 @@ object: context [
 			size  [integer!]
 			slots [integer!]
 			type  [integer!]
+			MEMGUARD_TOKEN
 	][
 		#if debug? = yes [if verbose > 0 [print-line "object/copy"]]
 		
@@ -1316,8 +1317,10 @@ object: context [
 		
 		if size <= 0 [return new]						;-- empty object!
 		
+		MEMGUARD_MARK
 		;-- process SYMBOLS
 		dst: as series! nctx/symbols/value
+		MEMGUARD_ADDNODE(dst/node)
 		copy-memory as byte-ptr! dst/offset as byte-ptr! src/offset size
 		dst/tail: dst/offset + slots
 		_context/set-context-each dst new/ctx
@@ -1325,6 +1328,7 @@ object: context [
 		;-- process VALUES
 		src: as series! ctx/values/value
 		dst: as series! nctx/values/value
+		MEMGUARD_ADDNODE(dst/node)
 		copy-memory as byte-ptr! dst/offset as byte-ptr! src/offset size
 		dst/tail: dst/offset + slots
 		
@@ -1367,6 +1371,7 @@ object: context [
 				value: value + 1
 			]
 		]
+		MEMGUARD_BACK
 		new
 	]
 	

--- a/runtime/datatypes/object.reds
+++ b/runtime/datatypes/object.reds
@@ -524,7 +524,7 @@ object: context [
 			evt1	[integer!]
 			evt2	[integer!]
 			id		[integer!]
-			blank	[byte!]
+			blank	[integer!]
 	][
 		ctx: 	GET_CTX(obj)
 		syms:   as series! ctx/symbols/value
@@ -540,13 +540,13 @@ object: context [
 
 		either flat? [
 			indent?: no
-			blank: space
+			blank: as-integer space
 		][
 			if mold? [
 				string/append-char GET_BUFFER(buffer) as-integer lf
 				part: part - 1
 			]
-			blank: lf
+			blank: as-integer lf
 		]
 		cycles/push obj/ctx
 
@@ -569,7 +569,7 @@ object: context [
 				part: actions/mold value buffer only? all? flat? arg part tabs
 
 				if any [indent? sym + 1 < s-tail][			;-- no final LF when FORMed
-					string/append-char GET_BUFFER(buffer) as-integer blank
+					string/append-char GET_BUFFER(buffer) blank
 					part: part - 1
 				]
 			]

--- a/runtime/datatypes/series.reds
+++ b/runtime/datatypes/series.reds
@@ -654,15 +654,20 @@ _series: context [
 		if all [
 			zero? part
 			limit = cell
-		][
-		return ser]									;-- early exit if nothing to change
+		][return ser]									;-- early exit if nothing to change
 
 		either any [blk? self?][
 			new-part: items * cnt
 			new-size: size - part + new-part
 			n: new-size << unit
 			if part > 0 [ownership/check as red-value! ser words/_change null head part]
-			if n > s/size [s: expand-series s n << 1]
+			if n > s/size [
+				s: expand-series s n << 1
+				if self? [								;-- cell no longer points to a valid buffer
+					cell:  as cell! (as byte-ptr! s/offset) + as-integer cell - s2/offset
+					limit: cell + items
+				]
+			]
 			dst: (as byte-ptr! s/offset) + (head << unit)
 			src: as byte-ptr! cell
 			bytes1: part << unit

--- a/runtime/datatypes/series.reds
+++ b/runtime/datatypes/series.reds
@@ -43,6 +43,28 @@ _series: context [
 		(as byte-ptr! s/offset) + offset >= as byte-ptr! s/tail
 	]
 
+	trim-head: func [									;-- cuts the head if it's after the tail
+		ser 	[red-series!]
+		return:	[series!]
+		/local
+			s	[series!]
+			sz	[integer!]
+	][
+		s: GET_BUFFER(ser)
+		sz: (as-integer s/tail - s/offset) >> log-b GET_UNIT(s)
+		if ser/head > sz [ser/head: sz]
+		s
+	]
+
+	trim-head-into: func [								;-- cuts the head if it's after the tail, puts result into `new`
+		ser 	[red-series!]
+		new 	[red-series!]
+		return:	[series!]
+	][
+		copy-cell as cell! ser as cell! new
+		trim-head new
+	]
+
 	get-position: func [
 		base	   [integer!]
 		return:	   [integer!]
@@ -400,13 +422,15 @@ _series: context [
 			int	  [red-integer!]
 			hash  [red-hash!]
 			cell  [red-value!]
+			origin' [red-series! value]
+			target' [red-series! value]
 	][
-		s:    GET_BUFFER(origin)
+		s:    trim-head-into origin origin'
 		unit: GET_UNIT(s)
-		src: (as byte-ptr! s/offset) + (origin/head << (log-b unit))
+		src: (as byte-ptr! s/offset) + (origin'/head << (log-b unit))
 		tail: as byte-ptr! s/tail
 		if src = tail [return as red-value! target]
-		
+
 		part: unit
 		items: 1
 
@@ -420,15 +444,16 @@ _series: context [
 			part: part << (log-b unit)
 		]
 		
-		type1: TYPE_OF(origin)
-		either origin/node = target/node [				;-- same series case
-			dst: (as byte-ptr! s/offset) + (target/head << (log-b unit))
+		type1: TYPE_OF(origin')
+		either origin'/node = target/node [				;-- same series case
+			trim-head-into target target'
+			dst: (as byte-ptr! s/offset) + (target'/head << (log-b unit))
 			if src = dst [return as red-value! target]	;-- early exit if no move is required
 			if all [dst > src dst <> tail part > (as-integer tail - dst)][
 				return as red-value! origin
 			]
 			if dst > tail [dst: tail]					;-- avoid overflows if part is too big
-			ownership/check as red-value! target words/_move null origin/head items
+			ownership/check as red-value! target' words/_move null origin'/head items
 
 			temp: allocate part							;@@ suboptimal for unit < 16
 			copy-memory	temp src part
@@ -449,11 +474,11 @@ _series: context [
 			free temp
 
 			if type1 = TYPE_HASH [
-				hash: as red-hash! origin
-				_hashtable/move hash/table target/head origin/head items
+				hash: as red-hash! origin'
+				_hashtable/move hash/table target'/head origin'/head items
 			]
 
-			index: target/head - items
+			index: target'/head - items
 		][												;-- different series case
 			type2: TYPE_OF(target)
 			if any [
@@ -462,9 +487,9 @@ _series: context [
 			][
 				fire [TO_ERROR(script move-bad) datatype/push type1 datatype/push type2]
 			]
-			ownership/check as red-value! target words/_move null origin/head items
+			ownership/check as red-value! target words/_move null origin'/head items
 			
-			s2:    GET_BUFFER(target)
+			s2: trim-head-into target target'
 			unit2: GET_UNIT(s2)
 			if unit <> unit2 [
 				if any [
@@ -475,13 +500,13 @@ _series: context [
 				][
 					fire [TO_ERROR(script move-bad) datatype/push type1 datatype/push type2]
 				]
-				string/move-chars as red-string! origin as red-string! target part
+				string/move-chars as red-string! origin' as red-string! target' part
 				return as red-value! target
 			]
 			;-- make enough space in target
 			size: as-integer (as byte-ptr! s2/tail) + part - as byte-ptr! s2/offset
 			if size > s2/size [s2: expand-series s2 size * 2]
-			dst: (as byte-ptr! s2/offset) + (target/head << (log-b unit))
+			dst: (as byte-ptr! s2/offset) + (target'/head << (log-b unit))
 			
 			;-- slide target series to right from insertion position
 			move-memory dst + part dst as-integer (as byte-ptr! s2/tail) - dst
@@ -495,12 +520,12 @@ _series: context [
 			s/tail: as cell! tail - part
 
 			if type1 = TYPE_HASH [
-				hash: as red-hash! origin
+				hash: as red-hash! origin'
 				part: (as-integer s/tail - s/offset) >> 4 - hash/head
 				_hashtable/refresh hash/table 0 - items hash/head + items part yes
 			]
 			if type2 = TYPE_HASH [
-				hash: as red-hash! target
+				hash: as red-hash! target'
 				part: (as-integer s2/tail - dst) >> 4 - items - hash/head
 				_hashtable/refresh hash/table items hash/head part yes
 				cell: as red-value! dst
@@ -509,9 +534,11 @@ _series: context [
 					cell: cell + 1
 				]
 			]
-			index: target/head
+			index: target'/head
 		]
-		ownership/check as red-value! target words/_moved null index items
+		ownership/check as red-value! target' words/_moved null index items
+		target/node: target'/node
+		; origin/node: origin'/node
 		as red-value! origin
 	]
 	
@@ -523,43 +550,54 @@ _series: context [
 		dup-arg  [red-value!]
 		return:	 [red-series!]
 		/local
-			s		[series!]
-			s2		[series!]
-			part	[integer!]
-			items	[integer!]
-			unit	[integer!]
-			size	[integer!]
-			type	[integer!]
-			head	[integer!]
-			src		[byte-ptr!]
-			tail	[byte-ptr!]
-			p		[byte-ptr!]
-			cell	[red-value!]
-			limit	[red-value!]
-			int		[red-integer!]
-			ser2	[red-series!]
-			hash	[red-hash!]
-			table	[node!]
-			values? [logic!]
-			neg?	[logic!]
-			part?	[logic!]
-			blk?	[logic!]
-			self?	[logic!]
-			added	[integer!]
-			n		[integer!]
-			cnt		[integer!]
+			s			[series!]
+			s2			[series!]
+			part		[integer!]
+			items		[integer!]
+			unit		[integer!]
+			unit2		[integer!]
+			bytes1		[integer!]
+			bytes2		[integer!]
+			shift		[integer!]
+			trail		[integer!]
+			shift-bytes	[integer!]
+			trail-bytes	[integer!]
+			size		[integer!]
+			new-size	[integer!]
+			new-part	[integer!]
+			n			[integer!]
+			left		[integer!]
+			type		[integer!]
+			head		[integer!]
+			src			[byte-ptr!]
+			dst			[byte-ptr!]
+			cell		[red-value!]
+			limit		[red-value!]
+			int			[red-integer!]
+			ser2		[red-series!]
+			ser2'		[red-series! value]					;-- temp alias with head <= tail
+			hash		[red-hash!]
+			table		[node!]
+			values? 	[logic!]
+			neg?		[logic!]
+			part?		[logic!]
+			blk?		[logic!]
+			self?		[logic!]
+			divided?	[logic!]
+			cnt			[integer!]
 	][
 		cnt: 1
 		if OPTION?(dup-arg) [
 			int: as red-integer! dup-arg
 			cnt: int/value
-			if cnt < 1 [return ser]
+			if cnt < 0 [cnt: 0]
 		]
+		part?: OPTION?(part-arg)
+		if all [not part? zero? cnt] [return ser]
 
-		neg?: no self?: no
-		s:    GET_BUFFER(ser)
-		unit: GET_UNIT(s)
-		unit: log-b unit
+		self?: no
+		s: trim-head ser
+		unit: log-b GET_UNIT(s)
 		head: ser/head
 		size: (as-integer s/tail - s/offset) >> unit
 
@@ -568,36 +606,37 @@ _series: context [
 
 		ser2: as red-series! value
 		values?: either all [only? blk?][no][
-			n: TYPE_OF(value)
-			self?: all [type = n ser/node = ser2/node]	;-- ser and value are the same series
-			ANY_BLOCK?(n)
+			left: TYPE_OF(value)
+			self?: ser/node = ser2/node					;-- ser and value are the same series
+			ANY_BLOCK?(left)
 		]
 
 		items: either any [self? values?][
-			s2: GET_BUFFER(ser2)
-			cell: as cell! (as byte-ptr! s2/offset) + (ser2/head << unit)
-			get-length ser2 no
+			s2: trim-head-into ser2 ser2'
+			unit2: log-b GET_UNIT(s2)
+			cell: as cell! (as byte-ptr! s2/offset) + (ser2'/head << unit2)
+			get-length ser2' no
 		][
 			cell: value
 			1
 		]
 		limit: cell + items
 
-		part: items
-		part?: OPTION?(part-arg)
-		either part? [
+		part: items * cnt
+		if part? [
 			part: either TYPE_OF(part-arg) = TYPE_INTEGER [
 				int: as red-integer! part-arg
 				int/value
 			][
 				ser2: as red-series! part-arg
 				unless all [
-					TYPE_OF(ser2) = TYPE_OF(ser)	;-- handles ANY-STRING!
+					TYPE_OF(ser2) = TYPE_OF(ser)		;-- handles ANY-STRING!
 					ser2/node = ser/node
 				][
 					ERR_INVALID_REFINEMENT_ARG(refinements/_part part-arg)
 				]
-				ser2/head - head
+				trim-head-into ser2 ser2'
+				ser2'/head - head
 			]
 			if negative? part [
 				part: 0 - part
@@ -605,110 +644,129 @@ _series: context [
 				ser/head: head
 				neg?: yes
 			]
-			size: size - head
-			if part > size [part: size]
-		][size: size - head]
+		]
+		left: size - head
+		if part > left [part: left]
+
+		if all [
+			zero? part
+			limit = cell
+		][return ser]									;-- early exit if nothing to change
 
 		either any [blk? self?][
-			n: either part? [part][items * cnt]
-			if n > size [n: size]
-			ownership/check as red-value! ser words/_change null head n
-
-			added: either part? [items - part][items - size]
-			added: added << unit
-			n: (as-integer (s/tail - s/offset)) + added
-			if n > s/size [s: expand-series s n * 2]
-
-			src: (as byte-ptr! s/offset) + (head << unit)
-			tail: as byte-ptr! s/tail
-			either part? [
-				size: size - part
-				move-memory
-					src + (items << unit)
-					src + (part << unit)
-					size << unit
-				s/tail: as cell! tail + added
+			new-part: items * cnt
+			new-size: size - part + new-part
+			n: new-size << unit
+			ownership/check as red-value! ser words/_change null head part
+			if n > s/size [s: expand-series s n << 1]
+			dst: (as byte-ptr! s/offset) + (head << unit)
+			src: as byte-ptr! cell
+			bytes1: part << unit
+			bytes2: items << unit
+			if zero? cnt [bytes2: 0]
+			trail: left - part
+			shift: items * cnt - part
+			trail-bytes: trail << unit
+			shift-bytes: shift << unit
+			either shift <= 0 [
+				if bytes2 > 0 [move-memory dst src bytes2]						;-- items -> part (possible overlap)
+				if trail > 0 [
+					move-memory dst + (bytes2 * cnt) dst + bytes1 trail-bytes	;-- contract the trail (possible overlap)
+				]
 			][
-				if added > 0 [s/tail: as cell! tail + added]
-			]
-			copy-memory src as byte-ptr! cell items << unit
-
-			if type = TYPE_HASH [
-				n: items * cnt
-				added: either part? [n - part][n - size]
-				hash: as red-hash! ser
-				table: hash/table
-				either part? [
-					_hashtable/refresh table added head + part size yes
-					n: either added < 0 [part + added][part]
+				divided?: no
+				if trail > 0 [													;-- at least 1 item remains after the part; move it to the right
+					move-memory dst + (bytes2 * cnt) dst + bytes1 trail-bytes	;-- move the trail (possible overlap)
+					divided?: all [												;-- src becomes divided into 2 segments by the expansion
+						self?
+						trail > shift											;-- if there's an intersection between the *new trail* and *items*
+					]
+				]
+				assert bytes2 > 0
+				either divided? [
+					move-memory dst src bytes1											;-- fill the part (possible overlap)
+					move-memory dst + bytes1 src + bytes1 + shift-bytes shift-bytes		;-- fill the gap after part (possible overlap)
 				][
-					if n > size [n: size]
+					move-memory dst src bytes2											;-- move the `items` (possible overlap)
 				]
-				_hashtable/clear table head n
 			]
+			s/tail: as cell! (as byte-ptr! s/offset) + (new-size << unit)
+			;@@ FIXME: THAT DOESN'T WORK:
+			; if type = TYPE_HASH [
+			; 	hash: as red-hash! ser
+			; 	table: hash/table
+			; 	if part > 0 [_hashtable/clear table head part]							;-- forget the old part
+			; 	if trail > 0 [_hashtable/refresh table shift head + part trail yes]		;-- shift the trail
+			; 	if size > new-size [_hashtable/clear table new-size size - new-size]	;-- forget the now past tail items
+			; ]
 		][
-			tail: as byte-ptr! s/tail
-			src: (as byte-ptr! s/offset) + (head << unit)
 			if part? [
-				added: part << unit
-				move-memory src src + added (as-integer tail - src) - added
-				s/tail: as cell! tail - added
+				dst: (as byte-ptr! s/offset) + (head << unit)
+				bytes1: part << unit
+				trail-bytes: left - part << unit
+				;-- don't know the size of the formed items yet; change-range will decide
+				;@@ FIXME: this is sub-optimal for long trails
+				if all [trail-bytes > 0 part > 0] [
+					move-memory dst dst + bytes1 trail-bytes
+					s/tail: as cell! dst + trail-bytes
+				]
 			]
-			items: switch type [
-				TYPE_BINARY [
-					binary/change-range as red-binary! ser cell limit part?
+			if cnt > 0 [
+				items: switch type [
+					TYPE_BINARY [
+						binary/change-range as red-binary! ser cell limit part?
+					]
+					TYPE_VECTOR [
+						vector/change-range as red-vector! ser cell limit part?
+					]
+					default [								;-- ANY-STRING!
+						string/change-range as red-string! ser cell limit part?
+					]
 				]
-				TYPE_VECTOR [
-					vector/change-range as red-vector! ser cell limit part?
+			]
+			new-part: items * cnt
+			if all [cnt > 1 items > 0] [
+				s: GET_BUFFER(ser)
+				unit: log-b GET_UNIT(s)
+				size: (as-integer s/tail - s/offset) >> unit
+				either part? [
+					new-size: size + new-part - items		;-- shrunk it before ^^
+				][
+					new-size: head + new-part				;-- the part to be overridden
+					if new-size < size [new-size: size]
 				]
-				default [					;-- ANY-STRING!
-					string/change-range as red-string! ser cell limit part?
-				]
+				n: new-size << unit
+				if n > s/size [s: expand-series s n << 1]
+				s/tail: as cell! (as byte-ptr! s/offset) + n
 			]
 		]
 
-		if cnt > 1 [						;-- /dup
-			s: GET_BUFFER(ser)
-			unit: GET_UNIT(s)
-			unit: log-b unit
+		if all [cnt > 1 items > 0] [					;-- /dup
 			src: (as byte-ptr! s/offset) + (head << unit)
-			tail: as byte-ptr! s/tail
-			
-			added: items << unit
-			n: added * cnt
-			n: either part? [n - added][as-integer src + n - tail]
-			size: (as-integer tail - as byte-ptr! s/offset) + n
-			if size > s/size [
-				s: expand-series s size * 2
-				src: (as byte-ptr! s/offset) + (head << unit)
-				tail: as byte-ptr! s/tail
-			]
-
-			src: src + added
-			if part? [
-				move-memory src + n src as-integer tail - src
-			]
-			if n > 0 [s/tail: as cell! tail + n]
-
-			items: items * cnt
-			p: src
-			src: src - added
-			until [
-				copy-memory p src added
-				p: p + added
-				cnt: cnt - 1
-				cnt = 1
+			bytes2: items << unit
+			dst: src + bytes2
+			loop cnt - 1 [
+				copy-memory dst src bytes2
+				dst: dst + bytes2
 			]
 		]
+		; if type = TYPE_HASH [
+		; 	hash: as red-hash! ser
+		; 	table: hash/table
+		; 	cell: as cell! s/offset + head
+		; 	loop new-part [_hashtable/put table cell  cell: cell + 1]		;-- insert the items
+		; ]
+
+		;@@ FIXME: temporary solution - reinsert everything after the head:
 		if type = TYPE_HASH [
-			cell: s/offset + head
-			loop items [
-				_hashtable/put table cell
-				cell: cell + 1
-			]
+			hash: as red-hash! ser
+			table: hash/table
+			_hashtable/clear table head size - head
+			cell: as cell! s/offset + head
+			loop new-size - head [_hashtable/put table cell  cell: cell + 1]
 		]
-		ser/head: head + items
-		ownership/check as red-value! ser words/_changed null head items
+		ownership/check as red-value! ser words/_changed null head new-part
+		ser/head: head + new-part											;-- set head after the change
 		ser
 	]
 
@@ -914,7 +972,10 @@ _series: context [
 			items: part
 			part: part << (log-b unit)
 		][
+			part: ser/head								;-- preserve the head
 			items: get-length ser no
+			ser/head: part
+			part: 0
 		]
 		
 		hash?: TYPE_OF(ser) = TYPE_HASH
@@ -956,100 +1017,116 @@ _series: context [
 			s		[series!]
 			buffer	[series!]
 			node	[node!]
+			head	[integer!]
 			unit	[integer!]
 			part	[integer!]
 			bytes	[integer!]
 			size	[integer!]
 			hash	[red-hash!]
 			part2	[integer!]
+			ser'	[red-series! value]
+			part-arg'	[red-value! value]
 	][
 		#if debug? = yes [if verbose > 0 [print-line "series/take"]]
-
-		size: get-length ser no
-		if size <= 0 [									;-- early exit if nothing to take
-			set-type as cell! ser TYPE_NONE
-			return as red-value! ser
-		]
-		s:    GET_BUFFER(ser)
+		s: trim-head-into ser ser'
+		head: ser'/head
+		size: get-length ser' yes
 		unit: GET_UNIT(s)
 		part: 1
 		part2: 1
 
-		if OPTION?(part-arg) [
-			part: either TYPE_OF(part-arg) = TYPE_INTEGER [
+		either OPTION?(part-arg) [
+			either TYPE_OF(part-arg) = TYPE_INTEGER [
 				int: as red-integer! part-arg
-				int/value
+				part: int/value
+				if last? [								;-- integer /last/part counts from the tail
+					if part < 0 [part: 0]
+					head: size - part
+					if head < 0 [head: 0]
+				]
 			][
-				ser2: as red-series! part-arg
+				ser2: as red-series! part-arg'
+				trim-head-into as red-series! part-arg as red-series! part-arg'
 				unless all [
 					TYPE_OF(ser2) = TYPE_OF(ser)		;-- handles ANY-STRING!
 					ser2/node = ser/node
 				][
 					ERR_INVALID_REFINEMENT_ARG(refinements/_part part-arg)
 				]
-				either ser2/head < ser/head [0][
-					either last? [size - (ser2/head - ser/head)][ser2/head - ser/head]
+				part: ser2/head - head
+				if all [
+					last?								;-- series /last/part takes everything after the biggest of ends
+					part > 0
+				][										;-- set head to the biggest end
+					head: head + part
+					if head > size [head: size]
 				]
 			]
 			part2: part
-			if negative? part [
-				size: ser/head
-				part: either last? [1][0 - part]
+			either last? [
+				part: size - head
+			][
+				if part < 0 [
+					part: 0 - part
+					head: head - part
+					if head < 0 [
+						part: part + head
+						head: 0
+					]
+				]
+				if part > (size - head) [part: size - head]
 			]
-			if part > size [part: size]
-			if zero? part [part: 1]
+		][;; either OPTION?(part-arg)
+			if head >= size [							;-- early exit if nothing to take (and part = 1)
+				set-type as cell! ser TYPE_NONE
+				return as red-value! ser
+			]
+			if last? [head: size - 1]
 		]
 
 		bytes:	part << (log-b unit)
 		node: 	alloc-bytes bytes
-		s:      GET_BUFFER(ser)
+		s:      GET_BUFFER(ser')
 		buffer: as series! node/value
 		buffer/flags: s/flags							;@@ filter flags?
+		tail: as byte-ptr! s/tail
 
 		ser2: as red-series! stack/push*
 		ser2/header: TYPE_OF(ser)
-		ser2/extra:  either TYPE_OF(ser) = TYPE_VECTOR [ser/extra][0]
+		ser2/extra:  either TYPE_OF(ser) = TYPE_VECTOR [ser'/extra][0]
 		ser2/node:  node
 		ser2/head:  0
 
-		ownership/check as red-value! ser words/_take null ser/head part2
+		ownership/check as red-value! ser' words/_take null head part2
 
-		offset: (as byte-ptr! s/offset) + (ser/head << (log-b unit))
-		tail: as byte-ptr! s/tail
-		either positive? part2 [
-			if last? [
-				offset: tail - bytes
-				s/tail: as cell! offset
-			]
-		][
-			if any [last? part > ser/head][return as red-value! ser2]
-			offset: offset - bytes
-		]
+		offset: (as byte-ptr! s/offset) + (head << (log-b unit))
 		copy-memory
 			as byte-ptr! buffer/offset
 			offset
 			bytes
 		buffer/tail: as cell! (as byte-ptr! buffer/offset) + bytes
 
-		unless last? [
+		unless head + part >= size [
 			move-memory
 				offset
 				offset + bytes
 				as-integer tail - offset - bytes
-			s/tail: as cell! tail - bytes
 		]
+		s/tail: as cell! tail - bytes
 
+		ser'/head: head
 		if TYPE_OF(ser) = TYPE_HASH [
-			unit: either last? [size][ser/head + part]
-			hash: as red-hash! ser
-			_hashtable/refresh hash/table 0 - part unit size - unit yes
+			hash: as red-hash! ser'
+			_hashtable/refresh hash/table 0 - part ser'/head + part size - ser'/head - part yes
 			hash: as red-hash! ser2
 			hash/header: TYPE_BLOCK		;-- set to TYPE_BLOCK so we don't mark hash/table
 			hash/table: _hashtable/init part ser2 HASH_TABLE_HASH 1
 			hash/header: TYPE_HASH
 		]
 		
-		ownership/check as red-value! ser words/_taken null ser/head 0
+		ownership/check as red-value! ser' words/_taken null ser'/head 0
+		ser/node: ser'/node								;-- could have been relocated
+
 		as red-value! ser2
 	]
 
@@ -1070,12 +1147,12 @@ _series: context [
 		s1:    GET_BUFFER(ser1)
 		unit1: GET_UNIT(s1)
 		head1: (as byte-ptr! s1/offset) + (ser1/head << (log-b unit1))
-		if head1 = as byte-ptr! s1/tail [return ser1]				;-- early exit if nothing to swap
+		if head1 >= as byte-ptr! s1/tail [return ser1]				;-- early exit if nothing to swap
 
 		s2:    GET_BUFFER(ser2)
 		unit2: GET_UNIT(s2)
 		head2: (as byte-ptr! s2/offset) + (ser2/head << (log-b unit2))
-		if head2 = as byte-ptr! s2/tail [return ser1]				;-- early exit if nothing to swap
+		if head2 >= as byte-ptr! s2/tail [return ser1]				;-- early exit if nothing to swap
 
 		char1: string/get-char head1 unit1
 		char2: string/get-char head2 unit2

--- a/runtime/datatypes/string.reds
+++ b/runtime/datatypes/string.reds
@@ -2187,6 +2187,7 @@ string: context [
 		/local
 			src		  [red-block!]
 			cell	  [red-value!]
+			start	  [red-value!]
 			limit	  [red-value!]
 			int		  [red-integer!]
 			char	  [red-char!]
@@ -2253,8 +2254,8 @@ string: context [
 			str'/head
 		]
 		
-		while [not zero? cnt][							;-- /dup support
-			type: TYPE_OF(value)
+		type: TYPE_OF(value)
+		unless zero? cnt [
 			either any [								;@@ replace it with: typeset/any-list?
 				type = TYPE_BLOCK
 				type = TYPE_PAREN
@@ -2262,12 +2263,15 @@ string: context [
 			][
 				s2: _series/trim-head-into as red-series! value as red-series! value'
 				src: as red-block! value'
-				cell:  s2/offset + src/head
-				limit: cell + block/rs-length? src
+				start:  s2/offset + src/head
+				limit: start + block/rs-length? src
 			][
-				cell:  value
+				start: value
 				limit: value + 1
 			]
+		]
+		while [not zero? cnt][							;-- /dup support
+			cell: start
 			rest: 0
 			added: 0
 			while [

--- a/runtime/datatypes/string.reds
+++ b/runtime/datatypes/string.reds
@@ -948,6 +948,8 @@ string: context [
 			s2	  [series!]
 			unit1 [integer!]
 			unit2 [integer!]
+			type1 [integer!]
+			type2 [integer!]
 			size  [integer!]
 			size1 [integer!]
 			size2 [integer!]
@@ -963,6 +965,10 @@ string: context [
 			same? [logic!]
 			MEMGUARD_TOKEN
 	][
+		type1: TYPE_OF(str1)
+		type2: TYPE_OF(str2)
+		assert any [type1 = TYPE_SYMBOL ANY_STRING?(type1)]
+		assert any [type2 = TYPE_SYMBOL ANY_STRING?(type2)]
 		s1: GET_BUFFER(str1)
 		s2: GET_BUFFER(str2)
 		unit1: GET_UNIT(s1)
@@ -1003,8 +1009,8 @@ string: context [
 			true [true]									;@@ catch-all case to make compiler happy
 		]
 		
-		h1: either TYPE_OF(str1) = TYPE_SYMBOL [0][str1/head << (log-b unit1)]	;-- make symbol! used as string! pass safely
-		h2: either TYPE_OF(str2) = TYPE_SYMBOL [0][str2/head << (log-b unit2)]	;-- make symbol! used as string! pass safely
+		h1: either type1 = TYPE_SYMBOL [0][str1/head << (log-b unit1)]	;-- make symbol! used as string! pass safely
+		h2: either type2 = TYPE_SYMBOL [0][str2/head << (log-b unit2)]	;-- make symbol! used as string! pass safely
 		
 		size2: (as-integer s2/tail - s2/offset) - h2 >> (log-b unit2)
 		if all [part >= 0 part < size2][size2: part]

--- a/runtime/datatypes/vector.reds
+++ b/runtime/datatypes/vector.reds
@@ -883,6 +883,8 @@ vector: context [
 			f1		[float!]
 			f2		[float!]
 			same?	[logic!]
+			vec1'	[red-vector! value]
+			vec2'	[red-vector! value]
 	][
 		#if debug? = yes [if verbose > 0 [print-line "vector/compare"]]
 
@@ -899,12 +901,12 @@ vector: context [
 			any [op = COMP_EQUAL op = COMP_FIND op = COMP_STRICT_EQUAL op = COMP_NOT_EQUAL]
 		][return 0]
 		
-		s1: GET_BUFFER(vec1)
-		s2: GET_BUFFER(vec2)
+		s1: _series/trim-head-into as red-series! vec1 as red-series! vec1'
+		s2: _series/trim-head-into as red-series! vec2 as red-series! vec2'
 		unit1: GET_UNIT(s1)
 		unit2: GET_UNIT(s2)
-		len1: rs-length? vec1
-		len2: rs-length? vec2
+		len1: rs-length? vec1'
+		len2: rs-length? vec2'
 
 		end: as byte-ptr! s2/tail
 
@@ -920,9 +922,9 @@ vector: context [
 			if zero? len1 [return 0]					;-- shortcut exit for empty vector!
 		]
 
-		type: vec1/type
-		p1: (as byte-ptr! s1/offset) + (vec1/head << (log-b unit1))
-		p2: (as byte-ptr! s2/offset) + (vec2/head << (log-b unit2))
+		type: vec1'/type
+		p1: (as byte-ptr! s1/offset) + (vec1'/head << (log-b unit1))
+		p2: (as byte-ptr! s2/offset) + (vec2'/head << (log-b unit2))
 
 		switch type [
 			TYPE_CHAR

--- a/runtime/datatypes/vector.reds
+++ b/runtime/datatypes/vector.reds
@@ -467,7 +467,7 @@ vector: context [
 					fl: as red-float! right
 					f2: fl/value
 				]
-				default [MEMGUARD_BACK --NOT_IMPLEMENTED--]
+				default [--NOT_IMPLEMENTED--]
 			]
 			while [i < len][
 				f1: get-value-float p unit
@@ -495,7 +495,7 @@ vector: context [
 					f1: fl/value
 					v2: as-integer f1
 				]
-				default [MEMGUARD_BACK --NOT_IMPLEMENTED--]
+				default [--NOT_IMPLEMENTED--]
 			]
 			while [i < len][
 				v1: get-value-int as int-ptr! p unit

--- a/runtime/debug-tools.reds
+++ b/runtime/debug-tools.reds
@@ -309,5 +309,17 @@ memory-info: func [
 		assert series = frame/heap
 		print lf
 	]
+
+	memguard-add-series: func [							;-- convenience wrapper (libc cannot use structs from runtime)
+		rs	[red-series!]
+		/local s [series!] t [integer!]
+	][
+		assert not zero? as-integer rs
+		t: TYPE_OF(rs)
+		assert any [ANY_SERIES?(t) t = TYPE_SYMBOL]
+		s: GET_BUFFER(rs)
+		assert VALID_BUFFER?(s)
+		memguard/add-node rs/node
+	]
 	
 ]

--- a/runtime/hashtable.reds
+++ b/runtime/hashtable.reds
@@ -1071,6 +1071,7 @@ _hashtable: context [
 		/local s [series!] h [hashtable!] flags [int-ptr!] i [integer!]
 			ii [integer!] sh [integer!] indexes [int-ptr!]
 	][
+		assert size >= 0
 		if zero? size [exit]
 		s: as series! node/value
 		h: as hashtable! s/offset
@@ -1109,6 +1110,7 @@ _hashtable: context [
 			n [integer!] keys [int-ptr!] index [int-ptr!] part [integer!]
 			flags [int-ptr!] ii [integer!] sh [integer!]
 	][
+		assert size >= 0
 		s: as series! node/value
 		h: as hashtable! s/offset
 		assert h/indexes <> null

--- a/runtime/interpreter.reds
+++ b/runtime/interpreter.reds
@@ -617,7 +617,10 @@ interpreter: context [
 							size: (as-integer (as int-ptr! s/tail) - p) / 4
 							ref-array: system/stack/top - size
 							system/stack/top: ref-array		;-- reserve space on native stack for refs array
-							copy-memory as byte-ptr! ref-array as byte-ptr! p size * 4
+							if size > 0 [
+								MEMGUARD_UNCHECKED
+								copy-memory as byte-ptr! ref-array as byte-ptr! p size * 4
+							]
 						]
 						default [assert false]				;-- trap it, if stack corrupted 
 					]

--- a/runtime/macros.reds
+++ b/runtime/macros.reds
@@ -346,9 +346,9 @@ Red/System [
 	;-- as-integer below is used to silence compiler warnings when pointer is byte-ptr already
 	#define MEMGUARD_ADDRANGE(s n)	[memguard/add-range   as byte-ptr! 0 + as-integer s  as byte-ptr! n + as-integer s]
 	#define MEMGUARD_ADDRANGE2(s e)	[memguard/add-range   as byte-ptr! 0 + as-integer s  as byte-ptr! 0 + as-integer e]
-	#define MEMGUARD_RANGECHK(s n)	[memguard/check-range as byte-ptr! 0 + as-integer s  as byte-ptr! n + as-integer s]
+	#define MEMGUARD_RANGECHK(s n)	[assert yes = memguard/check-range as byte-ptr! 0 + as-integer s  as byte-ptr! n + as-integer s]
 	; #define MEMGUARD_RANGECHK2(s e)	[memguard/check-range as byte-ptr! 0 + as-integer s  as byte-ptr! 0 + as-integer e]
-	#define MEMGUARD_PCHK(p)		[memguard/check-range as byte-ptr! 0 + as-integer p  as byte-ptr! 0 + as-integer p + 1]
+	#define MEMGUARD_PCHK(p)		[assert yes = memguard/check-range as byte-ptr! 0 + as-integer p  as byte-ptr! 0 + as-integer p + 1]
 ][
 	#define MEMGUARD_TOKEN			[]
 	#define MEMGUARD_MARK			[]

--- a/runtime/macros.reds
+++ b/runtime/macros.reds
@@ -333,6 +333,37 @@ Red/System [
 #define TO_ERROR(cat id)	[#in system/catalog/errors cat #in system/catalog/errors/cat id]
 #define VALID_BUFFER?(buf)	[not zero? (buf/flags and series-in-use)]	;-- checks if buffer hasn't been freed
 
+#either debug? = yes [
+	#define MEMGUARD_TOKEN			[mgtoken [integer!]]		;-- goes into function spec
+	#define MEMGUARD_MARK			[mgtoken: memguard/mark]
+	#define MEMGUARD_BACK			[memguard/back mgtoken]
+	#define MEMGUARD_UNCHECKED		[memguard/flag-skip-next: yes]
+	#define MEMGUARD_ADD(srs)		[memguard-add-series as red-series! srs]
+	#define MEMGUARD_ADDRO(srs)		[0] ;[memguard-add-series as red-series! srs]	;@@ TBD - readonly
+	#define MEMGUARD_ADDNODE(n)		[memguard/add-node n]
+	#define MEMGUARD_ADDNODERO(n)	[0]							;@@ TBD - readonly
+	;-- as-integer below is used to silence compiler warnings when pointer is byte-ptr already
+	#define MEMGUARD_ADDRANGE(s n)	[memguard/add-range   as byte-ptr! 0 + as-integer s  as byte-ptr! n + as-integer s]
+	#define MEMGUARD_ADDRANGE2(s e)	[memguard/add-range   as byte-ptr! 0 + as-integer s  as byte-ptr! 0 + as-integer e]
+	#define MEMGUARD_RANGECHK(s n)	[memguard/check-range as byte-ptr! 0 + as-integer s  as byte-ptr! n + as-integer s]
+	; #define MEMGUARD_RANGECHK2(s e)	[memguard/check-range as byte-ptr! 0 + as-integer s  as byte-ptr! 0 + as-integer e]
+	#define MEMGUARD_PCHK(p)		[memguard/check-range as byte-ptr! 0 + as-integer p  as byte-ptr! 0 + as-integer p + 1]
+][
+	#define MEMGUARD_TOKEN			[]
+	#define MEMGUARD_MARK			[]
+	#define MEMGUARD_BACK			[]
+	#define MEMGUARD_UNCHECKED		[]
+	#define MEMGUARD_ADD(srs)		[]
+	#define MEMGUARD_ADDRO(srs)		[]
+	#define MEMGUARD_ADDNODE(n)		[]
+	#define MEMGUARD_ADDNODERO(n)	[]
+	#define MEMGUARD_ADDRANGE(s n)	[]
+	#define MEMGUARD_ADDRANGE2(s e)	[]
+	#define MEMGUARD_RANGECHK(s n)	[]
+	; #define MEMGUARD_RANGECHK2(s e)	[]
+	#define MEMGUARD_PCHK(p)		[]
+]
+
 #define PLATFORM_TO_CSTR(cstr str len) [	;-- len in bytes
 	len: -1
 	#either OS = 'Windows [

--- a/runtime/macros.reds
+++ b/runtime/macros.reds
@@ -331,6 +331,7 @@ Red/System [
 #define FLAG_NOT?(s)		(s/flags and flag-bitset-not <> 0)
 #define SET_RETURN(value)	[stack/set-last as red-value! value]
 #define TO_ERROR(cat id)	[#in system/catalog/errors cat #in system/catalog/errors/cat id]
+#define VALID_BUFFER?(buf)	[not zero? (buf/flags and series-in-use)]	;-- checks if buffer hasn't been freed
 
 #define PLATFORM_TO_CSTR(cstr str len) [	;-- len in bytes
 	len: -1

--- a/runtime/macros.reds
+++ b/runtime/macros.reds
@@ -337,6 +337,7 @@ Red/System [
 	#define MEMGUARD_TOKEN			[mgtoken [integer!]]		;-- goes into function spec
 	#define MEMGUARD_MARK			[mgtoken: memguard/mark]
 	#define MEMGUARD_BACK			[memguard/back mgtoken]
+	#define MEMGUARD_RESET			[memguard/reset]
 	#define MEMGUARD_UNCHECKED		[memguard/flag-skip-next: yes]
 	#define MEMGUARD_ADD(srs)		[memguard-add-series as red-series! srs]
 	#define MEMGUARD_ADDRO(srs)		[0] ;[memguard-add-series as red-series! srs]	;@@ TBD - readonly
@@ -352,6 +353,7 @@ Red/System [
 	#define MEMGUARD_TOKEN			[]
 	#define MEMGUARD_MARK			[]
 	#define MEMGUARD_BACK			[]
+	#define MEMGUARD_RESET			[]
 	#define MEMGUARD_UNCHECKED		[]
 	#define MEMGUARD_ADD(srs)		[]
 	#define MEMGUARD_ADDRO(srs)		[]

--- a/runtime/stack.reds
+++ b/runtime/stack.reds
@@ -104,6 +104,11 @@ stack: context [										;-- call stack
 		
 		body-symbol: words/_body/symbol
 		anon-symbol: words/_anon/symbol
+
+		#if debug? = yes [
+			memguard/ignore-node arg-stk/node
+			memguard/enabled?: yes
+		]
 	]
 	
 	mark: func [

--- a/system/runtime/libc.reds
+++ b/system/runtime/libc.reds
@@ -187,6 +187,11 @@ Red/System [
 			last-token: last-token - 1
 			until [0 = pop]
 		]
+		reset: does [									;-- use it when memguard stack can't be preserved
+			top: list
+			last-token: 0
+			flag-skip-next: no
+		]
 		
 		ignore-node: func [node [int-ptr!]] [
 			;@@ TBD: stack of intervals?

--- a/system/runtime/libc.reds
+++ b/system/runtime/libc.reds
@@ -30,7 +30,7 @@ Red/System [
 			size		[integer!]
 			return:		[byte-ptr!]
 		]
-		move-memory: "memmove" [
+		#either debug? = yes [libc.move-memory:][move-memory:] "memmove" [
 			target		[byte-ptr!]
 			source		[byte-ptr!]
 			size		[integer!]
@@ -152,6 +152,166 @@ Red/System [
 ]
 
 #if debug? = yes [
+
+	memguard: context [
+		enabled?: no
+
+		list: as int-ptr! allocate 4096
+		tail:		list + 1024
+		top:		list
+
+		ignored: as int-ptr! allocate 256
+		ignored/1: 0
+
+		last-token: 0
+		flag-skip-next: no
+
+		push: func [v [integer!]][
+			assert top < tail
+			top/value: v
+			top: top + 1
+		]
+		pop: func [return: [integer!]][
+			assert top > list
+			top: top - 1
+			top/value
+		]
+
+		mark: func [return: [integer!]] [
+			push 0
+			last-token: last-token + 1
+			last-token
+		]
+		back: func [token [integer!]] [
+			assert token = last-token					;-- `back` should have a corresponding `mark`
+			last-token: last-token - 1
+			until [0 = pop]
+		]
+		
+		ignore-node: func [node [int-ptr!]] [
+			;@@ TBD: stack of intervals?
+			assert not zero? as-integer node
+			assert zero? ignored/1
+			ignored/1: as-integer node
+		]
+
+		ignored?: func [h [byte-ptr!] t [byte-ptr!] return: [logic!]
+			/local s [int-ptr!] ih [byte-ptr!] it [byte-ptr!]
+		][
+			unless enabled? [return yes]
+			s: as int-ptr! ignored/1
+			s: as int-ptr! s/value
+			assert not zero? ignored/1
+			ih: as byte-ptr! s/4
+			it: ih + s/3
+			assert not zero? as-integer ih
+			assert not zero? as-integer it
+			all [ih <= h t <= it]
+		]
+
+		add-node: func [node [int-ptr!]][
+			push as-integer node						;-- node/value is series!
+		]
+
+		add-range: func [h [byte-ptr!] t [byte-ptr!]][
+			push 0 - as-integer h
+			push 0 - as-integer t
+		]
+
+		get-next-region: func [
+			&p [int-ptr!]								;-- in/out: stack pointer
+			&h [int-ptr!]								;-- out: head
+			&t [int-ptr!]								;-- out: tail
+			&n [int-ptr!]								;-- out: node (if any, else zero)
+			return: [logic!]							;-- true if the region exists
+			/local p [int-ptr!] n [int-ptr!] s [int-ptr!]
+		][
+			p: as int-ptr! &p/value
+			p: p - 1
+			assert p >= list
+			case [
+				zero? p/value [return no]				;-- end of the marked space
+				p/value > 0 [							;-- node found
+					n: as int-ptr! p/value
+					s: as int-ptr! n/value
+					&n/value: as-integer n
+					&h/value: s/4							;-- series!/offset
+					&t/value: &h/value + s/3				;-- series!/offset + series!/size
+				]
+				true [									;-- fixed range
+					&t/value: 0 - p/value
+					p: p - 1
+					assert not zero? p/value
+					assert p >= list
+					&h/value: 0 - p/value
+					&n/value: 0
+				]
+			]
+			assert &t/value >= &h/value
+			&p/value: as-integer p
+			yes
+		]
+
+		check-range: func [
+			hd	[byte-ptr!]
+			tl	[byte-ptr!]
+			return: [logic!]							;-- yes if region is allowed
+			/local
+				reg-hd [integer!] reg-tl [integer!] node [integer!]
+				s [int-ptr!] p [integer!] heading? [logic!]
+		][
+			reg-hd: 0  reg-tl: 0  node: 0
+
+			assert hd <= tl
+			if top = list [return yes]					;-- do not do checks outside of mark/back scope
+			if ignored? hd tl [return yes]
+			
+			assert enabled?
+			p: as-integer top
+			heading?: no
+			while [get-next-region :p :reg-hd :reg-tl :node][
+				assert reg-tl >= reg-hd
+
+				if all [reg-hd <= as-integer hd tl <= as byte-ptr! reg-tl] [return yes]		;-- all OK
+
+				if all [reg-hd <= as-integer hd hd <= as byte-ptr! reg-tl] [
+					print-line  "*** MEMGUARD ALERT: over the tail access detected"
+					print-line ["    registered series:^-" as byte-ptr! reg-hd ".." as byte-ptr! reg-tl]
+					print-line ["    requested region: ^-" hd ".." tl]
+					dump-regions
+					assert 1 = 0
+				]
+
+				if all [reg-hd <= as-integer tl tl <= as byte-ptr! reg-tl] [
+					print-line  "*** MEMGUARD ALERT: before the head access detected"
+					print-line ["    registered series:^-" as byte-ptr! reg-hd ".." as byte-ptr! reg-tl]
+					print-line ["    requested region: ^-" hd ".." tl]
+					dump-regions
+					assert 1 = 0
+				]
+			]
+			print-line  "*** MEMGUARD ALERT: access to unallowed memory region detected"
+			print-line ["    requested region: ^-" hd ".." tl]
+			dump-regions
+			assert 1 = 0
+			no
+		]
+
+		dump-regions: func [/local p [integer!] h [integer!] t [integer!] n [integer!] i [integer!]] [
+			h: 0  t: 0  n: 0  i: 1
+			print-line "  * Defined regions so far are:"
+			p: as-integer top
+			while [get-next-region :p :h :t :n] [
+				either zero? n [
+					print-line ["^-^-" i "^-" as byte-ptr! h ".." as byte-ptr! t " (fixed)"]
+				][
+					print-line ["^-^-" i "^-" as byte-ptr! h ".." as byte-ptr! t " (node=" as byte-ptr! n ")"]
+				]
+				i: i + 1
+			]
+		]
+	]
+
 	copy-memory: func [ 
 		target		[byte-ptr!]
 		source		[byte-ptr!]
@@ -163,7 +323,22 @@ Red/System [
 			(target + size) <= source
 			(source + size) <= target
 		]
+		; memguard/check-range source source + size
+		unless memguard/flag-skip-next [memguard/check-range target target + size]
+		memguard/flag-skip-next: no
 		libc.copy-memory target source size
+	]
+
+	move-memory: func [ 
+		target		[byte-ptr!]
+		source		[byte-ptr!]
+		size		[integer!]				;; number of bytes to copy
+		return:		[byte-ptr!]
+	][
+		; memguard/check-range source source + size
+		unless memguard/flag-skip-next [memguard/check-range target target + size]
+		memguard/flag-skip-next: no
+		libc.move-memory target source size
 	]
 ]
 

--- a/system/runtime/libc.reds
+++ b/system/runtime/libc.reds
@@ -298,7 +298,7 @@ Red/System [
 			print-line  "*** MEMGUARD ALERT: access to unallowed memory region detected"
 			print-line ["    requested region: ^-" hd ".." tl]
 			dump-regions
-			assert 1 = 0
+			; assert 1 = 0		;-- better to have assertion in a macro - to report the line number
 			no
 		]
 
@@ -329,7 +329,7 @@ Red/System [
 			(source + size) <= target
 		]
 		; memguard/check-range source source + size
-		unless memguard/flag-skip-next [memguard/check-range target target + size]
+		unless memguard/flag-skip-next [assert yes = memguard/check-range target target + size]
 		memguard/flag-skip-next: no
 		libc.copy-memory target source size
 	]
@@ -341,7 +341,7 @@ Red/System [
 		return:		[byte-ptr!]
 	][
 		; memguard/check-range source source + size
-		unless memguard/flag-skip-next [memguard/check-range target target + size]
+		unless memguard/flag-skip-next [assert yes = memguard/check-range target target + size]
 		memguard/flag-skip-next: no
 		libc.move-memory target source size
 	]

--- a/tests/source/units/clipboard-test.red
+++ b/tests/source/units/clipboard-test.red
@@ -71,6 +71,7 @@ Red [
 			--assert ii2 = read-clipboard
 			unset 'ii2
 
+		unless unset? :draw [
 		--test-- "image-io-3"
 			ii3: draw make image! [100x100 0.200.200.200] [pen purple line-width 5 circle 50x50 40]
 			--assert false <> write-clipboard ii3
@@ -82,6 +83,7 @@ Red [
 			--assert false <> write-clipboard iil1
 			--assert iil1 = read-clipboard
 			unset 'iil1
+		]
 
 	]];; do [if system/platform = 'Windows [
 

--- a/tests/source/units/series-test.red
+++ b/tests/source/units/series-test.red
@@ -272,17 +272,10 @@ Red [
         --assert no = pick cs "caq"
 
     --test-- "series-pick-29"
-        im: make image! [2x2 #{001122 334455 667788 99AABB}]
-        --assert 0.17.34.0     = pick im 1x1
-        --assert 51.68.85.0    = pick im 2x1
-        --assert 102.119.136.0 = pick im 1x2
-        --assert 153.170.187.0 = pick im 2x2
-
-    --test-- "series-pick-30"
         --assert 1 = pick [1 2] yes
         --assert 2 = pick [1 2] no
 
-    --test-- "series-pick-31"                           ;-- issue #3369
+    --test-- "series-pick-30"                           ;-- issue #3369
         a: "12345678"
         b: skip a 6
         remove/part a 4

--- a/tests/source/units/series-test.red
+++ b/tests/source/units/series-test.red
@@ -2630,6 +2630,10 @@ Red [
         str: "a"
         --assert "" = change/part str "1" next str
         --assert "1" = str
+    ;@@ FIXME: #4099
+    ; --test-- "change-str-9"                             ;-- issue #4099
+    ;     --assert "" = change next s: "/\" reduce [s s s]
+    ;     --assert "//\/\/\" = s
 
 	--test-- "change-bin-1"
 		bin: #{12345678}
@@ -2652,6 +2656,11 @@ Red [
 		bin: change bin [a b]
 		--assert #{9033} = bin
 		--assert #{61629033} = head bin
+    ;@@ FIXME: #4099
+    ; --test-- "change-bin-6"                             ;-- issue #4099
+    ;     --assert #{} = change next t: copy s: #{0110} reduce [s s s]
+    ;     --assert #{} = change next s reduce [s s s]
+    ;     --assert t = s
 
 	--test-- "change-vec-1"
 		vec: make vector! [1 2 3 4]
@@ -2737,6 +2746,11 @@ Red [
 		--assert #"b" = last str
 		--assert empty? str2
 
+    ;@@ FIXME: #4099
+    ; --test-- "change/dup-str-3"                         ;-- issue #4099
+    ;     --assert "" = change/dup next s: "/\" reduce [s s s] 2
+    ;     --assert "//\/\/\/\/\/\" = s
+
 	--test-- "change/dup-bin-1"
 		bin: #{12345678}
 		bin1: change/dup bin #"x" 3
@@ -2749,6 +2763,12 @@ Red [
 		--assert 205 = last bin
 		--assert empty? bin2
 
+    ;@@ FIXME: #4099
+    ; --test-- "change/dup-bin-3"                         ;-- issue #4099
+    ;     --assert #{} = change/dup next t: copy s: #{0110} reduce [s s s] 3
+    ;     --assert #{} = change/dup next s reduce [s s s] 3
+    ;     --assert t = s
+
 	--test-- "change/dup-vec-1"
 		vec: make vector! [1 2 3 4]
 		vec1: change/dup vec 5 3
@@ -2760,6 +2780,7 @@ Red [
 		change/dup hs [x y] 2
 		--assert 'y = select hs 'x
 		--assert 3  = select hs 2
+
 ===end-group===
 
 ===start-group=== "change/part"
@@ -2994,6 +3015,11 @@ Red [
         --assert "e" = change/part/dup skip s: "abcde" 4 "!" -3 0
         --assert "ae" = s
 
+    ;@@ FIXME: #4099
+    ; --test-- "change/part-str-19"                       ;-- issue #4099
+    ;     --assert "\" = change/part/dup next s: "/\" reduce [s s s] 0 2
+    ;     --assert "//\/\/\/\/\/\\" = s
+
 	--test-- "change/part-bin-1"
 		bin: #{12345678}
 		bin1: change/part bin #"x" 3
@@ -3017,7 +3043,13 @@ Red [
 		--assert val = first bin3
 		--assert 5 = length? bin
 		--assert 120 = first bin
-	;--test-- "change/part-vec-1"
+
+    ;@@ FIXME: #4099
+    ; --test-- "change/part-bin-5"                        ;-- issue #4099
+    ;     t: copy s: #{0110}
+    ;     --assert #{} = change/part/dup next t reduce [s s s] 0 3
+    ;     --assert #{} = change/part/dup next s reduce [s s s] 0 3
+    ;     --assert t = s
 
 	--test-- "change/part-hash-1"
 		hs: make hash! [a b c 1 2 3]
@@ -3035,12 +3067,11 @@ Red [
         --assert (make hash! [1 2 3]) = change/part b: make hash! [1 2 3] tail b b
         --assert (make hash! [1 2 3]) = b
 
-    ;@@ FIXME: hash table troubles
-    ; --test-- "change/part-hash-4"                       ;-- issue #4088
-    ;     --assert (make hash! [1 2 3]) = probe change/part b: make hash! [1 2 3] next b b
-    ;     --assert (make hash! [2 3 1 2 3]) = probe b
-    ;     --assert (make hash! [2 3 1 2 3]) = probe change/part b next b b
-    ;     --assert (make hash! [3 1 2 3 2 3 1 2 3]) = probe b
+    --test-- "change/part-hash-4"                       ;-- issue #4088
+        --assert (make hash! [1 2 3]) = change/part b: make hash! [1 2 3] next b b
+        --assert (make hash! [2 3 1 2 3]) = b
+        --assert (make hash! [2 3 1 2 3]) = change/part b next b b
+        --assert (make hash! [3 1 2 3 2 3 1 2 3]) = b
 
     --test-- "change/part-hash-5"                       ;-- issue #4088
         --assert (make hash! [3]) = change/part next b: make hash! [1 2 3] b skip b 2

--- a/tests/source/units/series-test.red
+++ b/tests/source/units/series-test.red
@@ -2592,6 +2592,9 @@ Red [
 		blk3: change blk1 [9 8 7 6 5 4 3]
 		--assert empty? blk3
 		--assert 8 = length? blk
+    --test-- "change-blk-4"
+        --assert (reduce [()]) = head change [] ()
+        --assert (reduce [()]) = head change b: [] ()
 
 	--test-- "change-str-1"
 		str: "abcde"
@@ -2623,6 +2626,10 @@ Red [
 	--test-- "change-str-7"
 		str: "我ab/cd"
 		--assert "-cd" = back change/part skip str 3 "-" skip str 4
+    --test-- "change-str-8"
+        str: "a"
+        --assert "" = change/part str "1" next str
+        --assert "1" = str
 
 	--test-- "change-bin-1"
 		bin: #{12345678}

--- a/tests/source/units/series-test.red
+++ b/tests/source/units/series-test.red
@@ -8,6 +8,7 @@ Red [
 ]
 
 #include  %../../../quick-test/quick-test.red
+; qt-verbose: yes
 
 ~~~start-file~~~ "series"
 
@@ -133,6 +134,15 @@ Red [
   	--assert 1 = first back next make hash! [1 2 3 4 5]
   --test-- "series-back-13"
  	 --assert 1 = first back next next #{00010203}
+
+    --test-- "series-back-14"                           ;-- issue #3369
+        a: "12345678"
+        b: skip a 6
+        remove/part a 4
+        --assert 7 = index? b
+        --assert 6 = index? back b
+        --assert 5 = index? back back b
+
 ===end-group===
 
 ===start-group=== "tail"
@@ -148,6 +158,14 @@ Red [
   	--assert none = pick tail hs-ser-2 1
   --test-- "series-tail-5"
   	--assert #{02} = back tail #{0102}
+
+    --test-- "series-tail-6"                            ;-- issue #3369
+        a: "12345678"
+        b: skip a 6
+        remove/part a 4
+        --assert 7 = index? b
+        --assert 5 = index? tail b
+
 ===end-group===
 
 ===start-group=== "pick"
@@ -239,6 +257,105 @@ Red [
   	sp26-b: [4 7 9 [11] test /ref 'red]
   	--assert 'red = pick sp26-b 7
   	
+===end-group===
+
+===start-group=== "series-equal"
+
+  --test-- "series-equal-1"
+  --assert [] = []
+  
+  --test-- "series-equal-2"
+    se2-b: []
+  --assert [] = se2-b
+  
+  --test-- "series-equal-3"
+    se3-b: []
+  --assert se3-b = []
+  
+  --test-- "series-equal-4"
+    se4-b: [1]
+  --assert se4-b = [1]
+  
+  --test-- "series-equal-5"
+    se5-b: ["abcde"]
+  --assert se5-b = ["abcde"]
+
+  --test-- "series-equal-6"
+  --assert #{} = #{}
+
+  --test-- "series-equal-7"
+  --assert #{01} = next #{0001}
+
+  --test-- "series-equal-8"
+  --assert (make hash! []) = make hash! []
+
+  --test-- "series-equal-9"
+  --assert (make hash! [a 2 b 4]) = make hash! [a 2 b 4]
+
+  --test-- "series-equal-10"
+    se10-h: make hash! []
+    append se10-h [a 2 b 4]
+  --assert se10-h = make hash! [a 2 b 4]
+
+    --test-- "series-equal-11"                          ;-- issue #3369
+        a: "12345678"
+        b: skip a 6
+        remove/part a 4
+        --assert a = "5678"
+        --assert "5678" = a
+        --assert b = ""
+        --assert b == ""
+        --assert "" = b
+        --assert "" == b
+        --assert (index? b) <> (index? tail a)
+        --assert not same? b tail a
+        --assert not same? tail a b
+        --assert 7 = index? b
+
+    --test-- "series-equal-12"                          ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        --assert a = [5 6 7 8]
+        --assert [5 6 7 8] = a
+        --assert b = []
+        --assert b == []
+        --assert [] = b
+        --assert [] == b
+        --assert (index? b) <> (index? tail a)
+        --assert not same? b tail a
+        --assert not same? tail a b
+
+    --test-- "series-equal-13"                          ;-- issue #3369
+        a: #{01 02 03 04 05 06 07 08}
+        b: skip a 6
+        remove/part a 4
+        --assert a = #{05 06 07 08}
+        --assert #{05 06 07 08} = a
+        --assert b = #{}
+        --assert b == #{}
+        --assert #{} = b
+        --assert #{} == b
+        --assert (index? b) <> (index? tail a)
+        --assert not same? b tail a
+        --assert not same? tail a b
+        --assert 7 = index? b
+
+    --test-- "series-equal-14"                          ;-- issue #3369
+        a: make vector! [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        --assert a = make vector! [5 6 7 8]
+        --assert (make vector! [5 6 7 8]) = a
+        --assert b = make vector! []
+        --assert b == make vector! []
+        --assert (make vector! []) = b
+        --assert (make vector! []) == b
+        --assert (index? b) <> (index? tail a)
+        --assert not same? b tail a
+        --assert not same? tail a b
+        --assert 7 = index? b
+
 ===end-group===
 
 ===start-group=== "select"
@@ -400,6 +517,103 @@ Red [
   --assert #{C3A9} = append/part #{} "ébc" 2
   --assert #{C3A96263} = append #{} "ébc"
 
+    --test-- "series-append-27"                         ;-- issue #3369
+        a: "12345678"
+        b: skip a 6
+        remove/part a 4
+        append a "999"
+        --assert a = "5678999"
+        --assert b = "9"
+
+    --test-- "series-append-28"                         ;-- issue #3369
+        a: "12345678"
+        b: skip a 6
+        remove/part a 4
+        append/part a a b
+        --assert a = "56785678"
+        --assert b = "78"
+
+    --test-- "series-append-29"                         ;-- issue #3369
+        a: "12345678"
+        b: skip a 6
+        remove/part a 4
+        append/part a b a
+        --assert a = "5678"
+        --assert b = ""
+
+    --test-- "series-append-30"                         ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        append a [9 9 9]
+        --assert a = [5 6 7 8 9 9 9]
+        --assert b = [9]
+
+    --test-- "series-append-31"                         ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        append/part a a b
+        --assert a = [5 6 7 8 5 6 7 8]
+        --assert b = [7 8]
+
+    --test-- "series-append-32"                         ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        append/part a b a
+        --assert a = [5 6 7 8]
+        --assert b = []
+
+    --test-- "series-append-33"                         ;-- issue #3369
+        a: to-binary [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        append a [9 9 9]
+        --assert a = to-binary [5 6 7 8 9 9 9]
+        --assert b = to-binary [9]
+
+    --test-- "series-append-34"                         ;-- issue #3369
+        a: to-binary [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        append/part a a b
+        --assert a = to-binary [5 6 7 8 5 6 7 8]
+        --assert b = to-binary [7 8]
+
+    --test-- "series-append-35"                         ;-- issue #3369
+        a: to-binary [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        append/part a b a
+        --assert a = to-binary [5 6 7 8]
+        --assert b = to-binary []
+
+    --test-- "series-append-36"                         ;-- issue #3369
+        a: make vector! [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        append a [9 9 9]
+        --assert a = make vector! [5 6 7 8 9 9 9]
+        --assert b = make vector! [9]
+
+    ;@@ FIXME: no vector support
+    ; --test-- "series-append-37"
+    ;     a: make vector! [1 2 3 4 5 6 7 8]
+    ;     b: skip a 6
+    ;     remove/part a 4
+    ;     append/part a a b
+    ;     --assert a = make vector! [5 6 7 8 5 6 7 8]
+    ;     --assert b = make vector! [7 8]
+
+    ; --test-- "series-append-38"
+    ;     a: make vector! [1 2 3 4 5 6 7 8]
+    ;     b: skip a 6
+    ;     remove/part a 4
+    ;     append/part a b a
+    ;     --assert a = make vector! [5 6 7 8]
+    ;     --assert b = make vector! []
+
 ===end-group===
 
 ===start-group=== "series-put"
@@ -417,51 +631,66 @@ Red [
     put sp-3 'b 3
   --assert sp-3 = make hash! [a 1 b 3]
 
+    --test-- "series-put-4"                             ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        put b 1 'x
+        --assert a = [5 6 7 8 1 x]
+        --assert b = []
+        put b 1 'x
+        --assert a = [5 6 7 8 1 x 1 x]
+        --assert b = [1 x]
+        put b 1 'y
+        --assert a = [5 6 7 8 1 x 1 y]
+        --assert b = [1 y]
+
+    --test-- "series-put-5"                             ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        put a 5 'x
+        --assert a = [5 x 7 8]
+        --assert b = []
+        put a 1 'y
+        --assert a = [5 x 7 8 1 y]
+        --assert b = []
+        put a 'y 'z
+        --assert a = [5 x 7 8 1 y z]
+        --assert b = [z]
+
+    --test-- "series-put-6"                             ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        put b 1 'x
+        --assert a = make hash! [5 6 7 8 1 x]
+        --assert b = make hash! []
+        put b 1 'x
+        --assert a = make hash! [5 6 7 8 1 x 1 x]
+        --assert b = make hash! [1 x]
+        put b 1 'y
+        --assert a = make hash! [5 6 7 8 1 x 1 y]
+        --assert b = make hash! [1 y]
+
+    --test-- "series-put-7"                             ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        put a 5 'x
+        --assert a = make hash! [5 x 7 8]
+        --assert b = make hash! []
+        put a 1 'y
+        --assert a = make hash! [5 x 7 8 1 y]
+        --assert b = make hash! []
+        put a 'y 'z
+        --assert a = make hash! [5 x 7 8 1 y z]
+        --assert b = make hash! [z]
+
   --test-- "series-put-issue 3567"
 	v: [a 1 c]
 	put v 'c 3
 	--assert v = [a 1 c 3]
-===end-group===
-
-===start-group=== "series-equal"
-
-  --test-- "series-equal-1"
-  --assert [] = []
-  
-  --test-- "series-equal-2"
-    se2-b: []
-  --assert [] = se2-b
-  
-  --test-- "series-equal-3"
-    se3-b: []
-  --assert se3-b = []
-  
-  --test-- "series-equal-4"
-    se4-b: [1]
-  --assert se4-b = [1]
-  
-  --test-- "series-equal-5"
-    se5-b: ["abcde"]
-  --assert se5-b = ["abcde"]
-
-  --test-- "series-equal-6"
-  --assert #{} = #{}
-
-  --test-- "series-equal-7"
-  --assert #{01} = next #{0001}
-
-  --test-- "series-equal-8"
-  --assert (make hash! []) = make hash! []
-
-  --test-- "series-equal-9"
-  --assert (make hash! [a 2 b 4]) = make hash! [a 2 b 4]
-
-  --test-- "series-equal-10"
-    se10-h: make hash! []
-    append se10-h [a 2 b 4]
-  --assert se10-h = make hash! [a 2 b 4]
-
-  
 ===end-group===
 
 ===start-group=== "series-find"
@@ -789,7 +1018,38 @@ Red [
 		put sf-105 'a 1
 		--assert (make hash! [a 1]) = find sf-105 'a
 
+    --test-- "series-find-106"                          ;-- issue #3369
+        a: "12345678"
+        b: skip a 6
+        c: tail a
+        remove/part a 4
+        --assert none? find b "7"
+        --assert none? find/part b "7" c
+        --assert none? find/part c "7" b
+        --assert not none? find/part a "7" b
 		
+    --test-- "series-find-107"                          ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        c: tail a
+        remove/part a 4
+        --assert none? find b [7]
+        --assert none? find/part b [7] c
+        --assert none? find/part c [7] b
+        --assert not none? find/part a [7] b
+
+    ;@@ FIXME: #4091
+    ; --test-- "series-find-108"                          ;-- issue #3369
+    ;     a: make hash! [1 2 3 4 5 6 7 8]
+    ;     b: skip a 6
+    ;     c: tail a
+    ;     remove/part a 4
+    ;     --assert     none? probe find b make hash! [7]
+    ;     --assert not none? probe find a make hash! [7]
+    ;     --assert     none? probe find/part b make hash! [7] c
+    ;     --assert     none? probe find/part c make hash! [7] b
+    ;     --assert not none? probe find/part a make hash! [7] b
+        
 ===end-group===
 
 ===start-group=== "remove"
@@ -833,6 +1093,25 @@ Red [
 		blk: [a 1 1 b 2 2 c 3 3]
 		--assert [a 1 1 c 3 3] =  remove/key/part blk 'b 2
 
+    --test-- "remove-blk-10"                            ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: c': skip a 6
+        d: tail a
+        remove/part a 4
+        --assert same? c remove c'                      ;-- docstring says "returns on the same index"
+        --assert a = [5 6 7 8]
+        --assert c = []
+        --assert 7 = index? remove/part c d
+        --assert a = [5 6 7 8]
+        --assert c = []
+        --assert 3 = index? remove/part b c
+        --assert a = [5 6]
+        --assert b = []
+        --assert 7 = index? remove/part c a
+        --assert a = [5 6]
+        --assert b = []
+
 	--test-- "remove-hash-1"
 		hs-remove-1: make hash! [a 2 3]
 		--assert (make hash! [2 3]) = remove hs-remove-1
@@ -865,6 +1144,25 @@ Red [
 	--test-- "remove-hash-7"
 		hs: make hash! [a 1 1 b 2 2 c 3 3]
 		--assert (make hash! [a 1 1 c 3 3]) =  remove/key/part hs 'b 2
+
+    --test-- "remove-hash-8"                            ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: c': skip a 6
+        d: tail a
+        remove/part a 4
+        --assert same? c remove c'                      ;-- docstring says "returns on the same index"
+        --assert a = make hash! [5 6 7 8]
+        --assert c = make hash! []
+        --assert 7 = index? remove/part c d
+        --assert a = make hash! [5 6 7 8]
+        --assert c = make hash! []
+        --assert 3 = index? remove/part b c
+        --assert a = make hash! [5 6]
+        --assert b = make hash! []
+        --assert 7 = index? remove/part c a
+        --assert a = make hash! [5 6]
+        --assert b = make hash! []
 
 	--test-- "remove-str-1"
 		a: "123"
@@ -902,6 +1200,25 @@ Red [
 		--assert "" = remove back tail a
 		--assert "str12" = head a
 
+    --test-- "remove-str-9"                             ;-- issue #3369
+        a: "12345678"
+        b: skip a 2
+        c: c': skip a 6
+        d: tail a
+        remove/part a 4
+        --assert same? c remove c'                      ;-- docstring says "returns on the same index"
+        --assert a = "5678"
+        --assert c = ""
+        --assert 7 = index? remove/part c d
+        --assert a = "5678"
+        --assert c = ""
+        --assert 3 = index? remove/part b c
+        --assert a = "56"
+        --assert b = ""
+        --assert 7 = index? remove/part c a
+        --assert a = "56"
+        --assert b = ""
+
 	--test-- "remove-bin-1"
 		b: #{00010203}
 		--assert #{010203} = remove b
@@ -911,6 +1228,44 @@ Red [
 		--assert #{000203} = head remove next #{00010203}
 	--test-- "remove-bin-4"
 		--assert #{0003} = head remove/part next #{00010203} 2
+
+    --test-- "remove-bin-5"                             ;-- issue #3369
+        a: to-binary [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: c': skip a 6
+        d: tail a
+        remove/part a 4
+        --assert same? c remove c'                      ;-- docstring says "returns on the same index"
+        --assert a = to-binary [5 6 7 8]
+        --assert c = to-binary []
+        --assert 7 = index? remove/part c d
+        --assert a = to-binary [5 6 7 8]
+        --assert c = to-binary []
+        --assert 3 = index? remove/part b c
+        --assert a = to-binary [5 6]
+        --assert b = to-binary []
+        --assert 7 = index? remove/part c a
+        --assert a = to-binary [5 6]
+        --assert b = to-binary []
+
+    --test-- "remove-vec-1"                             ;-- issue #3369
+        a: make vector! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: c': skip a 6
+        d: tail a
+        remove/part a 4
+        --assert same? c remove c'                      ;-- docstring says "returns on the same index"
+        --assert a = make vector! [5 6 7 8]
+        --assert c = make vector! []
+        --assert 7 = index? remove/part c d
+        --assert a = make vector! [5 6 7 8]
+        --assert c = make vector! []
+        --assert 3 = index? remove/part b c
+        --assert a = make vector! [5 6]
+        --assert b = make vector! []
+        --assert 7 = index? remove/part c a
+        --assert a = make vector! [5 6]
+        --assert b = make vector! []
 
 ===end-group===
 
@@ -966,6 +1321,19 @@ Red [
 		--assert empty? clear #{0102}
 	--test-- "clear-12"
 		--assert #{01} = head clear next #{010203}
+
+    --test-- "clear-13"                                 ;-- issue #3369
+        a: "12345678"
+        b: skip a 2
+        c: skip b 4
+        --assert 3 = index? clear b
+        --assert 3 = index? b
+        --assert 7 = index? clear c
+        --assert 7 = index? c
+        --assert a = "12"
+        --assert b = ""
+        --assert c = ""
+
 ===end-group===
 
 ===start-group=== "at"
@@ -1017,21 +1385,63 @@ Red [
 		code: [print "Hello"]
 		--assert 'print = first replace code "Hello" "Cheers"
 		--assert "Cheers" = second code
-	--test-- "replace-str"
+
+    --test-- "replace-block-2"                          ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        --assert [] = replace/all b 7 9
+        --assert [5 6 7 8] = a
+        --assert [5 6 9 8] = replace/all a 7 9
+
+    --test-- "replace-hash-1"                           ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        --assert (make hash! []) = replace/all b 7 9
+        --assert (make hash! [5 6 7 8]) = a
+        --assert (make hash! [5 6 9 8]) = replace/all a 7 9
+
+    --test-- "replace-vector-1"                         ;-- issue #3369
+        a: make vector! [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        --assert (make vector! []) = replace/all b 7 9
+        --assert (make vector! [5 6 7 8]) = a
+        --assert (make vector! [5 6 9 8]) = replace/all a 7 9
+
+	--test-- "replace-str-1"
 		--assert "Xbab" = replace "abab" #"a" #"X"
 		--assert "XbXb" = replace/all "abab" #"a" #"X"
 		--assert "Xab" = replace "abab" "ab" "X"
 		--assert "abab" = replace/all "abab" #"a" #"a"
 
-	--test-- "replace-bin"
+    --test-- "replace-str-2"                            ;-- issue #3369
+        a: "12345678"
+        b: skip a 6
+        remove/part a 4
+        --assert "" = replace/all b "7" "9"
+        --assert "5678" = a
+        --assert "5698" = replace/all a "7" "9"
+        ; --assert "5998" = replace/all a 6 9
+    
+	--test-- "replace-bin-1"
 		--assert #{FF0201} = replace #{010201} #{01} #{FF}
 		--assert #{FF02FF} = replace/all #{010201} #{01} #{FF}
 		--assert #{FF03}   = replace #{010203} #{0102} #{FF}
 		--assert #{FFFFFF03} = replace #{010203} #{0102} #{FFFFFF}
 
+    --test-- "replace-bin-2"                            ;-- issue #3369
+        a: to-binary [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        remove/part a 4
+        --assert #{} = replace/all b #{07} #{09}
+        --assert (to-binary [5 6 7 8]) = a
+        --assert (to-binary [5 6 9 8]) = replace/all a #{07} #{09}
+
 	--test-- "replace-bitset-issue-#3132"
 		--assert "s" = replace/all "test" charset [#"t" #"e"] ""
-	
+
 ===end-group===
 
 ===start-group=== "max/min"			;-- have some overlap with lesser tests
@@ -1079,6 +1489,22 @@ Red [
 		s: "abcdef"
 		p: next next next s
 		--assert "cbadef" = reverse/part s p
+
+    --test-- "reverse-str-6"                            ;-- issue #3369
+        a: "12345678"
+        b: skip a 2
+        c: c': skip a 6
+        remove/part a 4
+        --assert 7 = index? reverse c                   ;-- docstring says "returns at same position"
+        --assert same? c' reverse c
+        --assert c = ""
+        --assert a = "5678"
+        --assert "87" = reverse b
+        --assert a = "5687"
+        --assert "78" = reverse/part b c
+        --assert 7 = index? c
+        --assert 3 = index? b
+        --assert a = "5678"
 
 	--test-- "reverse-file-1"			;-- inherit from string!
 		--assert %321cba = reverse/part %abc123 6
@@ -1162,10 +1588,77 @@ Red [
 		--assert b = c: take/deep a
 		--assert b <> remove c
 
-	--test-- "take-blk-5"
+	--test-- "take-blk-10"
 		a: [1 2 3]
 		--assert [1 2 3] = take/part a 22
 		--assert [] = a
+
+    --test-- "take-blk-11"                              ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert none? take c
+        --assert [] = take/part c d
+        --assert [] = take/part d c
+        --assert none? take/last c
+        --assert [7 8] = take/part c b
+        --assert 7 = index? c
+        --assert [] = take/part b c
+        --assert [5 6 7 8] = append a [7 8]
+        --assert [7 8] = take/part b c
+        --assert [5 6] = a
+        --assert 6 = take/last a
+
+    --test-- "take-blk-12"                              ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert [] = take/part/last c d
+        --assert [] = take/part/last d c
+        --assert [] = take/part/last b c
+        --assert [] = take/part/last c b
+        --assert [] = take/part/last a d
+        --assert [] = take/part/last d a
+        --assert [7 8] = take/part/last b a
+        --assert [5 6 7 8] = append a [7 8]
+        --assert [7 8] = take/part/last a b
+        --assert [5 6 7 8] = append a [7 8]
+        --assert [7 8] = take/part/last a 2
+        --assert [5 6 7 8] = append a [7 8]
+        --assert [7 8] = take/part/last c 2
+        --assert [] = take/part/last c 0
+        --assert [] = take/part/last c -2
+        --assert [] = take/part/last b -2
+        --assert [] = take/part/last a -2
+        --assert 7 = index? c
+
+    --test-- "take-blk-13"                              ;-- issue #4078
+        --assert [     ] = take/part      s: [1 2 3]    -1
+        --assert [1    ] = take/part skip s: [1 2 3] 1  -1
+        --assert [2    ] = take/part skip s: [1 2 3] 2  -1
+        --assert [3    ] = take/part skip s: [1 2 3] 3  -1
+        --assert [1    ] = take/part skip s: [1 2 3] 1  -2
+        --assert [1 2  ] = take/part skip s: [1 2 3] 2  -2
+        --assert [2 3  ] = take/part skip s: [1 2 3] 3  -2
+        --assert [1    ] = take/part skip s: [1 2 3] 1  -3
+        --assert [1 2  ] = take/part skip s: [1 2 3] 2  -3
+        --assert [1 2 3] = take/part skip s: [1 2 3] 3  -3
+        --assert [1    ] = take/part      s: [1 2 3]    skip s 1
+        --assert [1    ] = take/part skip s: [1 2 3] 1       s
+        --assert [2    ] = take/part skip s: [1 2 3] 1  skip s 2
+        --assert [2    ] = take/part skip s: [1 2 3] 2  skip s 1
+        --assert [3    ] = take/part skip s: [1 2 3] 2  skip s 3
+        --assert [3    ] = take/part skip s: [1 2 3] 3  skip s 2
+        --assert [1 2  ] = take/part      s: [1 2 3]    skip s 2
+        --assert [1 2  ] = take/part skip s: [1 2 3] 2       s
+        --assert [2 3  ] = take/part skip s: [1 2 3] 1  skip s 3
+        --assert [2 3  ] = take/part skip s: [1 2 3] 3  skip s 1
+        --assert [1 2 3] = take/part      s: [1 2 3]    skip s 3
+        --assert [1 2 3] = take/part skip s: [1 2 3] 3       s
 
 	--test-- "take-str-1"
 		a: "123"
@@ -1215,6 +1708,72 @@ Red [
 		--assert "123" = take/part a 22
 		--assert "" = a
 
+    --test-- "take-str-11"                              ;-- issue #3369
+        a: "12345678"
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert none? take c
+        --assert "" = take/part c d
+        --assert "" = take/part d c
+        --assert none? take/last c
+        --assert "78" = take/part c b
+        --assert 7 = index? c
+        --assert "5678" = append a "78"
+        --assert "78" = take/part b c
+        --assert "56" = a
+        --assert #"6" = take/last a
+
+    --test-- "take-str-12"                              ;-- issue #3369
+        a: "12345678"
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert "" = take/part/last c d
+        --assert "" = take/part/last d c
+        --assert "" = take/part/last b c
+        --assert "" = take/part/last c b
+        --assert "" = take/part/last a d
+        --assert "" = take/part/last d a
+        --assert "78" = take/part/last b a
+        --assert "5678" = append a "78"
+        --assert "78" = take/part/last a b
+        --assert "5678" = append a "78"
+        --assert "78" = take/part/last a 2
+        --assert "5678" = append a "78"
+        --assert "78" = take/part/last c 2
+        --assert "" = take/part/last c 0
+        --assert "" = take/part/last c -2
+        --assert "" = take/part/last b -2
+        --assert "" = take/part/last a -2
+        --assert 7 = index? c
+
+    --test-- "take-str-13"                              ;-- issue #4078
+        --assert ""    = take/part      s: "123"    -1
+        --assert "1"   = take/part skip s: "123" 1  -1
+        --assert "2"   = take/part skip s: "123" 2  -1
+        --assert "3"   = take/part skip s: "123" 3  -1
+        --assert "1"   = take/part skip s: "123" 1  -2
+        --assert "12"  = take/part skip s: "123" 2  -2
+        --assert "23"  = take/part skip s: "123" 3  -2
+        --assert "1"   = take/part skip s: "123" 1  -3
+        --assert "12"  = take/part skip s: "123" 2  -3
+        --assert "123" = take/part skip s: "123" 3  -3
+        --assert "1"   = take/part      s: "123"    skip s 1
+        --assert "1"   = take/part skip s: "123" 1       s
+        --assert "2"   = take/part skip s: "123" 1  skip s 2
+        --assert "2"   = take/part skip s: "123" 2  skip s 1
+        --assert "3"   = take/part skip s: "123" 2  skip s 3
+        --assert "3"   = take/part skip s: "123" 3  skip s 2
+        --assert "12"  = take/part      s: "123"    skip s 2
+        --assert "12"  = take/part skip s: "123" 2       s
+        --assert "23"  = take/part skip s: "123" 1  skip s 3
+        --assert "23"  = take/part skip s: "123" 3  skip s 1
+        --assert "123" = take/part      s: "123"    skip s 3
+        --assert "123" = take/part skip s: "123" 3       s
+
 	--test-- "take-hash-1"
 		h: make hash! [1 2 3]
 		--assert 1 = take h
@@ -1230,6 +1789,78 @@ Red [
 		h: make hash! [1 2 3]
 		--assert 2 = take next h
 		--assert 3 = select h 1
+
+    --test-- "take-hash-4"
+        a: make hash! [1 2 3]
+        --assert none? take tail a
+        --assert (make hash! []) = take/part tail a tail a
+
+    --test-- "take-hash-5"                              ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert none? take c
+        --assert (make hash! []) = take/part c d
+        --assert (make hash! []) = take/part d c
+        --assert none? take/last c
+        --assert (make hash! [7 8]) = take/part c b
+        --assert 7 = index? c
+        --assert (make hash! [5 6 7 8]) = append a make hash! [7 8]
+        --assert (make hash! [7 8]) = take/part b c
+        --assert (make hash! [5 6]) = a
+        --assert 6 = take/last a
+        --assert (make hash! [5]) = a
+
+    --test-- "take-hash-6"                              ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert (make hash! []) = take/part/last c d
+        --assert (make hash! []) = take/part/last d c
+        --assert (make hash! []) = take/part/last b c
+        --assert (make hash! []) = take/part/last c b
+        --assert (make hash! []) = take/part/last a d
+        --assert (make hash! []) = take/part/last d a
+        --assert (make hash! [7 8]) = take/part/last b a
+        --assert (make hash! [5 6 7 8]) = append a make hash! [7 8]
+        --assert (make hash! [7 8]) = take/part/last a b
+        --assert (make hash! [5 6 7 8]) = append a make hash! [7 8]
+        --assert (make hash! [7 8]) = take/part/last a 2
+        --assert (make hash! [5 6 7 8]) = append a make hash! [7 8]
+        --assert (make hash! [7 8]) = take/part/last c 2
+        --assert (make hash! []) = take/part/last c 0
+        --assert (make hash! []) = take/part/last c -2
+        --assert (make hash! []) = take/part/last b -2
+        --assert (make hash! []) = take/part/last a -2
+        --assert 7 = index? c
+
+    --test-- "take-hash-7"                              ;-- issue #4078
+        --assert (make hash! [     ]) = take/part      s: make hash! [1 2 3]    -1
+        --assert (make hash! [1    ]) = take/part skip s: make hash! [1 2 3] 1  -1
+        --assert (make hash! [2    ]) = take/part skip s: make hash! [1 2 3] 2  -1
+        --assert (make hash! [3    ]) = take/part skip s: make hash! [1 2 3] 3  -1
+        --assert (make hash! [1    ]) = take/part skip s: make hash! [1 2 3] 1  -2
+        --assert (make hash! [1 2  ]) = take/part skip s: make hash! [1 2 3] 2  -2
+        --assert (make hash! [2 3  ]) = take/part skip s: make hash! [1 2 3] 3  -2
+        --assert (make hash! [1    ]) = take/part skip s: make hash! [1 2 3] 1  -3
+        --assert (make hash! [1 2  ]) = take/part skip s: make hash! [1 2 3] 2  -3
+        --assert (make hash! [1 2 3]) = take/part skip s: make hash! [1 2 3] 3  -3
+        --assert (make hash! [1    ]) = take/part      s: make hash! [1 2 3]    skip s 1
+        --assert (make hash! [1    ]) = take/part skip s: make hash! [1 2 3] 1       s
+        --assert (make hash! [2    ]) = take/part skip s: make hash! [1 2 3] 1  skip s 2
+        --assert (make hash! [2    ]) = take/part skip s: make hash! [1 2 3] 2  skip s 1
+        --assert (make hash! [3    ]) = take/part skip s: make hash! [1 2 3] 2  skip s 3
+        --assert (make hash! [3    ]) = take/part skip s: make hash! [1 2 3] 3  skip s 2
+        --assert (make hash! [1 2  ]) = take/part      s: make hash! [1 2 3]    skip s 2
+        --assert (make hash! [1 2  ]) = take/part skip s: make hash! [1 2 3] 2       s
+        --assert (make hash! [2 3  ]) = take/part skip s: make hash! [1 2 3] 1  skip s 3
+        --assert (make hash! [2 3  ]) = take/part skip s: make hash! [1 2 3] 3  skip s 1
+        --assert (make hash! [1 2 3]) = take/part      s: make hash! [1 2 3]    skip s 3
+        --assert (make hash! [1 2 3]) = take/part skip s: make hash! [1 2 3] 3       s
 
 	--test-- "take-bin-1"
 		b: #{0102}
@@ -1274,6 +1905,93 @@ Red [
 		--assert #{0203} = take/part/last b next b
 		--assert #{01} = b
 
+    --test-- "take-bin-10"                              ;-- issue #3369
+        a: make binary! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert none? take c
+        --assert (make binary! []) = take/part c d
+        --assert (make binary! []) = take/part d c
+        --assert none? take/last c
+        --assert (make binary! [7 8]) = take/part c b
+        --assert 7 = index? c
+        --assert (make binary! [5 6 7 8]) = append a make binary! [7 8]
+        --assert (make binary! [7 8]) = take/part b c
+        --assert (make binary! [5 6]) = a
+        --assert 6 = take/last a
+        --assert (make binary! [5]) = a
+
+    --test-- "take-bin-11"                              ;-- issue #3369
+        a: make binary! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert (make binary! []) = take/part/last c d
+        --assert (make binary! []) = take/part/last d c
+        --assert (make binary! []) = take/part/last b c
+        --assert (make binary! []) = take/part/last c b
+        --assert (make binary! []) = take/part/last a d
+        --assert (make binary! []) = take/part/last d a
+        --assert (make binary! [7 8]) = take/part/last b a
+        --assert (make binary! [5 6 7 8]) = append a make binary! [7 8]
+        --assert (make binary! [7 8]) = take/part/last a b
+        --assert (make binary! [5 6 7 8]) = append a make binary! [7 8]
+        --assert (make binary! [7 8]) = take/part/last a 2
+        --assert (make binary! [5 6 7 8]) = append a make binary! [7 8]
+        --assert (make binary! [7 8]) = take/part/last c 2
+        --assert (make binary! []) = take/part/last c 0
+        --assert (make binary! []) = take/part/last c -2
+        --assert (make binary! []) = take/part/last b -2
+        --assert (make binary! []) = take/part/last a -2
+        --assert 7 = index? c
+
+    ;@@ FIXME: no vector support
+    ; --test-- "take-vector-1"
+    ;     a: make vector! [1 2 3 4 5 6 7 8]
+    ;     b: skip a 2
+    ;     c: skip a 6
+    ;     d: tail a
+    ;     remove/part a 4
+    ;     --assert none? take c
+    ;     --assert none? take/part c d
+    ;     --assert none? take/part d c
+    ;     --assert none? take/last c
+    ;     --assert none? take/part c b
+    ;     --assert 7 = index? c
+    ;     --assert (make vector! [5 6 7 8]) = append a make vector! [7 8]
+    ;     --assert (make vector! [7 8]) = take/part b c
+    ;     --assert (make vector! [5 6]) = a
+    ;     --assert 6 = take/last a
+    ;     --assert (make vector! [5]) = a
+
+    ; --test-- "take-vector-2"
+    ;     a: make vector! [1 2 3 4 5 6 7 8]
+    ;     b: skip a 2
+    ;     c: skip a 6
+    ;     d: tail a
+    ;     remove/part a 4
+    ;     --assert (make vector! []) = take/part/last c d
+    ;     --assert (make vector! []) = take/part/last d c
+    ;     --assert (make vector! []) = take/part/last b c
+    ;     --assert (make vector! []) = take/part/last c b
+    ;     --assert (make vector! []) = take/part/last a d
+    ;     --assert (make vector! []) = take/part/last d a
+    ;     --assert (make vector! [7 8]) = take/part/last b a
+    ;     --assert (make vector! [5 6 7 8]) = append a make vector! [7 8]
+    ;     --assert (make vector! [7 8]) = take/part/last a b
+    ;     --assert (make vector! [5 6 7 8]) = append a make vector! [7 8]
+    ;     --assert (make vector! [7 8]) = take/part/last a 2
+    ;     --assert (make vector! [5 6 7 8]) = append a make vector! [7 8]
+    ;     --assert (make vector! [7 8]) = take/part/last c 2
+    ;     --assert (make vector! []) = take/part/last c 0
+    ;     --assert (make vector! []) = take/part/last c -2
+    ;     --assert (make vector! []) = take/part/last b -2
+    ;     --assert (make vector! []) = take/part/last a -2
+    ;     --assert 7 = index? c
+
 ===end-group===
 
 ===start-group=== "swap"
@@ -1298,6 +2016,19 @@ Red [
 	--test-- "swap-str-4"
 		--assert "123" = swap "123" ""
 
+    --test-- "swap-str-5"                               ;-- issue #3369
+        a: "12345678"
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert "" = swap c d
+        --assert "" = swap c b
+        --assert "5678" = swap a c
+        --assert "5678" = swap a d
+        --assert   "58" = swap b a
+        --assert "5678" = swap a b
+
 	--test-- "swap-blk-1"
 		a: [1 2]
 		b: [a b]
@@ -1315,6 +2046,19 @@ Red [
 	--test-- "swap-blk-3"
 		--assert [1 a] = swap [1 a] []
 
+    --test-- "swap-blk-4"                               ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert [] = swap c d
+        --assert [] = swap c b
+        --assert [5 6 7 8] = swap a c
+        --assert [5 6 7 8] = swap a d
+        --assert     [5 8] = swap b a
+        --assert [5 6 7 8] = swap a b
+
 	--test-- "swap-hash-1"
 		a: make hash! [1 2]
 		b: make hash! [a b]
@@ -1322,13 +2066,53 @@ Red [
 		--assert 2 = a/a
 		--assert 'b = select b 1
 
-	--test-- "swap-bin"
+    --test-- "swap-hash-2"                              ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert (make hash! []) = swap c d
+        --assert (make hash! []) = swap c b
+        --assert (make hash! [5 6 7 8]) = swap a c
+        --assert (make hash! [5 6 7 8]) = swap a d
+        --assert (make hash!     [5 8]) = swap b a
+        --assert (make hash! [5 6 7 8]) = swap a b
+
+	--test-- "swap-bin-1"
 		a: #{0102}
 		b: #{0304}					;-- 𠃌 = #"^(200CC)"
 		--assert #{0302} = swap a b
 		--assert #{0302} = a
 		--assert #{0104} = b
 		--assert #{0104} = swap b #{}
+
+    --test-- "swap-bin-2"                               ;-- issue #3369
+        a: make binary! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert (make binary! []) = swap c d
+        --assert (make binary! []) = swap c b
+        --assert (make binary! [5 6 7 8]) = swap a c
+        --assert (make binary! [5 6 7 8]) = swap a d
+        --assert (make binary!     [5 8]) = swap b a
+        --assert (make binary! [5 6 7 8]) = swap a b
+
+    ;@@FIXME: no vector support
+    ; --test-- "swap-vector-1"
+    ;     a: make vector! [1 2 3 4 5 6 7 8]
+    ;     b: skip a 2
+    ;     c: skip a 6
+    ;     d: tail a
+    ;     remove/part a 4
+    ;     --assert (make vector! []) = swap c d
+    ;     --assert (make vector! []) = swap c b
+    ;     --assert (make vector! [5 6 7 8]) = swap a c
+    ;     --assert (make vector! [5 6 7 8]) = swap a d
+    ;     --assert (make vector!     [5 8]) = swap b a
+    ;     --assert (make vector! [5 6 7 8]) = swap a b
 
 ===end-group===
 
@@ -1370,8 +2154,50 @@ Red [
 	--test-- "trim-str-11"
 		--assert "    ^-1^/    b2^-  ^/  c3  ^/  ^/^/" = trim/with copy mstr 97
 
+    --test-- "trim-str-12"                              ;-- issue #3369
+        a: " 2 4 6 8"
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert ""   = trim d
+        --assert ""   = trim c
+        --assert "8"  = trim b
+        --assert 3    = index? b
+        --assert " 68"= a
+        --assert "68" = trim a
+        --assert "68" = a
+
+    --test-- "trim-str-13"                              ;-- issue #3369
+        a: " 2 4 6 8"
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert ""   = trim/with d "1234"
+        --assert 9    = index? d
+        --assert " 6 8" = trim/with a c
+        --assert " 6 8" = a
+        --assert 7    = index? c
+        --assert "46" = trim/with "468" b
+        --assert 3    = index? b
+
 	--test-- "trim-block-1"
 		--assert [1 2] = trim [#[none] 1 #[none] 2 #[none]]
+
+    --test-- "trim-block-2"                             ;-- issue #3369
+        a: reduce [none 2 none 4 none 6 none 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert []   = trim d
+        --assert []   = trim c
+        --assert [8]  = trim b
+        --assert 3    = index? b
+        --assert [#[none] 6 8] = a
+        --assert [6 8] = trim a
+        --assert [6 8] = a
 
 	--test-- "trim-bin-1"
 		--assert #{} = trim #{00}
@@ -1384,6 +2210,35 @@ Red [
 
 	--test-- "trim-bin-4"
 		--assert #{00001234} = trim/tail #{000012340000}
+
+    --test-- "trim-bin-5"                               ;-- issue #3369
+        a: #{00 02 00 04 00 06 00 08}
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert #{}   = trim d
+        --assert #{}   = trim c
+        --assert #{08} = trim b
+        --assert 3     = index? b
+        --assert #{000608} = a
+        --assert #{0608}   = trim a
+        --assert #{0608}   = a
+
+    --test-- "trim-bin-6"                               ;-- issue #3369
+        a: #{00 02 00 04 00 06 00 08}
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert #{}  = trim/with d #{0a0b0c0d}
+        --assert 9    = index? d
+        --assert #{00060008} = trim/with a c
+        --assert #{00060008} = a
+        --assert 7    = index? c
+        --assert #{0406} = trim/with #{040608} b
+        --assert 3    = index? b
+
 ===end-group===
 
 ===start-group=== "sort"
@@ -1407,6 +2262,39 @@ Red [
 		--assert "1cd2ab3ef4gh" = sort/skip a 3
 		--assert "12abcd3ef4gh" = sort/part a 6
 		--assert "34efgh" = sort/part skip a 6 tail a
+
+    --test-- "sort-str-5"                               ;-- issue #3369
+        a: "12345678"
+        b: skip a 2
+        c: skip a 6
+        remove/part a 4
+        --assert "" = sort c
+        --assert 7 = index? c
+        --assert "87"   = sort/reverse b
+        --assert "5687" = a
+        --assert "8765" = sort/reverse a
+        --assert "56"   = sort/part c b
+        --assert "65"   = sort/part/reverse b c
+        --assert "7865" = sort/part b -2
+        --assert "7865" = a
+
+    --test-- "sort-str-6"                               ;-- issue #4083
+        --assert "4321" = sort/part skip s: "4321" -100 s
+        --assert "4321" = sort/part skip s: "4321" 0 s
+        --assert "4321" = sort/part skip s: "4321" 1 s
+        --assert "3421" = sort/part skip s: "4321" 2 s
+        --assert "2341" = sort/part skip s: "4321" 3 s
+        --assert "1234" = sort/part skip s: "4321" 4 s
+        --assert "1234" = sort/part skip s: "4321" 100 s
+
+    --test-- "sort-str-7"                               ;-- issue #4083
+        --assert   "12" = sort/part skip s: "4321" 2 100
+        --assert   "12" = sort/part skip s: "4321" 2 2
+        --assert   "21" = sort/part skip s: "4321" 2 1
+        --assert   "21" = sort/part skip s: "4321" 2 0
+        --assert  "321" = sort/part skip s: "4321" 2 -1
+        --assert "3421" = sort/part skip s: "4321" 2 -2
+        --assert "3421" = sort/part skip s: "4321" 2 -100
 
 	--test-- "sort-blk-1"
 		a: [bc 799 ab2 42 bb1 321.3 "Mo" "Curly" "Larry" -24 0 321.8] 
@@ -1448,6 +2336,90 @@ Red [
 		--assert [1 2 3 4 5 6] = sort/compare [1 2 3 4 5 6] func [a b] [a < b]
 		--assert [6 5 4 3 2 1] = sort/compare [1 2 3 4 5 6] func [a b] [a > b]
 		
+    --test-- "sort-blk-5"                               ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        remove/part a 4
+        --assert [] = sort c
+        --assert 7 = index? c
+        --assert [8 7]     = sort/reverse b
+        --assert [5 6 8 7] = a
+        --assert [8 7 6 5] = sort/reverse a
+        --assert [5 6]     = sort/part c b
+        --assert [6 5]     = sort/part/reverse b c
+        --assert 3 = index? b
+        --assert [7 8 6 5] = sort/part b -2
+        --assert [7 8 6 5] = a
+
+    --test-- "sort-blk-6"                               ;-- issue #4083
+        --assert [4 3 2 1] = sort/part skip s: [4 3 2 1] -100 s
+        --assert [4 3 2 1] = sort/part skip s: [4 3 2 1] 0 s
+        --assert [4 3 2 1] = sort/part skip s: [4 3 2 1] 1 s
+        --assert [3 4 2 1] = sort/part skip s: [4 3 2 1] 2 s
+        --assert [2 3 4 1] = sort/part skip s: [4 3 2 1] 3 s
+        --assert [1 2 3 4] = sort/part skip s: [4 3 2 1] 4 s
+        --assert [1 2 3 4] = sort/part skip s: [4 3 2 1] 100 s
+
+    --test-- "sort-blk-7"                               ;-- issue #4083
+        --assert [    1 2] = sort/part skip s: [4 3 2 1] 2 100
+        --assert [    1 2] = sort/part skip s: [4 3 2 1] 2 2
+        --assert [    2 1] = sort/part skip s: [4 3 2 1] 2 1
+        --assert [    2 1] = sort/part skip s: [4 3 2 1] 2 0
+        --assert [  3 2 1] = sort/part skip s: [4 3 2 1] 2 -1
+        --assert [3 4 2 1] = sort/part skip s: [4 3 2 1] 2 -2
+        --assert [3 4 2 1] = sort/part skip s: [4 3 2 1] 2 -100
+
+    --test-- "sort-hash-1"                              ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        remove/part a 4
+        --assert (make hash! []) = sort c
+        --assert 7 = index? c
+        --assert (make hash! [8 7]    ) = sort/reverse b
+        --assert (make hash! [5 6 8 7]) = a
+        --assert (make hash! [8 7 6 5]) = sort/reverse a
+        --assert (make hash! [5 6]    ) = sort/part c b
+        --assert (make hash! [6 5]    ) = sort/part/reverse b c
+        --assert 3 = index? b
+        --assert (make hash! [7 8 6 5]) = sort/part b -2
+        --assert (make hash! [7 8 6 5]) = a
+
+    --test-- "sort-hash-2"                              ;-- issue #4083
+        --assert (make hash! [4 3 2 1]) = sort/part skip s: make hash! [4 3 2 1] -100 s
+        --assert (make hash! [4 3 2 1]) = sort/part skip s: make hash! [4 3 2 1] 0 s
+        --assert (make hash! [4 3 2 1]) = sort/part skip s: make hash! [4 3 2 1] 1 s
+        --assert (make hash! [3 4 2 1]) = sort/part skip s: make hash! [4 3 2 1] 2 s
+        --assert (make hash! [2 3 4 1]) = sort/part skip s: make hash! [4 3 2 1] 3 s
+        --assert (make hash! [1 2 3 4]) = sort/part skip s: make hash! [4 3 2 1] 4 s
+        --assert (make hash! [1 2 3 4]) = sort/part skip s: make hash! [4 3 2 1] 100 s
+
+    --test-- "sort-hash-3"                              ;-- issue #4083
+        --assert (make hash! [    1 2]) = sort/part skip s: make hash! [4 3 2 1] 2 100
+        --assert (make hash! [    1 2]) = sort/part skip s: make hash! [4 3 2 1] 2 2
+        --assert (make hash! [    2 1]) = sort/part skip s: make hash! [4 3 2 1] 2 1
+        --assert (make hash! [    2 1]) = sort/part skip s: make hash! [4 3 2 1] 2 0
+        --assert (make hash! [  3 2 1]) = sort/part skip s: make hash! [4 3 2 1] 2 -1
+        --assert (make hash! [3 4 2 1]) = sort/part skip s: make hash! [4 3 2 1] 2 -2
+        --assert (make hash! [3 4 2 1]) = sort/part skip s: make hash! [4 3 2 1] 2 -100
+
+    --test-- "sort-vector-1"                            ;-- issue #3369
+        a: make vector! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        remove/part a 4
+        --assert (make vector! []) = sort c
+        --assert 7 = index? c
+        --assert (make vector! [8 7]    ) = sort/reverse b
+        --assert (make vector! [5 6 8 7]) = a
+        --assert (make vector! [8 7 6 5]) = sort/reverse a
+        --assert (make vector! [5 6]    ) = sort/part c b
+        --assert (make vector! [6 5]    ) = sort/part/reverse b c
+        --assert 3 = index? b
+        --assert (make vector! [7 8 6 5]) = sort/part b -2
+        --assert (make vector! [7 8 6 5]) = a
+
 ===end-group===
 
 ===start-group=== "path access"	
@@ -1484,15 +2456,63 @@ Red [
 
 ===start-group=== "set operations"	
 
-	--test-- "set-op-blk"
-		a: [1 3 2 4]
-		b: [3 4 5 4 6]
-		--assert [3 4 5 6]		= unique b
-		--assert [1 3 2 4 5 6]	= union a b
-		--assert [3 4]			= intersect a b
-		--assert [1 2 5 6]		= difference a b
-		--assert [1 2]			= exclude a b
-		--assert [5 6]			= exclude b a
+    --test-- "set-op-blk"
+        a: [1 3 2 4]
+        b: [3 4 5 4 6]
+        --assert [3 4 5 6]      = unique b
+        --assert [1 3 2 4 5 6]  = union a b
+        --assert [3 4]          = intersect a b
+        --assert [1 2 5 6]      = difference a b
+        --assert [1 2]          = exclude a b
+        --assert [5 6]          = exclude b a
+
+    --test-- "set-op-blk-2"
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        remove/part a 4
+        --assert []        = unique c
+        --assert [7 8]     = unique b
+        --assert [5 6 7 8] = unique a
+        --assert [5 6 7 8] = union a b
+        --assert [7 8]     = union c b
+        --assert [7 8]     = intersect a b
+        --assert [7 8]     = intersect b a
+        --assert [5 6]     = difference a b
+        --assert [5 6]     = difference b a
+        --assert [5 6]     = exclude a b
+        --assert []        = exclude b a
+
+    ;@@ FIXME: #4086
+    ; --test-- "set-op-hash-1"
+    ;     a: make hash! [5 6 7 8]
+    ;     b: skip a 2
+    ;     --assert (make hash! [7 8]    ) = unique b
+    ;     --assert (make hash! [5 6 7 8]) = unique a
+    ;     --assert (make hash! [5 6 7 8]) = union a b
+    ;     --assert (make hash! [7 8]    ) = intersect a b
+    ;     --assert (make hash! [7 8]    ) = intersect b a
+    ;     --assert (make hash! [5 6]    ) = difference a b
+    ;     --assert (make hash! [5 6]    ) = difference b a
+    ;     --assert (make hash! [5 6]    ) = exclude a b
+    ;     --assert (make hash! []       ) = exclude b a
+
+    ; --test-- "set-op-hash-2"
+    ;     a: make hash! [1 2 3 4 5 6 7 8]
+    ;     b: skip a 2
+    ;     c: skip a 6
+    ;     remove/part a 4
+    ;     --assert (make hash! []       ) = unique c
+    ;     --assert (make hash! [7 8]    ) = unique b
+    ;     --assert (make hash! [5 6 7 8]) = unique a
+    ;     --assert (make hash! [5 6 7 8]) = union a b
+    ;     --assert (make hash! [7 8]    ) = union c b
+    ;     --assert (make hash! [7 8]    ) = intersect a b
+    ;     --assert (make hash! [7 8]    ) = intersect b a
+    ;     --assert (make hash! [5 6]    ) = difference a b
+    ;     --assert (make hash! [5 6]    ) = difference b a
+    ;     --assert (make hash! [5 6]    ) = exclude a b
+    ;     --assert (make hash! []       ) = exclude b a
 
 	--test-- "set-op-str"
 		a: "CBAD"
@@ -1503,6 +2523,31 @@ Red [
 		--assert "BAEF"		= difference a b
 		--assert "BA"		= exclude a b
 		--assert "EF"		= exclude b a
+
+    --test-- "set-op-str-2"
+        --assert "" = intersect "" "a"
+        --assert "" = unique ""
+        --assert "" = union "" ""
+        --assert "" = intersect "" ""
+        --assert "" = difference "" ""
+        --assert "" = exclude "" ""
+
+    --test-- "set-op-str-3"
+        a: "12345678"
+        b: skip a 2
+        c: skip a 6
+        remove/part a 4
+        --assert ""     = unique c
+        --assert "78"   = unique b
+        --assert "5678" = unique a
+        --assert "5678" = union a b
+        --assert "78"   = union c b
+        --assert "78"   = intersect a b
+        --assert "78"   = intersect b a
+        --assert "56"   = difference a b
+        --assert "56"   = difference b a
+        --assert "56"   = exclude a b
+        --assert ""     = exclude b a
 
 	--test-- "set-op-bitset"
 		a: make bitset! [1 2 3 4]
@@ -1537,10 +2582,12 @@ Red [
 		blk1: change blk 6
 		--assert [2 3] = blk1
 		--assert 6 = first blk
+        --assert [6 2 3] = blk
 	--test-- "change-blk-2"
 		blk2: change blk1 [a b]
 		--assert empty? blk2
 		--assert 'a = first blk1
+        --assert [6 a b] = blk
 	--test-- "change-blk-3"
 		blk3: change blk1 [9 8 7 6 5 4 3]
 		--assert empty? blk3
@@ -1734,6 +2781,97 @@ Red [
 		--assert 5 = length? blk
 		--assert 'x = first blk
 
+    --test-- "change/part-blk-5"                        ;-- issue #4087
+        --assert []      = change/part b: [] b b
+        --assert [1 2 3] = change/part b: [1 2 3] tail b b
+        --assert [1 2 3] = b
+
+    --test-- "change/part-blk-6"                        ;-- issue #4088
+        --assert [1 2 3] = change/part b: [1 2 3] next b b
+        --assert [2 3 1 2 3] = b
+        --assert [2 3 1 2 3] = change/part b next b b
+        --assert [3 1 2 3 2 3 1 2 3] = b
+
+    --test-- "change/part-blk-7"                        ;-- issue #4088
+        --assert [3] = change/part next b: [1 2 3] b skip b 2
+        --assert [1 1 2 3 3] = b
+        --assert [5] = change/part next b: [1 2 3 4 5] skip b 3 skip b 4
+        --assert [1 4 5 5] = b
+
+    --test-- "change/part-blk-8"                        ;-- issue #4088
+        a: [x . . . . . . x]
+        --assert [. . . x] = change/part (skip a 2) a 2
+        --assert [x . x . . . . . . x . . . x] = a
+    --test-- "change/part-blk-9"                        ;-- issue #4088
+        a: [x . . . . . . x]
+        --assert [. . . . . x] = change/part a a 2
+        --assert [x . . . . . . x . . . . . x] = a
+    --test-- "change/part-blk-10"                       ;-- issue #4088
+        a: [x . . . . . . x]
+        --assert [. . . x] = change/part (skip a 2) as path! a 2
+        --assert [x . x . . . . . . x . . . x] = a
+    --test-- "change/part-blk-11"                       ;-- issue #4088
+        a: [x . . . . . . x]
+        --assert [. . . . . x] = change/part a as path! a 2
+        --assert [x . . . . . . x . . . . . x] = a
+
+    --test-- "change/part-blk-12"                       ;-- issue #4088
+        a: [x . . . . x]
+        --assert [. x] = change/part/dup (skip a 2) a 2 2
+        --assert [x . x . . . . x x . . . . x . x] = a
+    --test-- "change/part-blk-13"                       ;-- issue #4088
+        a: [x . . . . x]
+        --assert [. . . x] = change/part/dup a a 2 2
+        --assert [x . . . . x x . . . . x . . . x] = a
+    --test-- "change/part-blk-14"                       ;-- issue #4088
+        a: [x . . . . x]
+        --assert [. x] = change/part/dup (skip a 2) as path! a 2 2
+        --assert [x . x . . . . x x . . . . x . x] = a
+    --test-- "change/part-blk-15"                       ;-- issue #4088
+        a: [x . . . . x]
+        --assert [. . . x] = change/part/dup a as path! a 2 2
+        --assert [x . . . . x x . . . . x . . . x] = a
+
+    --test-- "change/part-blk-16"                       ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert []            = change/part c b 2
+        --assert [7 8 7 8]     = b
+        --assert [5 6 7 8 7 8] = a
+        --assert []            = change/part skip b 2 c 20
+        --assert [7 8]         = b
+        --assert [5 6 7 8]     = a
+        --assert []            = change/part c b b
+        --assert [7 8]         = b
+        --assert [5 6 7 8]     = a
+
+    --test-- "change/part-blk-17"                       ;-- issue #3369
+        a: [0 0 1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 6
+        --assert []                = change/part/dup c b 2 2
+        --assert [7 8 7 8 7 8]     = b
+        --assert [5 6 7 8 7 8 7 8] = a
+        --assert []                = change/part/dup skip b 2 d 20 300
+        --assert [7 8]             = b
+        --assert [5 6 7 8]         = a
+        --assert []                = change/part/dup c b b 3
+        --assert [7 8 7 8 7 8]     = b
+        --assert [5 6 7 8 7 8 7 8] = a
+
+    --test-- "change/part-blk-18"                       ;-- issue #4088
+        --assert [e]   = change/part/dup s: [a b c d e] [!] 4 0
+        --assert [e]   = s
+        --assert [e]   = change/part/dup s: [a b c d e] [!] 4 -1
+        --assert [e]   = s
+        --assert [e]   = change/part/dup skip s: [a b c d e] 4 [!] -3 0
+        --assert [a e] = s
+
 	--test-- "change/part-str-1"
 		str: "1234"
 		str1: change/part str #"x" 3
@@ -1757,6 +2895,97 @@ Red [
 		--assert val = first str3
 		--assert 5 = length? str
 		--assert #"x" = first str
+
+    --test-- "change/part-str-5"                        ;-- issue #4087
+        --assert ""    = change/part s: "" s s
+        --assert "123" = change/part s: "123" tail s s
+        --assert "123" = s
+
+    --test-- "change/part-str-6"                        ;-- issue #4088
+        --assert "123" = change/part s: "123" next s s
+        --assert "23123" = s
+        --assert "23123" = change/part s next s s
+        --assert "312323123" = s
+
+    --test-- "change/part-str-7"                        ;-- issue #4088
+        --assert "3" = change/part next s: "123" s skip s 2
+        --assert "11233" = s
+        --assert "5" = change/part next s: "12345" skip s 3 skip s 4
+        --assert "1455" = s
+
+    --test-- "change/part-str-8"                        ;-- issue #4088
+        a: "[......]"
+        --assert "...]" = change/part (skip a 2) a 2
+        --assert "[.[......]...]" = a
+    --test-- "change/part-str-9"                        ;-- issue #4088
+        a: "[......]"
+        --assert ".....]" = change/part a a 2
+        --assert "[......].....]" = a
+    --test-- "change/part-str-10"                       ;-- issue #4088
+        a: "[......]"
+        --assert "...]" = change/part (skip a 2) as file! a 2
+        --assert "[.[......]...]" = a
+    --test-- "change/part-str-11"                       ;-- issue #4088
+        a: "[......]"
+        --assert ".....]" = change/part a as file! a 2
+        --assert "[......].....]" = a
+
+    --test-- "change/part-str-12"                       ;-- issue #4088
+        a: "[....]"
+        --assert ".]" = change/part/dup (skip a 2) a 2 2
+        --assert "[.[....][....].]" = a
+    --test-- "change/part-str-13"                       ;-- issue #4088
+        a: "[....]"
+        --assert "...]" = change/part/dup a a 2 2
+        --assert "[....][....]...]" = a
+    --test-- "change/part-str-14"                       ;-- issue #4088
+        a: "[....]"
+        --assert ".]" = change/part/dup (skip a 2) as file! a 2 2
+        --assert "[.[....][....].]" = a
+    --test-- "change/part-str-15"                       ;-- issue #4088
+        a: "[....]"
+        --assert "...]" = change/part/dup a as file! a 2 2
+        --assert "[....][....]...]" = a
+
+    --test-- "change/part-str-16"                       ;-- issue #3369
+        a: "12345678"
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert "" = change/part c b 2
+        --assert "7878" = b
+        --assert "567878" = a
+        --assert "" = change/part skip b 2 c 20
+        --assert "78" = b
+        --assert "5678" = a
+        --assert "" = change/part c b b
+        --assert "78" = b
+        --assert "5678" = a
+
+    --test-- "change/part-str-17"                       ;-- issue #3369
+        a: "0012345678"
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 6
+        --assert "" = change/part/dup c b 2 2
+        --assert "787878" = b
+        --assert "56787878" = a
+        --assert "" = change/part/dup skip b 2 d 20 300
+        --assert "78" = b
+        --assert "5678" = a
+        --assert "" = change/part/dup c b b 3
+        --assert "787878" = b
+        --assert "56787878" = a
+
+    --test-- "change/part-str-18"                       ;-- issue #4088
+        --assert "e" = change/part/dup s: "abcde" "!" 4 0
+        --assert "e" = s
+        --assert "e" = change/part/dup s: "abcde" "!" 4 -1
+        --assert "e" = s
+        --assert "e" = change/part/dup skip s: "abcde" 4 "!" -3 0
+        --assert "ae" = s
 
 	--test-- "change/part-bin-1"
 		bin: #{12345678}
@@ -1793,6 +3022,83 @@ Red [
 		--assert none = select hs 'x
 		--assert 'y = select hs 'p
 		--assert 3  = select hs 2
+
+    --test-- "change/part-hash-3"                       ;-- issue #4087
+        --assert (make hash! []     ) = change/part b: make hash! [] b b
+        --assert (make hash! [1 2 3]) = change/part b: make hash! [1 2 3] tail b b
+        --assert (make hash! [1 2 3]) = b
+
+    ;@@ FIXME: hash table troubles
+    ; --test-- "change/part-hash-4"                       ;-- issue #4088
+    ;     --assert (make hash! [1 2 3]) = probe change/part b: make hash! [1 2 3] next b b
+    ;     --assert (make hash! [2 3 1 2 3]) = probe b
+    ;     --assert (make hash! [2 3 1 2 3]) = probe change/part b next b b
+    ;     --assert (make hash! [3 1 2 3 2 3 1 2 3]) = probe b
+
+    --test-- "change/part-hash-5"                       ;-- issue #4088
+        --assert (make hash! [3]) = change/part next b: make hash! [1 2 3] b skip b 2
+        --assert (make hash! [1 1 2 3 3]) = b
+        --assert (make hash! [5]) = change/part next b: make hash! [1 2 3 4 5] skip b 3 skip b 4
+        --assert (make hash! [1 4 5 5]) = b
+
+    --test-- "change/part-hash-6"                        ;-- issue #4088
+        a: make hash! [x . . . . . . x]
+        --assert (make hash! [. . . x]) = change/part (skip a 2) a 2
+        --assert (make hash! [x . x . . . . . . x . . . x]) = a
+    --test-- "change/part-hash-7"                        ;-- issue #4088
+        a: make hash! [x . . . . . . x]
+        --assert (make hash! [. . . . . x]) = change/part a a 2
+        --assert (make hash! [x . . . . . . x . . . . . x]) = a
+
+    --test-- "change/part-hash-8"                       ;-- issue #4088
+        a: make hash! [x . . . . x]
+        --assert (make hash! [. x]) = change/part/dup (skip a 2) a 2 2
+        --assert (make hash! [x . x . . . . x x . . . . x . x]) = a
+    --test-- "change/part-hash-9"                       ;-- issue #4088
+        a: make hash! [x . . . . x]
+        --assert (make hash! [. . . x]) = change/part/dup a a 2 2
+        --assert (make hash! [x . . . . x x . . . . x . . . x]) = a
+
+    --test-- "change/part-hash-10"                      ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 4
+        --assert (make hash! []           ) = change/part c b 2
+        --assert (make hash! [7 8 7 8]    ) = b
+        --assert (make hash! [5 6 7 8 7 8]) = a
+        --assert (make hash! []           ) = change/part skip b 2 c 20
+        --assert (make hash! [7 8]        ) = b
+        --assert (make hash! [5 6 7 8]    ) = a
+        --assert (make hash! []           ) = change/part c b b
+        --assert (make hash! [7 8]        ) = b
+        --assert (make hash! [5 6 7 8]    ) = a
+
+    --test-- "change/part-hash-11"                      ;-- issue #3369
+        a: make hash! [0 0 1 2 3 4 5 6 7 8]
+        b: skip a 2
+        c: skip a 6
+        d: tail a
+        remove/part a 6
+        --assert (make hash! []               ) = change/part/dup c b 2 2
+        --assert (make hash! [7 8 7 8 7 8]    ) = b
+        --assert (make hash! [5 6 7 8 7 8 7 8]) = a
+        --assert (make hash! []               ) = change/part/dup skip b 2 d 20 300
+        --assert (make hash! [7 8]            ) = b
+        --assert (make hash! [5 6 7 8]        ) = a
+        --assert (make hash! []               ) = change/part/dup c b b 3
+        --assert (make hash! [7 8 7 8 7 8]    ) = b
+        --assert (make hash! [5 6 7 8 7 8 7 8]) = a
+
+    --test-- "change/part-hash-12"                       ;-- issue #4088
+        --assert (make hash! [e]  ) = change/part/dup s: make hash! [a b c d e] [!] 4 0
+        --assert (make hash! [e]  ) = s
+        --assert (make hash! [e]  ) = change/part/dup s: make hash! [a b c d e] [!] 4 -1
+        --assert (make hash! [e]  ) = s
+        --assert (make hash! [e]  ) = change/part/dup skip s: make hash! [a b c d e] 4 make hash! [!] -3 0
+        --assert (make hash! [a e]) = s
+
 ===end-group===
 
 ===start-group=== "copy"
@@ -1807,7 +3113,7 @@ Red [
 		c2-a: next c2-a
 		--assert not equal? c2-a c2-b
 
-	--test-- "copy-3"
+	--test-- "copy-3"                                   ;-- issue #3369
 		a: "12345678"
 		b: skip a 6
 		c: tail a
@@ -1833,6 +3139,61 @@ Red [
 		--assert empty? copy/part a -4
 		--assert "3456" = copy/part b -4
 		--assert "123456" = copy/part b -10
+
+    --test-- "copy-5"                                   ;-- issue #3369
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        c: tail a
+        d: skip a 2
+        remove/part a 4
+        --assert [5 6 7 8] = a
+        --assert empty? b
+        --assert empty? copy b
+        --assert empty? c
+        --assert empty? copy c
+        --assert [7 8] = d
+        --assert [7 8] = copy d
+        --assert [7 8] = copy/part d b
+        --assert [7 8] = copy/part b d
+        clear a
+        --assert empty? d
+        --assert empty? copy d
+        --assert empty? copy/part d b
+
+    --test-- "copy-6"
+        a: [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        --assert empty? copy/part a -4
+        --assert [3 4 5 6] = copy/part b -4
+        --assert [1 2 3 4 5 6] = copy/part b -10
+
+    --test-- "copy-7"                                   ;-- issue #3369
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        c: tail a
+        d: skip a 2
+        remove/part a 4
+        --assert (make hash! [5 6 7 8]) = a
+        --assert empty? b
+        --assert empty? copy b
+        --assert empty? c
+        --assert empty? copy c
+        --assert (make hash! [7 8]) = d
+        --assert (make hash! [7 8]) = copy d
+        --assert (make hash! [7 8]) = copy/part d b
+        --assert (make hash! [7 8]) = copy/part b d
+        clear a
+        --assert empty? d
+        --assert empty? copy d
+        --assert empty? copy/part d b
+
+    --test-- "copy-8"
+        a: make hash! [1 2 3 4 5 6 7 8]
+        b: skip a 6
+        --assert empty? copy/part a -4
+        --assert (make hash! [3 4 5 6]) = copy/part b -4
+        --assert (make hash! [1 2 3 4 5 6]) = copy/part b -10
+
 ===end-group===
 
 ===start-group=== "random"


### PR DESCRIPTION
Fixes #3369 , fixes #4078 , fixes #4083 , fixes #4085 , fixes #4087 , fixes #4088 , fixes #4100 , fixes #4913

This PR fixes numerous crashes in series-related functions, and includes a total rewrite of `change` and `take`. Lots of tests included.

Series funcs behavior now follows [the one I outlined in red/red](https://gitter.im/red/red?at=5da5b83b870fa33a4df7e0b7) in all edge cases. How it all works is seen from the tests, so I'm not duping it here.

`next`, `skip`, `at` I do not plan to modify until we agree on some sort of series model.
`take/last/part` behavior is unchanged, only fixed, although I'm not happy with it ([reasons](https://gitter.im/red/red?at=5da5861f809de9699f3ec707))

**Status**

This PR is ready for review, though a bit more work is ~required~ desirable:
- `move` func ~has no tests at all, and it's~ very unintuitive, I'd love to rewrite it as well (see #3527 ); no tests for it so far; ~`alter` has no tests either~
- ~I didn't test select/pick/random/min/max yet~
- ~I didn't run tests except `series-test.red` yet~
- ~All tests succeed when run from the console, but some heisenbug still remains, causing `run-all-interp.red` (when compiled only) to stop just after `fun-12` test, executing only 1687 of over 10k tests, ignorantly reporting a false success~

P.S. Added memory protection (see below)


