### PR TITLE
FIX: issue #4271 ([GTK] NO-BUTTONS window flag has no effect)

### DIFF
--- a/modules/view/backends/gtk3/events.reds
+++ b/modules/view/backends/gtk3/events.reds
@@ -1024,6 +1024,7 @@ connect-widget-events: func [
 			gobj_signal_connect(widget "focus-in-event" :focus-in-event widget)
 			gobj_signal_connect(widget "focus-out-event" :focus-out-event widget)
 			gobj_signal_connect(widget "configure-event" :window-configure-event widget)
+			gobj_signal_connect(widget "realize" :window-realize widget)
 		]
 		sym = slider [
 			gobj_signal_connect(widget "value-changed" :range-value-changed widget)

--- a/modules/view/backends/gtk3/gtk.reds
+++ b/modules/view/backends/gtk3/gtk.reds
@@ -1278,6 +1278,10 @@ GPtrArray!: alias struct! [
 			window		[handle!]
 			mode		[logic!]
 		]
+		gtk_window_set_type_hint: "gtk_window_set_type_hint" [
+			window		[handle!]
+			mode		[integer!]
+		]
 		gtk_window_move: "gtk_window_move" [
 			window		[handle!]
 			x			[integer!]
@@ -2930,7 +2934,10 @@ GPtrArray!: alias struct! [
 			win 		[handle!]
 			cursor		[handle!]
 		]
-
+		gdk_window_set_decorations: "gdk_window_set_decorations" [
+			window		[handle!]
+			flags		[integer!]
+		]
 		;; Useless since already called inside pango_cairo_create_context
 		; pango_cairo_font_map_get_default: "pango_cairo_font_map_get_default" [
 		; 	return: 	[handle!]

--- a/modules/view/backends/gtk3/gui.reds
+++ b/modules/view/backends/gtk3/gui.reds
@@ -1629,7 +1629,6 @@ OS-make-view: func [
 			]
 			if any [
 				bits and FACET_FLAGS_NO_MIN <> 0
-				bits and FACET_FLAGS_NO_MAX <> 0
 				bits and FACET_FLAGS_NO_BTNS <> 0
 			][
 				gtk_window_set_type_hint widget 5					;-- WINDOW_TYPE_HINT_UTILITY

--- a/modules/view/backends/gtk3/gui.reds
+++ b/modules/view/backends/gtk3/gui.reds
@@ -1617,13 +1617,30 @@ OS-make-view: func [
 		]
 		sym = window [
 			widget: gtk_window_new 0
-
+			
 			if bits and FACET_FLAGS_MODAL <> 0 [
 				gtk_window_set_modal widget yes
 			]
+			if any [
+				bits and FACET_FLAGS_NO_TITLE <> 0
+				bits and FACET_FLAGS_NO_BORDER <> 0
+			][
+				gtk_window_set_decorated widget no
+			]
+			if any [
+				bits and FACET_FLAGS_NO_MIN <> 0
+				bits and FACET_FLAGS_NO_MAX <> 0
+				bits and FACET_FLAGS_NO_BTNS <> 0
+			][
+				gtk_window_set_type_hint widget 5					;-- WINDOW_TYPE_HINT_UTILITY
+			]
+			if bits and FACET_FLAGS_NO_BTNS <> 0 [
+				gtk_window_set_deletable widget no					;-- hide Close button
+			]
+			
 			unless null? caption [gtk_window_set_title widget caption]
 
-			winbox: gtk_box_new GTK_ORIENTATION_VERTICAL  0
+			winbox: gtk_box_new GTK_ORIENTATION_VERTICAL 0
 			gtk_container_add widget winbox
 			if menu-bar? menu window [
 				hMenu: gtk_menu_bar_new
@@ -1638,17 +1655,8 @@ OS-make-view: func [
 			gtk_box_pack_start winbox container yes yes 0
 			gtk_window_move widget offset/x offset/y
 
-			;; The following line really matters to fix the initial size of the window
-			gtk_widget_set_size_request widget size/x size/y
+			gtk_widget_set_size_request widget size/x size/y		;-- fix the initial size of the window
 			gtk_window_set_resizable widget (bits and FACET_FLAGS_RESIZE <> 0)
-			either any [
-				bits and FACET_FLAGS_NO_TITLE <> 0
-				bits and FACET_FLAGS_NO_BORDER <> 0
-			][
-				gtk_window_set_decorated widget no
-			][
-				gtk_window_set_decorated widget yes
-			]
 		]
 		sym = camera [
 			widget: gtk_layout_new null null

--- a/modules/view/backends/gtk3/handlers.reds
+++ b/modules/view/backends/gtk3/handlers.reds
@@ -440,6 +440,25 @@ window-size-allocate: func [
 	]
 ]
 
+window-realize: func [
+	[cdecl]
+	widget [handle!]
+	/local
+		values [red-value!]
+		flags  [integer!]
+		bits   [integer!]
+][
+	values: get-face-values widget
+	flags:  get-flags as red-block! values + FACE_OBJ_FLAGS
+	bits:   1																;-- GDK_DECOR_ALL
+	
+	if flags and FACET_FLAGS_NO_BTNS <> 0 [bits: bits or 16 or 32 or 64]	;-- hide Menu, Min and Max buttons
+	if flags and FACET_FLAGS_NO_MIN  <> 0 [bits: bits or 32]				;-- hide Min button
+	if flags and FACET_FLAGS_NO_MAX  <> 0 [bits: bits or 64]				;-- hide Max button
+	
+	gdk_window_set_decorations gtk_widget_get_window widget bits
+]
+
 widget-realize: func [
 	[cdecl]
 	evbox		[handle!]


### PR DESCRIPTION
This PR fixes #4271, but only partially and in a two-fold manner, here's why:

1. Window decoration flags can be set separately with combination of [`gdk-window-set-decorations`](https://developer.gnome.org/gdk3/stable/gdk3-Windows.html#gdk-window-set-decorations) and [`GdkWMDecoration`](https://developer.gnome.org/gdk3/stable/gdk3-Windows.html#GdkWMDecoration) in `realize` signal handler (i.e. after allocation of low-level GDK resources), but it still leaves window at the mercy of a window manager, which is free to ignore all the (un)set bits when applying decorations; per documentation referenced above:

   > Most window managers honor a decorations hint of 0 to disable all decorations, but very few honor all possible combinations of bits.

1. GTK itself offers only coarse-grained management of window's appearance:
   * [`gtk-window-set-decorated`](https://developer.gnome.org/gtk3/stable/GtkWindow.html#gtk-window-set-decorated) to disable decorations altogether (i.e. remove window's frame with decoration hint of 0);
   * [`gtk-window-set-type-hint`](https://developer.gnome.org/gtk3/stable/GtkWindow.html#gtk-window-set-type-hint) with [`GdkWindowTypeHint`](https://developer.gnome.org/gdk3/stable/gdk3-Windows.html#GdkWindowTypeHint) to prompt WM to decorate window according to its functional purpose (i.e. window's type);
   * [`gtk_window_set_deletable`](https://developer.gnome.org/gtk3/stable/GtkWindow.html#gtk_window_set_deletable) to mark window as 'deletable', hinting WM to hide 'Close' button.

Consequently, https://github.com/red/red/commit/df43497db2387a4a5193dc68fd3fa986e9891c75 addresses **(1)** and sets decoration hints manually in GDK window, while **(2)** https://github.com/red/red/commit/a21f9a270148757f115636a82ba2ad9792cd7c9d relies on high-level GTK API.

Testing on `xfwm4` gave the following results:
* Most of the manually set hint combinations are not honored, rendering **(1)** ineffective;
* `gtk_window_set_deletable` hides 'Close' button; 
* `GDK_WINDOW_TYPE_HINT_UTILITY` window type hint hides 'Min' button.

What this means with regard to View is:
* `no-buttons` removes only 'Close' and 'Min' buttons;
* `no-min` removes 'Min' button;
* `no-max` is ignored since it's apparently impossible to hide the 'Max' button when the window is marked as resizable.

Examples:

| `resize` | — | `no-buttons` | `no-min` | `no-max` |
|:-:|-|-|-|-|
| ✗ | ![image](https://user-images.githubusercontent.com/15716466/73590932-c49dd180-44e8-11ea-86b6-60f567c784b0.png) | ![image](https://user-images.githubusercontent.com/15716466/73591018-bac89e00-44e9-11ea-8a0a-06d4704e89e3.png) | ![image](https://user-images.githubusercontent.com/15716466/73591031-e6e41f00-44e9-11ea-8587-88759f8f54a3.png) | ![image](https://user-images.githubusercontent.com/15716466/73590932-c49dd180-44e8-11ea-86b6-60f567c784b0.png) |
| ✓ | ![image](https://user-images.githubusercontent.com/15716466/73590943-f31bac80-44e8-11ea-8227-8799ebb8130b.png) | ![image](https://user-images.githubusercontent.com/15716466/73590968-3118d080-44e9-11ea-900f-d0b8d5fd8c56.png) | ![image](https://user-images.githubusercontent.com/15716466/73591003-85bc4b80-44e9-11ea-8802-b32b6d1affdb.png) | ![image](https://user-images.githubusercontent.com/15716466/73590943-f31bac80-44e8-11ea-8227-8799ebb8130b.png) |

---

This PR can be merged when:

- [ ] Interested contributors tested these changes on their WM of choice and reported back;
- [ ] If **(1)** has no effect, then I'll revert the respective commit, to avoid cluttering codebase with redundant code;
- [ ] If there are any significant differences across WMs, the least we can do is to document them.




