### PR TITLE
FEAT: enable LARGE_ADDRESS_AWARE flag on Windows.

### DIFF
--- a/system/formats/PE.r
+++ b/system/formats/PE.r
@@ -703,6 +703,7 @@ context [
 		fh/opt-headers-size: opt-header-size
 		fh/flags:			 to integer! defs/c-flags/executable-image
 									  or defs/c-flags/machine-32bit
+									  or defs/c-flags/large-address-aware
 		
 		unless find job/sections 'reloc	[
 			fh/flags: fh/flags or to integer! defs/c-flags/relocs-stripped


### PR DESCRIPTION
Now Red Apps can use 4GB memory on 64-bit Windows system.
```
>> loop 240 [make block! 1024 * 1024]
== []
```
> On 64-bit editions of Windows, 32-bit applications marked with the IMAGE_FILE_LARGE_ADDRESS_AWARE flag have 4 GB of address space available.
https://docs.microsoft.com/zh-cn/windows/win32/memory/4-gigabyte-tuning