### PR TITLE
FEAT: grant wish #3133 (more friendly form binary)

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -884,10 +884,10 @@ path-thru: function [
 	so: system/options
 	unless so/thru-cache [make-dir/deep so/thru-cache: append copy so/cache %cache/]
 
-	file: checksum form url 'MD5
-	path: dirize append copy so/thru-cache copy/part file 2
+	hash: form checksum form url 'MD5
+	path: dirize append copy so/thru-cache copy/part hash 2
 	unless exists? path [make-dir path] 
-	append path file
+	append path hash
 ]
 
 exists-thru?: function [

--- a/environment/functions.red
+++ b/environment/functions.red
@@ -501,7 +501,7 @@ save: function [
 		file? where [write where data]
 		url?  where [write where data]
 		none? where [data]
-		'else		[append where data]
+		'else		[append where mold data]
 	]
 ]
 

--- a/environment/functions.red
+++ b/environment/functions.red
@@ -884,8 +884,7 @@ path-thru: function [
 	so: system/options
 	unless so/thru-cache [make-dir/deep so/thru-cache: append copy so/cache %cache/]
 
-	hash: checksum form url 'MD5
-	file: head (remove back tail remove remove (form hash))
+	file: checksum form url 'MD5
 	path: dirize append copy so/thru-cache copy/part file 2
 	unless exists? path [make-dir path] 
 	append path file

--- a/runtime/datatypes/binary.reds
+++ b/runtime/datatypes/binary.reds
@@ -1067,7 +1067,7 @@ binary: context [
 	][
 		#if debug? = yes [if verbose > 0 [print-line "binary/form"]]
 		
-		serialize bin buffer no no no arg part no
+		serialize bin buffer no no yes arg part no
 	]
 	
 	mold: func [

--- a/runtime/datatypes/binary.reds
+++ b/runtime/datatypes/binary.reds
@@ -863,7 +863,7 @@ binary: context [
 		if mold? [
 			string/concatenate-literal buffer "#{"
 			part: part - 2
-			if size > 32 [
+			if all [not flat? size > 32][
 				string/append-char GET_BUFFER(buffer) as-integer lf
 				part: part - 1
 			]
@@ -874,7 +874,7 @@ binary: context [
 			string/concatenate-literal buffer string/byte-to-hex as-integer head/value
 			bytes: bytes + 1
 			part: part - 2
-			if all [bytes % 32 = 0 bytes <> size][
+			if all [not flat? bytes % 32 = 0 bytes <> size][
 				string/append-char GET_BUFFER(buffer) as-integer lf
 				part: part - 1
 			]
@@ -883,7 +883,7 @@ binary: context [
 		]
 		
 		if mold? [
-			if size > 32 [
+			if all [not flat? size > 32][
 				string/append-char GET_BUFFER(buffer) as-integer lf
 				part: part - 1
 			]

--- a/runtime/datatypes/binary.reds
+++ b/runtime/datatypes/binary.reds
@@ -854,7 +854,8 @@ binary: context [
 			size   [integer!]
 	][
 		#if debug? = yes [if verbose > 0 [print-line "binary/serialize"]]
-
+		
+		if part < 0 [part: 0]
 		s: GET_BUFFER(bin)
 		head: (as byte-ptr! s/offset) + bin/head
 		tail: as byte-ptr! s/tail

--- a/runtime/datatypes/binary.reds
+++ b/runtime/datatypes/binary.reds
@@ -860,30 +860,37 @@ binary: context [
 		tail: as byte-ptr! s/tail
 		size: as-integer tail - head
 
-		string/concatenate-literal buffer "#{"
-		bytes: 0
-		if size > 30 [
-			string/append-char GET_BUFFER(buffer) as-integer lf
-			part: part - 1
-		]
-		part: part - 2
-		while [head < tail][
-			string/concatenate-literal buffer string/byte-to-hex as-integer head/value
-			bytes: bytes + 1
-			if bytes % 32 = 0 [
+		if mold? [
+			string/concatenate-literal buffer "#{"
+			part: part - 2
+			if size > 32 [
 				string/append-char GET_BUFFER(buffer) as-integer lf
 				part: part - 1
 			]
+		]
+		
+		bytes: 0
+		while [head < tail][
+			string/concatenate-literal buffer string/byte-to-hex as-integer head/value
+			bytes: bytes + 1
 			part: part - 2
+			if all [bytes % 32 = 0 bytes <> size][
+				string/append-char GET_BUFFER(buffer) as-integer lf
+				part: part - 1
+			]
 			if all [OPTION?(arg) part <= 0][return part]
 			head: head + 1
 		]
-		if all [size > 30 bytes % 32 <> 0] [
-			string/append-char GET_BUFFER(buffer) as-integer lf
+		
+		if mold? [
+			if size > 32 [
+				string/append-char GET_BUFFER(buffer) as-integer lf
+				part: part - 1
+			]
+			string/append-char GET_BUFFER(buffer) as-integer #"}"
 			part: part - 1
 		]
-		string/append-char GET_BUFFER(buffer) as-integer #"}"
-		part - 1
+		part
 	]
 
 	make-at: func [

--- a/tests/source/units/serialization-test.red
+++ b/tests/source/units/serialization-test.red
@@ -91,6 +91,35 @@ ser-formed: {1 none true false c red Red a/b 'a/b :a/b a/b: 1 + 2 a  a c d b e f
  
 ===end-group===
 
+===start-group=== "binary"
+	--test-- "binary-1"  --assert "#{}" = mold #{}
+	--test-- "binary-2"  --assert empty? form #{}
+	--test-- "binary-3"  --assert "#{ABCD}" = mold #{abcd}
+	--test-- "binary-4"  --assert "ABCD" = form #{abcd}
+	--test-- "binary-5"  --assert "" = mold/part #{deadbeef} -1
+	--test-- "binary-6"  --assert "" = mold/part #{deadbeef} 0
+	--test-- "binary-7"  --assert "#" = mold/part #{deadbeef} 1
+	--test-- "binary-8"  --assert "#{DEADBEEF}" = mold/part #{deadbeef} 11
+	--test-- "binary-9"  --assert "#{DEADBEEF}" = mold/part #{deadbeef} 100
+	--test-- "binary-10" --assert "" = form/part #{deadbeef} -1
+	--test-- "binary-11" --assert "" = form/part #{deadbeef} 0
+	--test-- "binary-12" --assert "D" = form/part #{deadbeef} 1
+	--test-- "binary-13" --assert "DEADBEEF" = form/part #{deadbeef} 8
+	--test-- "binary-14" --assert "DEADBEEF" = form/part #{deadbeef} 100
+	--test-- "binary-15"
+		--assert equal?
+			rejoin ["#{" newline append/dup "" "DEADBEEF" 8 newline "DEADBEEF" newline "}"]
+			mold append/dup #{} #{deadbeef} 9
+	--test-- "binary-16"
+		--assert equal?
+			rejoin ["#{" append/dup "" "DEADBEEF" 10 "}"]
+			mold/flat append/dup #{} #{deadbeef} 10
+	--test-- "binary-17"
+		--assert equal?
+			append/dup "" "DEADBEEF" 10
+			form append/dup #{} #{deadbeef} 10
+===end-group===
+
 ===start-group=== "logic"
 	
 	--test-- "mold-logic1"

--- a/tests/source/units/series-test.red
+++ b/tests/source/units/series-test.red
@@ -391,7 +391,7 @@ Red [
   --assert 6 = select hs-append-1 'c
 
   --test-- "series-append-25"
-  --assert "a#{6263}" = append "a" #{6263}
+  --assert "a6263" = append "a" #{6263}
   --assert #{6162} = append #{} "ab"
 
   --test-- "series-append-26"


### PR DESCRIPTION
`form` on `binary!` was changed to a more human-friendly version (equivalent of `enbase/base ... 16`):
```red
>> form #{deadbeef}
== "DEADBEEF"
>> form/part #{deadbeef} 4
== "DEAD"
```
Both `form` and `mold` still hold 32 bytes (i.e. 64 characters) per line; I'm not sure if `form` should discard them, would like to hear out other's thoughts on that. Either way changing that is a matter of flipping `flat?` flag.

```red
>> print form append/dup #{} #{deadbeef} 8
DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF
>> print form append/dup #{} #{deadbeef} 9
DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF
DEADBEEF
>> print mold append/dup #{} #{deadbeef} 8
#{DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF}
>> print mold append/dup #{} #{deadbeef} 9
#{
DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF
DEADBEEF
}
```

Fulfills and closes #3133, fixes #4365.