### PR TITLE
FEAT: fetch-next supports set-words/paths, get/lit-args, objects...

### DIFF
--- a/tests/source/compiler/preprocessor-test.r
+++ b/tests/source/compiler/preprocessor-test.r
@@ -116,12 +116,12 @@ REBOL [
 			prin "*test11* " probe preprocessor/fetch-next [a: o b: 1]
 			prin "*test12* " probe preprocessor/fetch-next [f o f 1]
 			prin "*test13* " probe preprocessor/fetch-next [b/o/f o b/o/f/x 1 2 3]
-			i: make image! 10x10 s: "abcd"
-			b: reduce [i s]
-			w1: 'i w2: 's w3: 3
-			prin "*test14* " probe preprocessor/fetch-next [i/size s/3]
+			p: 10x20 s: "abcd"
+			b: reduce [p s]
+			w1: 'p w2: 's w3: 3
+			prin "*test14* " probe preprocessor/fetch-next [p/y s/3]
 			prin "*test15* " probe preprocessor/fetch-next [s/3]
-			prin "*test16* " probe preprocessor/fetch-next [b/:w1/size b/(w2)/:w3]
+			prin "*test16* " probe preprocessor/fetch-next [b/:w1/y b/(w2)/:w3]
 			prin "*test17* " probe preprocessor/fetch-next [b/(w2)/:w3]
 		}
 		

--- a/tests/source/compiler/preprocessor-test.r
+++ b/tests/source/compiler/preprocessor-test.r
@@ -116,6 +116,13 @@ REBOL [
 			prin "*test11* " probe preprocessor/fetch-next [a: o b: 1]
 			prin "*test12* " probe preprocessor/fetch-next [f o f 1]
 			prin "*test13* " probe preprocessor/fetch-next [b/o/f o b/o/f/x 1 2 3]
+			i: make image! 10x10 s: "abcd"
+			b: reduce [i s]
+			w1: 'i w2: 's w3: 3
+			prin "*test14* " probe preprocessor/fetch-next [i/size s/3]
+			prin "*test15* " probe preprocessor/fetch-next [s/3]
+			prin "*test16* " probe preprocessor/fetch-next [b/:w1/size b/(w2)/:w3]
+			prin "*test17* " probe preprocessor/fetch-next [b/(w2)/:w3]
 		}
 		
 		--assert-printed? "*test1* []"
