### PR TITLE
FIX: minor bit layout correction

### DIFF
--- a/runtime/allocator.reds
+++ b/runtime/allocator.reds
@@ -55,7 +55,7 @@ cell!: alias struct! [
 ;	19:		complement						;-- complement flag for bitsets
 ;	18:		UTF-16 cache					;-- signifies that the string cache is UTF-16 encoded (UTF-8 by default)
 ;	17:		owned							;-- series is owned by an object
-;	16-3: 	<reserved>
+;	16-5: 	<reserved>
 ;	4-0:	unit							;-- size in bytes of atomic element stored in buffer
 											;-- 0: UTF-8, 1: Latin1/binary, 2: UCS-2, 4: UCS-4, 16: block! cell
 series-buffer!: alias struct! [


### PR DESCRIPTION
Corrected bit layout in series flags - previously there was 1 bit of an overlap between `<reserved>` and `unit`.