### PR TITLE
FEAT: support for handle loading

### DIFF
--- a/environment/lexer.red
+++ b/environment/lexer.red
@@ -262,6 +262,18 @@ system/lexer: context [
 		n
 	]
 
+	make-handle: routine [
+		start	[string!]
+		end		[string!]
+		/local
+			n	  [integer!]
+			value [red-value!]
+	][
+		n: make-hexa start end
+		value: as red-value! integer/box n
+		set-type value TYPE_HANDLE
+	]
+
 	make-char: routine [
 		start	[string!]
 		end		[string!]
@@ -870,6 +882,7 @@ system/lexer: context [
 					| "routine!"	(value: routine!)
 				]
 				| "none" 			(value: none)
+				| "handle!" some ws s: hexa-rule (value: make-handle s e)
 			] pos: any ws #"]"
 		]
 


### PR DESCRIPTION
Addresses https://github.com/red/red/issues/4126#issuecomment-581180069 by making handle! loadable after mold:
```
>> mold/all load mold/all load "#[handle! 10h]"
== "#[handle! 00000010h]"
```

I didn't change the R2 lexer. Not sure how - no handles in R2. Or if there's a point it that.
