### PR TITLE
FIX: [GTK] issues #4244 and #4245

### DIFF
--- a/modules/view/VID.red
+++ b/modules/view/VID.red
@@ -309,6 +309,7 @@ system/view/VID: context [
 				| 'loose	  (add-option opts [drag-on: 'down])
 				| 'all-over   (set-flag opts 'flags 'all-over)
 				| 'password   (set-flag opts 'flags 'password)
+				| 'tri-state  (set-flag opts 'flags 'tri-state)
 				| 'hidden	  (opts/visible?: no)
 				| 'disabled	  (opts/enabled?: no)
 				| 'select	  (opts/selected: fetch-argument integer! spec)

--- a/modules/view/backends/gtk3/events.reds
+++ b/modules/view/backends/gtk3/events.reds
@@ -23,9 +23,11 @@ Red/System [
 gui-evt: declare red-event!								;-- low-level event value slot
 gui-evt/header: TYPE_EVENT
 
-modal-loop-type: 	0										;-- remanence of last EVT_MOVE or EVT_SIZE
+check-handler: 0										;-- for blocking signal propagation during check's state update
+
+modal-loop-type:	0									;-- remanence of last EVT_MOVE or EVT_SIZE
 zoom-distance:	 	0
-special-key: 		-1										;-- <> -1 if a non-displayable key is pressed
+special-key: 		-1									;-- <> -1 if a non-displayable key is pressed
 
 flags-blk: declare red-block!							;-- static block value for event/flags
 flags-blk/header:	TYPE_BLOCK
@@ -1001,7 +1003,7 @@ connect-widget-events: func [
 
 	case [
 		sym = check [
-			gobj_signal_connect(widget "toggled" :button-toggled widget)
+			check-handler: gobj_signal_connect(widget "toggled" :button-toggled widget)	;-- used to block signal
 		]
 		sym = radio [
 			0

--- a/modules/view/backends/gtk3/gtk.reds
+++ b/modules/view/backends/gtk3/gtk.reds
@@ -609,6 +609,14 @@ GPtrArray!: alias struct! [
 		g_signal_emit_by_name: "g_signal_emit_by_name" [
 			[variadic]
 		]
+		g_signal_handler_block: "g_signal_handler_block" [
+			object  [handle!]
+			handler [integer!]
+		]
+		g_signal_handler_unblock: "g_signal_handler_unblock" [
+			object  [handle!]
+			handler [integer!]
+		]
 		g_object_ref: "g_object_ref" [
 			object		[int-ptr!]
 			return:		[int-ptr!]

--- a/modules/view/backends/gtk3/gtk.reds
+++ b/modules/view/backends/gtk3/gtk.reds
@@ -1791,17 +1791,17 @@ GPtrArray!: alias struct! [
 			button		[handle!]
 			return:		[logic!]
 		]
+		gtk_toggle_button_set_active: "gtk_toggle_button_set_active" [
+			button		[handle!]
+			active?		[logic!]
+		]
 		gtk_toggle_button_get_inconsistent: "gtk_toggle_button_get_inconsistent" [
 			button		[handle!]
 			return:		[logic!]
 		]
-		gtk_toggle_button_set_inconsistent: "gtk_toggle_button_get_inconsistent" [
+		gtk_toggle_button_set_inconsistent: "gtk_toggle_button_set_inconsistent" [
 			button		[handle!]
-			inconsist?	[logic!]
-		]
-		gtk_toggle_button_set_active: "gtk_toggle_button_set_active" [
-			button		[handle!]
-			active?		[logic!]
+			setting		[logic!]
 		]
 		gtk_toggle_button_toggled: "gtk_toggle_button_toggled" [
 			button		[handle!]

--- a/modules/view/backends/platform.red
+++ b/modules/view/backends/platform.red
@@ -75,7 +75,8 @@ system/view/platform: context [
 			
 			#enum flags-flag! [
 				FACET_FLAGS_ALL_OVER:	00000001h
-
+				
+				FACET_FLAGS_TRISTATE:	00020000h
 				FACET_FLAGS_SCROLLABLE:	00040000h
 				FACET_FLAGS_PASSWORD:	00080000h
 
@@ -278,6 +279,7 @@ system/view/platform: context [
 			no-buttons:		symbol/make "no-buttons"
 			modal:			symbol/make "modal"
 			popup:			symbol/make "popup"
+			tri-state:		symbol/make "tri-state"
 			scrollable:		symbol/make "scrollable"
 			password:		symbol/make "password"
 


### PR DESCRIPTION
This PR is a follow-up to https://github.com/red/red/pull/4255. It fixes #4244, closes #4245, and implements 3-state mode for `check` face (described [here](https://github.com/red/docs/pull/211)).

I gotta say adding 3-state checkbox was a huge hassle due to various GTK quirks, the major one being a complete absence of 3-state style for `GtkCheckButton`, so I had to emulate it with ingenious workarounds. It bulked out the GTK backend codebase but faithfully mimics behavior on other platforms.