### PR TITLE
FIX: issue #3583 and some

### DIFF
--- a/environment/actions.red
+++ b/environment/actions.red
@@ -458,7 +458,7 @@ sort: make action! [[
 			comparator [integer! block! any-function!]
 		/part "Sort only part of a series"
 			length [number! series!]
-		/all "Compare all fields"
+		/all "Compare all fields (used with /skip)"
 		/reverse "Reverse sort order"
 		/stable "Stable sorting"
 		return:  [series!]

--- a/runtime/datatypes/block.reds
+++ b/runtime/datatypes/block.reds
@@ -1250,13 +1250,11 @@ block: context [
 		flags: 0
 		s: GET_BUFFER(blk)
 		head: s/offset + blk/head
-		if head = s/tail [return blk]					;-- early exit if nothing to reverse
 		len: rs-length? blk
 
 		if OPTION?(part) [
 			len2: either TYPE_OF(part) = TYPE_INTEGER [
 				int: as red-integer! part
-				if int/value <= 0 [return blk]			;-- early exit if part <= 0
 				int/value
 			][
 				blk2: as red-block! part
@@ -1278,8 +1276,9 @@ block: context [
 				]
 			]
 		]
+		if zero? len [return blk]						;-- early exit if nothing to sort
 
-		if OPTION?(skip) [
+		either OPTION?(skip) [
 			assert TYPE_OF(skip) = TYPE_INTEGER
 			step: skip/value
 			if any [
@@ -1290,6 +1289,8 @@ block: context [
 				ERR_INVALID_REFINEMENT_ARG(refinements/_skip skip)
 			]
 			if step > 1 [len: len / step]
+		][
+			if all? [fire [TO_ERROR(script bad-refines)]]
 		]
 
 		if reverse? [flags: flags or sort-reverse-mask]
@@ -1307,6 +1308,9 @@ block: context [
 					op: as-integer comparator
 				]
 				TYPE_INTEGER [
+					if any [all? not OPTION?(skip)] [
+						fire [TO_ERROR(script bad-refines)]
+					]
 					int: as red-integer! comparator
 					offset: int/value
 					if any [offset < 1 offset > step][
@@ -1322,7 +1326,7 @@ block: context [
 				]
 			]
 		][
-			if all [all? OPTION?(skip)] [
+			if all? [
 				flags: flags or sort-all-mask
 				flags: step << 2 or flags
 			]

--- a/runtime/datatypes/string.reds
+++ b/runtime/datatypes/string.reds
@@ -2174,8 +2174,9 @@ string: context [
 				]
 			]
 		]
+		if zero? len [return str]						;-- early exit if nothing to sort
 
-		if OPTION?(skip) [
+		either OPTION?(skip) [
 			assert TYPE_OF(skip) = TYPE_INTEGER
 			step: skip/value
 			if any [
@@ -2186,6 +2187,8 @@ string: context [
 				ERR_INVALID_REFINEMENT_ARG(refinements/_skip skip)
 			]
 			if step > 1 [len: len / step]
+		][
+			if all? [fire [TO_ERROR(script bad-refines)]]
 		]
 
 		cmp: either all [
@@ -2222,6 +2225,9 @@ string: context [
 					op: as-integer comparator
 				]
 				TYPE_INTEGER [
+					if any [all? not OPTION?(skip)] [
+						fire [TO_ERROR(script bad-refines)]
+					]
 					int: as red-integer! comparator
 					offset: int/value
 					if any [offset < 1 offset > step][

--- a/runtime/datatypes/string.reds
+++ b/runtime/datatypes/string.reds
@@ -1593,16 +1593,33 @@ string: context [
 		flags	[integer!]
 		return: [integer!]
 		/local
-			c1	[integer!]
-			c2	[integer!]
+			c1		[integer!]
+			c2		[integer!]
+			count	[integer!]
+			res		[integer!]
+			rev		[integer!]
 	][
-		c1: as-integer p1/1
-		c2: as-integer p2/1
-		if op = COMP_EQUAL [
-			if all [65 <= c1 c1 <= 90][c1: c1 + 32]
-			if all [65 <= c2 c2 <= 90][c2: c2 + 32]
+		rev: either flags and sort-reverse-mask = sort-reverse-mask [-1][1]
+		either flags and sort-all-mask = sort-all-mask [
+			count: flags >> 2
+		][
+			count: flags >> 2
+			p1: p1 + count
+			p2: p2 + count
+			count: 1
 		]
-		either zero? flags [c1 - c2][c2 - c1]
+		loop count [
+			c1: as-integer p1/1
+			c2: as-integer p2/1
+			if op = COMP_EQUAL [
+				if all [65 <= c1 c1 <= 90][c1: c1 + 32]
+				if all [65 <= c2 c2 <= 90][c2: c2 + 32]
+			]
+			res: c1 - c2 * rev
+			unless zero? res [break]
+			p1: p1 + 1 p2: p2 + 1
+		]
+		res
 	]
 
 	compare-UCS2: func [
@@ -1612,16 +1629,33 @@ string: context [
 		flags	[integer!]
 		return: [integer!]
 		/local
-			c1	[integer!]
-			c2	[integer!]
+			c1		[integer!]
+			c2		[integer!]
+			count	[integer!]
+			res		[integer!]
+			rev		[integer!]
 	][
-		c1: (as-integer p1/2) << 8 + p1/1
-		c2: (as-integer p2/2) << 8 + p2/1
-		if op = COMP_EQUAL [
-			c1: case-folding/change-char c1 yes	;-- uppercase c1
-			c2: case-folding/change-char c2 yes	;-- uppercase c2
+		rev: either flags and sort-reverse-mask = sort-reverse-mask [-1][1]
+		either flags and sort-all-mask = sort-all-mask [
+			count: flags >> 2
+		][
+			count: flags >> 2 << 1
+			p1: p1 + count
+			p2: p2 + count
+			count: 1
 		]
-		either zero? flags [c1 - c2][c2 - c1]
+		loop count [
+			c1: (as-integer p1/2) << 8 + p1/1
+			c2: (as-integer p2/2) << 8 + p2/1
+			if op = COMP_EQUAL [
+				c1: case-folding/change-char c1 yes	;-- uppercase c1
+				c2: case-folding/change-char c2 yes	;-- uppercase c2
+			]
+			res: c1 - c2 * rev
+			unless zero? res [break]
+			p1: p1 + 2 p2: p2 + 2
+		]
+		res
 	]
 
 	compare-UCS4: func [
@@ -1631,19 +1665,36 @@ string: context [
 		flags	[integer!]
 		return: [integer!]
 		/local
-			c1	[integer!]
-			c2	[integer!]
-			p4  [int-ptr!]
+			c1		[integer!]
+			c2		[integer!]
+			count	[integer!]
+			res		[integer!]
+			rev		[integer!]
+			p4  	[int-ptr!]
 	][
-		p4: as int-ptr! p1
-		c1: p4/1
-		p4: as int-ptr! p2
-		c2: p4/1
-		if op = COMP_EQUAL [
-			c1: case-folding/change-char c1 yes	;-- uppercase c1
-			c2: case-folding/change-char c2 yes	;-- uppercase c2
+		rev: either flags and sort-reverse-mask = sort-reverse-mask [-1][1]
+		either flags and sort-all-mask = sort-all-mask [
+			count: flags >> 2
+		][
+			count: flags and -4							;-- flags >> 2 * 4
+			p1: p1 + count
+			p2: p2 + count
+			count: 1
 		]
-		either zero? flags [c1 - c2][c2 - c1]
+		loop count [
+			p4: as int-ptr! p1
+			c1: p4/1
+			p4: as int-ptr! p2
+			c2: p4/1
+			if op = COMP_EQUAL [
+				c1: case-folding/change-char c1 yes	;-- uppercase c1
+				c2: case-folding/change-char c2 yes	;-- uppercase c2
+			]
+			res: c1 - c2 * rev
+			unless zero? res [break]
+			p1: p1 + 4 p2: p2 + 4
+		]
+		res
 	]
 
 	compare-float32: func [
@@ -1653,19 +1704,32 @@ string: context [
 		flags	[integer!]
 		return: [integer!]
 		/local
-			pf	[pointer! [float32!]]
-			f1	[float32!]
-			f2	[float32!]
+			pf		[pointer! [float32!]]
+			f1		[float32!]
+			f2		[float32!]
+			count	[integer!]
+			res		[integer!]
+			rev		[integer!]
 	][
-		pf: as pointer! [float32!] p1
-		f1: pf/1
-		pf: as pointer! [float32!] p2
-		f2: pf/1
-		either zero? flags [
-			SIGN_COMPARE_RESULT(f1 f2)
+		rev: either flags and sort-reverse-mask = sort-reverse-mask [-1][1]
+		either flags and sort-all-mask = sort-all-mask [
+			count: flags >> 2
 		][
-			SIGN_COMPARE_RESULT(f2 f1)
+			count: flags and -4							;-- flags >> 2 * 4
+			p1: p1 + count
+			p2: p2 + count
+			count: 1
 		]
+		loop count [
+			pf: as pointer! [float32!] p1
+			f1: pf/1
+			pf: as pointer! [float32!] p2
+			f2: pf/1
+			res: (SIGN_COMPARE_RESULT(f1 f2)) * rev
+			unless zero? res [break]
+			p1: p1 + 4 p2: p2 + 4
+		]
+		res
 	]
 
 	compare-float: func [
@@ -1675,19 +1739,32 @@ string: context [
 		flags	[integer!]
 		return: [integer!]
 		/local
-			pf	[pointer! [float!]]
-			f1	[float!]
-			f2	[float!]
+			pf		[pointer! [float!]]
+			f1		[float!]
+			f2		[float!]
+			count	[integer!]
+			res		[integer!]
+			rev		[integer!]
 	][
-		pf: as pointer! [float!] p1
-		f1: pf/1
-		pf: as pointer! [float!] p2
-		f2: pf/1
-		either zero? flags [
-			SIGN_COMPARE_RESULT(f1 f2)
+		rev: either flags and sort-reverse-mask = sort-reverse-mask [-1][1]
+		either flags and sort-all-mask = sort-all-mask [
+			count: flags >> 2
 		][
-			SIGN_COMPARE_RESULT(f2 f1)
+			count: flags and -4 << 1					;-- flags >> 2 * 8
+			p1: p1 + count
+			p2: p2 + count
+			count: 1
 		]
+		loop count [
+			pf: as pointer! [float!] p1
+			f1: pf/1
+			pf: as pointer! [float!] p2
+			f2: pf/1
+			res: (SIGN_COMPARE_RESULT(f1 f2)) * rev
+			unless zero? res [break]
+			p1: p1 + 8 p2: p2 + 8
+		]
+		res
 	]
 
 	find: func [
@@ -2133,7 +2210,7 @@ string: context [
 		]
 		flags: either reverse? [SORT_REVERSE][SORT_NORMAL]
 
-		if OPTION?(comparator) [
+		either OPTION?(comparator) [
 			switch TYPE_OF(comparator) [
 				TYPE_FUNCTION [
 					flags: unit << 2 or flags
@@ -2153,11 +2230,16 @@ string: context [
 							comparator
 						]
 					]
-					flags: offset - 1 << 1 or flags
+					flags: offset - 1 << 2 or flags
 				]
 				default [
 					ERR_INVALID_REFINEMENT_ARG(refinements/compare comparator)
 				]
+			]
+		][
+			if all [all? OPTION?(skip)] [
+				flags: flags or sort-all-mask
+				flags: step << 2 or flags
 			]
 		]
 		_sort/qsort buffer len unit * step op flags cmp

--- a/tests/source/units/series-test.red
+++ b/tests/source/units/series-test.red
@@ -1408,6 +1408,19 @@ Red [
 		--assert "12abcd3ef4gh" = sort/part a 6
 		--assert "34efgh" = sort/part skip a 6 tail a
 
+    --test-- "sort-str-5"                              ;-- invalid refinements combos
+        --assert not error? try [sort/skip/part "abc" 2 0]  ;-- zero part is OK with any skip
+        --assert error? try [sort/all/compare "abc" 1]      ;-- either /all or /compare
+        --assert error? try [sort/compare "abc" 1]          ;-- needs /skip
+        --assert error? try [sort/all "abc" 1]              ;-- needs /skip
+
+    --test-- "sort-str-6"
+        s: does [copy "313312"]
+        --assert "123133" = sort/skip s 2
+        --assert "123133" = sort/skip/compare s 2 1
+        --assert "311233" = sort/skip/compare s 2 2
+        --assert "123133" = sort/skip/all s 2
+
 	--test-- "sort-blk-1"
 		a: [bc 799 ab2 42 bb1 321.3 "Mo" "Curly" "Larry" -24 0 321.8] 
 		--assert ["Curly" "Larry" "Mo" -24 0 42 321.3 321.8 799 ab2 bb1 bc] = sort a
@@ -1447,6 +1460,33 @@ Red [
 		--assert [3 2 1] = sort/compare [1 3 2] func [a b] [a > b]
 		--assert [1 2 3 4 5 6] = sort/compare [1 2 3 4 5 6] func [a b] [a < b]
 		--assert [6 5 4 3 2 1] = sort/compare [1 2 3 4 5 6] func [a b] [a > b]
+
+    --test-- "sort-blk-6"                               ;-- invalid refinements combos
+        --assert not error? try [sort/skip/part [a b c] 2 0]    ;-- zero part is OK with any skip
+        --assert error? try [sort/all/compare [a b c] 1]        ;-- either /all or /compare
+        --assert error? try [sort/compare [a b c] 1]            ;-- needs /skip
+        --assert error? try [sort/all [a b c] 1]                ;-- needs /skip
+
+    --test-- "sort-blk-7"
+        s: does [copy [3 1 3 3 1 2]]
+        --assert [1 2 3 1 3 3] = sort/skip s 2
+        --assert [1 2 3 1 3 3] = sort/skip/compare s 2 1
+        --assert [3 1 1 2 3 3] = sort/skip/compare s 2 2
+        --assert [1 2 3 1 3 3] = sort/skip/all s 2
+
+    --test-- "sort-vec-1"
+        s: does  [make vector! [3 1 3 3 1 2]]
+        --assert (make vector! [1 2 3 1 3 3]) = sort/skip s 2
+        --assert (make vector! [1 2 3 1 3 3]) = sort/skip/compare s 2 1
+        --assert (make vector! [3 1 1 2 3 3]) = sort/skip/compare s 2 2
+        --assert (make vector! [1 2 3 1 3 3]) = sort/skip/all s 2
+
+    --test-- "sort-bin-1"
+        s: does  [make binary! [3 1 3 3 1 2]]
+        --assert (make binary! [1 2 3 1 3 3]) = sort/skip s 2
+        --assert (make binary! [1 2 3 1 3 3]) = sort/skip/compare s 2 1
+        --assert (make binary! [3 1 1 2 3 3]) = sort/skip/compare s 2 2
+        --assert (make binary! [1 2 3 1 3 3]) = sort/skip/all s 2
 		
 ===end-group===
 


### PR DESCRIPTION
SORT-related. Fixes #3583 

Summary:
- support of `/skip i`, `/skip/all i` and `/skip/compare i j` for `binary!`, `vector!`, `any-string!`
- empty `/part` is allowed with any `/skip` to do nothing (it raised an error previously)
- `/all/compare int` is an erroneous combination now
- `/compare int` without `/skip` is an error
- `/all` without `/skip` is an error

It is currently somewhat forgiving about bad refinement combos when given an empty input (not my doing), but it's an optimization worth having.

![](https://i.gyazo.com/aaeac931bc532725876140177c14d3af.png)

