### PR TITLE
FEAT: slight refactoring

### DIFF
--- a/modules/view/backends/macOS/classes.reds
+++ b/modules/view/backends/macOS/classes.reds
@@ -146,7 +146,7 @@ add-camera-handler: func [class [integer!]][
 ]
 
 add-calendar-handler: func [class [integer!]][
-	class_addMethod class sel_getUid "calendar-change:" as-integer :calendar-change "v@:@"
+	class_addMethod class sel_getUid "calendar-change" as-integer :calendar-change "v@"
 ]
 
 add-tabview-handler: func [class [integer!]][

--- a/modules/view/backends/macOS/delegates.reds
+++ b/modules/view/backends/macOS/delegates.reds
@@ -546,8 +546,6 @@ slider-change: func [
 calendar-change: func [
 	[cdecl]
 	self   [integer!]
-	cmd	   [integer!]
-	sender [integer!]
 ][	
 	sync-calendar self
 	make-event self 0 EVT_CHANGE

--- a/modules/view/backends/macOS/gui.reds
+++ b/modules/view/backends/macOS/gui.reds
@@ -1256,7 +1256,7 @@ init-calendar: func [
 	objc_msgSend [calendar sel_getUid "setDatePickerElements:" NSDatePickerElementFlagYearMonthDay]
 	
 	objc_msgSend [calendar sel_getUid "setTarget:" calendar]
-	objc_msgSend [calendar sel_getUid "setAction:" sel_getUid "calendar-change:"]
+	objc_msgSend [calendar sel_getUid "setAction:" sel_getUid "calendar-change"]
 	objc_msgSend [calendar sel_getUid "sendActionOn:" NSLeftMouseDown]
 	
 	slot: declare red-value!

--- a/modules/view/styles.red
+++ b/modules/view/styles.red
@@ -66,6 +66,10 @@ Red [
 		default-actor: on-down
 		template: [type: 'camera size: 250x250]
 	]
+	calendar: [
+		default-actor: on-change
+		template: [type: 'calendar size: 139x148]
+	]
 	text-list: [
 		default-actor: on-change
 		template: [type: 'text-list size: 100x140]
@@ -118,9 +122,5 @@ Red [
 		default-actor: on-down
 		template: [type: 'base size: 100x100]
 		init: [unless face/image [face/image: make image! face/size]]
-	]
-	calendar: [
-		default-actor: on-change
-		template: [type: 'calendar size: 139x148]
 	]
 )


### PR DESCRIPTION
Simplifies interface and Obj-C type signature of calendar's delegate on macOS, also groups calendar with other list-like styles that offer a selection of a single value.