### PR TITLE
FIX: organize libRedRT exports for GTK branch

### DIFF
--- a/system/utils/libRedRT-exports.r
+++ b/system/utils/libRedRT-exports.r
@@ -391,7 +391,6 @@
 	red/string/to-hex
 	red/integer/make-in
 	red/logic/make-in
-	red/OS-image/to-pixbuf
 	red/string/make-at
 	red/unicode/load-utf8-buffer
 	red/unicode/utf8-next-char
@@ -405,12 +404,10 @@
 	red/block/select-word
 	red/block/find
 	red/_series/remove
-	red/OS-image/load-pixbuf
 	red/image/init-image
 	red/OS-image/lock-bitmap
 	red/OS-image/get-data
 	red/OS-image/unlock-bitmap
-	red/OS-image/buffer-argb-to-abgr
 	red/ownership/check
 	red/report
 	red/_context/set


### PR DESCRIPTION
These lines caused errors like this: `*** libRedRT Error: definition not found for red/OS-image/buffer-argb-to-abgr` during compilation with `-c -u` on GTK branch.

They probably will be needed back when merging GTK branch into master, see @qtxie comment in #4090.