### PR TITLE
FEAT: VALUE? native supports ANY-WORD! argument

### DIFF
--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -1861,11 +1861,13 @@ natives: context [
 		check? [logic!]
 		/local
 			value  [red-value!]
+			type   [integer!]
 			result [red-logic!]
 	][
 		#typecheck value?
 		value: stack/arguments
-		if TYPE_OF(value) = TYPE_WORD [
+		type: TYPE_OF(value)
+		if ANY_WORD?(type) [
 			value: _context/get as red-word! stack/arguments
 		]
 		result: as red-logic! stack/arguments


### PR DESCRIPTION
For the sake of consistency with Rebol's behavior and the recent change in `get` https://github.com/red/red/commit/3fc8ef25b7328d8ddeff362761d0a21798047c82, `value?` now checks value referenced by `any-word!`, not just `word!`.