@@ -131,5 +138,9 @@ REBOL [
 		--assert-printed? "*test11* [1]"
 		--assert-printed? "*test12* [1]"
 		--assert-printed? "*test13* [1 2 3]"
+		--assert-printed? "*test14* [s/3]"
+		--assert-printed? "*test15* []"
+		--assert-printed? "*test16* [b/(w2)/:w3]"
+		--assert-printed? "*test17* []"
 
 ~~~end-file~~~ 

--- a/tests/source/compiler/preprocessor-test.r
+++ b/tests/source/compiler/preprocessor-test.r
@@ -96,4 +96,40 @@ REBOL [
 		--assert-printed? "*test9*"
 		--assert-printed? "*test10* foo 5 9"
 
+	--test-- "fetch-next"
+		--compile-and-run-this {
+			Red []
+			prin "*test1* " probe preprocessor/fetch-next []
+			prin "*test2* " probe preprocessor/fetch-next [1 2]
+			prin "*test3* " probe preprocessor/fetch-next [1 + 2 3]
+			prin "*test4* " probe preprocessor/fetch-next [a: 1 + b: 2 3]
+			prin "*test5* " probe preprocessor/fetch-next [+ 1 2 3]
+			b: reduce ['o make object! [f: func [/x y z][]]]
+			prin "*test6* " probe preprocessor/fetch-next [a: 1 + b/o/f 2 3 4]
+			prin "*test7* " probe preprocessor/fetch-next [a: 1 + b/o/f/x 2 3 4]
+			prin "*test8* " probe preprocessor/fetch-next [a: 1 + b/o/f/x 2 3 * 4 * 5 6]
+			b: reduce ['o make object! [f: func [/x 'y :z][]]]
+			f: func [x][]
+			prin "*test9* " probe preprocessor/fetch-next [a: 1 + b/o/f/x f f 4 5 6]
+			prin "*test10* " probe preprocessor/fetch-next [a: 1 + b/o/f/x + * 4 5 6]
+			o: make op! func ['x 'y][]
+			prin "*test11* " probe preprocessor/fetch-next [a: o b: 1]
+			prin "*test12* " probe preprocessor/fetch-next [f o f 1]
+			prin "*test13* " probe preprocessor/fetch-next [b/o/f o b/o/f/x 1 2 3]
+		}
+		
+		--assert-printed? "*test1* []"
+		--assert-printed? "*test2* [2]"
+		--assert-printed? "*test3* [3]"
+		--assert-printed? "*test4* [3]"
+		--assert-printed? "*test5* [2 3]"
+		--assert-printed? "*test6* [2 3 4]"
+		--assert-printed? "*test7* [4]"
+		--assert-printed? "*test8* [6]"
+		--assert-printed? "*test9* [4 5 6]"
+		--assert-printed? "*test10* [4 5 6]"
+		--assert-printed? "*test11* [1]"
+		--assert-printed? "*test12* [1]"
+		--assert-printed? "*test13* [1 2 3]"
+
 ~~~end-file~~~ 

--- a/utils/preprocessor.r
+++ b/utils/preprocessor.r
@@ -136,13 +136,20 @@ preprocessor: context [
 		arity
 	]
 
-	value-path?: func [path [path!] /local value i] [
+	value-path?: func [path [path!] /local value i item] [
 		repeat i length? path [
-			set/any 'value either i = 1 [get/any first path][select value pick path i]
-			unless any [								;-- select-able types
-				series? get/any 'value
-				find [object! port! error! map!] type?/word get/any 'value
-			][
+			set/any 'value either i = 1 [get/any first path][
+				set/any 'item pick path i
+				case [
+					get-word? :item [set/any 'item get/any to word! item]
+					paren?    :item [set/any 'item do item]
+				]
+				either integer? :item [pick value item][select value :item]
+			]
+			unless find [								;-- select-able types
+				block! paren! path! lit-path! set-path! get-path!
+				object! port! error! map!
+			] type?/word get/any 'value [
 				path: copy/part path i
 				break
 			]

--- a/utils/preprocessor.r
+++ b/utils/preprocessor.r
@@ -99,11 +99,13 @@ preprocessor: context [
 		do-safe/with bind to block! code exec cmd
 	]
 	
-	count-args: func [spec [block!] /local total][
-		total: 0
+	count-args: func [spec [block!] /block /local total pos][
+		total: either block [copy []][0]
 		parse spec [
 			any [
-				[word! | lit-word! | get-word!] (total: total + 1)
+				pos: [word! | lit-word! | get-word!] (
+					either block [append total type? pos/1] [total: total + 1]
+				)
 				| refinement! (return total)
 				| skip
 			]
@@ -111,8 +113,12 @@ preprocessor: context [
 		total
 	]
 	
-	func-arity?: func [spec [block!] /with path [path!] /local arity pos][
-		arity: count-args spec
+	arg-mode?: func [spec [block!] idx [integer!]][
+		pick count-args/block spec idx
+	]
+	
+	func-arity?: func [spec [block!] /with path [path!] /block /local arity pos][
+		arity: either block [count-args/block spec] [count-args spec]
 		if path [
 			foreach word next path	[
 				unless pos: find/tail spec to refinement! word [
@@ -122,39 +128,82 @@ preprocessor: context [
 					]
 					do-quit
 				]
-				arity: arity + count-args pos
+				either block
+					[append arity count-args/block pos]
+					[arity: arity + count-args pos]
 			]
 		]
 		arity
 	]
-	
-	fetch-next: func [code [block! paren!] /local base arity value path][
-		base: code
-		arity: 1
-		
-		while [arity > 0][
-			arity: arity + either all [
-				not tail? next code
-				word? value: code/2
-				op? get/any value
+
+	value-path?: func [path [path!] /local value i] [
+		repeat i length? path [
+			set/any 'value either i = 1 [get/any first path][select value pick path i]
+			unless any [								;-- select-able types
+				series? get/any 'value
+				any-object? get/any 'value
+				map? get/any 'value
 			][
-				code: next code
-				1
-			][
-				either all [
-					find [word! path!] type?/word value: code/1
-					value: either word? value [value][first path: value]
-					any-function? get/any value
-				][
-					either path [
-						func-arity?/with spec-of get value path
-					][
-						func-arity? spec-of get value
-					]
-				][0]
+				path: copy/part path i
+				break
 			]
+		]
+		reduce [path get/any 'value]
+	]
+
+	fetch-next: func [code [block! paren!] /local i left item item2 value fn-spec path f-arity at-op? op-mode][
+		left: reduce [yes]
+		
+		while [all [not tail? left not tail? code]] [
+			either not left/1 [							;-- skip quoted argument
+				remove left
+			][
+				item: first code
+				f-arity: any [
+					all [									;-- a ...
+						word? :item
+						any-function? set/any 'value get/any :item
+						func-arity?/block fn-spec: spec-of get/any :item
+					]
+					all [									;-- a/b ...
+						path? :item
+						set/any [path value] value-path? :item
+						any-function? get/any 'value
+						func-arity?/block/with
+							fn-spec: spec-of :value
+							at :item length? :path
+					]
+				]
+
+				if at-op?: all [							;-- a * b
+					1 < length? code
+					word? item2: second code
+					op? get/any :item2
+				] [
+					op-mode: arg-mode? spec-of get/any :item2 1
+					if all [f-arity  op-mode = word!] [		;-- check if function's lit/get-arg takes priority
+						at-op?: word! = arg-mode? fn-spec 1
+					]
+				]
+
+				case [
+					at-op? [								;-- a * b
+						code: next code						;-- skip `a *` part
+						left/1: word! = arg-mode? spec-of get/any :item2 2
+					]
+
+					f-arity [								;-- a ... / a/b ...
+						if op? get/any 'value [return skip code 2]	;-- starting with op is an error
+						remove left
+						repeat i length? f-arity [insert at left i word! = f-arity/:i]
+					]
+
+					not find [set-word! set-path!] type?/word item [	;-- not a: or a/b:
+						remove left
+					]
+				]
+			];;either not left/1 [][
 			code: next code
-			arity: arity - 1
 		]
 		code
 	]

--- a/utils/preprocessor.r
+++ b/utils/preprocessor.r
@@ -136,7 +136,11 @@ preprocessor: context [
 		arity
 	]
 
-	value-path?: func [path [path!] /local value i item] [
+	value-path?: func [path [path!] /local value i item selectable] [
+		selectable: make typeset! [
+			block! paren! path! lit-path! set-path! get-path!
+			object! port! error! map!
+		]
 		repeat i length? path [
 			set/any 'value either i = 1 [get/any first path][
 				set/any 'item pick path i
@@ -146,10 +150,7 @@ preprocessor: context [
 				]
 				either integer? :item [pick value item][select value :item]
 			]
-			unless find [								;-- select-able types
-				block! paren! path! lit-path! set-path! get-path!
-				object! port! error! map!
-			] type?/word get/any 'value [
+			unless find selectable type? get/any 'value [
 				path: copy/part path i
 				break
 			]

--- a/utils/preprocessor.r
+++ b/utils/preprocessor.r
@@ -141,8 +141,7 @@ preprocessor: context [
 			set/any 'value either i = 1 [get/any first path][select value pick path i]
 			unless any [								;-- select-able types
 				series? get/any 'value
-				any-object? get/any 'value
-				map? get/any 'value
+				find [object! port! error! map!] type?/word get/any 'value
 			][
 				path: copy/part path i
 				break


### PR DESCRIPTION
Extension to `preprocessor/fetch-next` in the light of :point_up: [February 1, 2020 6:15 PM](https://gitter.im/red/bugs?at=5e3596233aca1e4c5f5a11d4)