### PR TITLE
FIX: issue #4280 ([View] custom font resets alignment for BUTTON, CHECK and RADIO)

### DIFF
--- a/modules/view/backends/windows/events.reds
+++ b/modules/view/backends/windows/events.reds
@@ -790,10 +790,11 @@ process-custom-draw: func [
 		type	[red-word!]
 		txt		[red-string!]
 		font	[red-object!]
+		para    [red-object!]
 		color	[red-tuple!]
+		flags	[integer!]
 		sym		[integer!]
 		old		[integer!]
-		flags	[integer!]
 		DC		[handle!]
 		rc		[RECT_STRUCT]
 ][
@@ -813,6 +814,7 @@ process-custom-draw: func [
 		][
 			;@@ TBD draw image
 			font: as red-object! values + FACE_OBJ_FONT
+			para: as red-object! values + FACE_OBJ_PARA
 			if TYPE_OF(font) = TYPE_OBJECT [
 				txt: as red-string! values + FACE_OBJ_TEXT
 				values: object/get-values font
@@ -825,14 +827,12 @@ process-custom-draw: func [
 					SetTextColor DC color/array1 and 00FFFFFFh
 				]
 				rc: as RECT_STRUCT (as int-ptr! item) + 5
-				flags: DT_VCENTER or DT_SINGLELINE
-				either sym = button [
-					flags: flags or DT_CENTER
-				][
+				unless sym = button [
 					rc/left: rc/left + dpi-scale 16
 				]
 				if TYPE_OF(txt) = TYPE_STRING [
-					DrawText DC unicode/to-utf16 txt -1 rc flags
+					flags: get-para-flags base para
+					DrawText DC unicode/to-utf16 txt -1 rc flags or DT_SINGLELINE
 				]
 				SetBkMode DC old
 				return CDRF_SKIPDEFAULT


### PR DESCRIPTION
Fixes #4280 by fetching DrawText flags via `get-para-flags` and applying them on text rendering. Not sure if regression tests are required though.

![image](https://user-images.githubusercontent.com/15716466/73772766-1b253d00-4781-11ea-8c5f-e032d6353920.png)


