### PR TITLE
FIX: issue #3910 (Wrong error message when using foreach wrongly on map)

### DIFF
--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -281,15 +281,17 @@ natives: context [
 	foreach*: func [
 		check? [logic!]
 		/local
-			value [red-value!]
-			body  [red-block!]
-			size  [integer!]
+			value  [red-value!]
+			series [red-value!]
+			body   [red-block!]
+			size   [integer!]
 	][
 		#typecheck foreach
 		value: stack/arguments
+		series: stack/arguments + 1
 		body: as red-block! stack/arguments + 2
 		
-		stack/push stack/arguments + 1					;-- copy arguments to stack top in reverse order
+		stack/push series								;-- copy arguments to stack top in reverse order
 		stack/push value								;-- (required by foreach-next)
 		
 		stack/mark-loop words/_body
@@ -310,6 +312,8 @@ natives: context [
 				]
 			]
 		][
+			if TYPE_OF(series) = TYPE_MAP [fire [TO_ERROR(script invalid-arg) value]]
+			
 			while [foreach-next][						;-- foreach <word!>
 				stack/reset
 				catch RED_THROWN_BREAK	[interpreter/eval body no]
@@ -3145,7 +3149,6 @@ natives: context [
 		
 		result: loop? series
 		if result [
-			if TYPE_OF(series) = TYPE_MAP [fire [TO_ERROR(script invalid-arg) word]]
 			_context/set word actions/pick series 1 null
 			series/head: series/head + 1
 		]

--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -3145,6 +3145,7 @@ natives: context [
 		
 		result: loop? series
 		if result [
+			if TYPE_OF(series) = TYPE_MAP [fire [TO_ERROR(script invalid-arg) word]]
 			_context/set word actions/pick series 1 null
 			series/head: series/head + 1
 		]


### PR DESCRIPTION
`foreach <word> <non-empty map> <block>` now reports an invalid argument:
```red
>> foreach value #(a b)[]
*** Script Error: invalid argument: value
*** Where: foreach
*** Stack:  

>> foreach value #()[]
```

Note that the last example is pertinent to _all_ cases with an empty `series` argument, regardless of its type:
```red
foreach [whatever #really /I don't/care][][]
```

This PR closes #3910. I'm not completely satisfied with the change though, as it makes `while [foreach-next][...]` loop less tight than it should be. An alternative solution is to move check into second `either` branch in `foreach*` before the loop kicks in.

Related tickets: https://github.com/red/red/issues/2279, https://github.com/red/red/issues/617, https://github.com/red/REP/issues/58.