### PR TITLE
FEAT: grant wish red/REP#51 (BODY-OF on ACTION! and NATIVE! values)

### DIFF
--- a/runtime/datatypes/native.reds
+++ b/runtime/datatypes/native.reds
@@ -186,7 +186,9 @@ native: context [
 		field	[integer!]
 		return:	[red-block!]
 		/local
-			blk [red-block!]
+			blk   [red-block!]
+			table [int-ptr!]
+			index [integer!]
 	][
 		case [
 			field = words/spec [
@@ -194,6 +196,14 @@ native: context [
 				blk/header: TYPE_BLOCK					;-- implicit reset of all header flags
 				blk/node:	native/spec
 				blk/head:	0
+			]
+			field = words/body [
+				table: either TYPE_OF(native) = TYPE_NATIVE [natives/table][actions/table]
+				index: 0
+				
+				until [index: index + 1 native/code = table/index]
+				
+				return as red-block! integer/box index
 			]
 			field = words/words [
 				--NOT_IMPLEMENTED--						;@@ build the words block from spec


### PR DESCRIPTION
This PR fulfills and closes https://github.com/red/REP/issues/51 by implementing `body` reflector for `action!` and `native!` values.

```red
>> load rejoin [body-of :now reflect :negate 'body]
== 9214
```

Rationale and use-cases for this are described in https://github.com/red/red/issues/3359#issuecomment-523405544.