### PR TITLE
FIX: libRed.red was not updated if libRed directory exists

### DIFF
--- a/compiler.r
+++ b/compiler.r
@@ -447,7 +447,7 @@ red: context [
 				append blk decorate-symbol/no-alias name ;-- local word, point to value slot
 			][
 				append blk [as cell!]
-				append/only blk prefix-exec name		;-- force global word
+				append/only blk duplicate-symbol name
 			]
 		][
 			if new: select-ssa name [name: new]			;@@ add a check for function! type
@@ -468,7 +468,7 @@ red: context [
 				]
 			][
 				append blk [as cell!]
-				append/only blk prefix-exec name
+				append/only blk duplicate-symbol name
 			]
 			
 		]
@@ -835,6 +835,16 @@ red: context [
 			]
 			new-line skip tail sym-table -3 on
 		]
+	]
+	
+	duplicate-symbol: func [name [word!] /local new][
+		new: decorate-symbol to word! append append mold/flat name #"|" get-counter
+		repend symbols [name select symbols name]
+		repend sym-table [
+			to set-word! new 'word/duplicate decorate-symbol name
+		]
+		new-line skip tail sym-table -3 on
+		new
 	]
 	
 	get-symbol-id: func [name [word!]][

--- a/environment/console/GUI/core.red
+++ b/environment/console/GUI/core.red
@@ -122,10 +122,10 @@ object [
 		calc-top
 	]
 
-	vprint: func [str [string!] lf? [logic!] /local s cnt][
+	vprint: func [str [string!] lf? [logic!] /local s cnt first-prin?][
 		unless console/state [exit]
 
-		if all [not lf? newline?][newline?: no add-line make string! 8]
+		if all [not lf? newline?][newline?: no first-prin?: yes]
 		if lf? [newline?: yes]
 		s: find str lf
 		either s [
@@ -140,13 +140,14 @@ object [
 				]
 				not s: find str lf
 			]
-			either str/1 = lf [
-				add-line ""
-			][
+			either all [empty? str lf = first back str][add-line copy ""][
 				either all [lf? not prin?][add-line copy str][vprin str]
 			]
 		][
-			either all [lf? not prin?][add-line copy str][vprin str]
+			either all [lf? not prin?][add-line copy str][
+				if first-prin? [add-line make string! 8]
+				vprin str
+			]
 		]
 		prin?: not lf?
 		if system/console/running? [

--- a/environment/system.red
+++ b/environment/system.red
@@ -234,7 +234,7 @@ system: context [
 				;security-level:	["attempt to lower security to" :arg1]
 				;security-error:	["invalid" :arg1 "security policy:" :arg2]
 				;no-codec:			["cannot decode or encode (no codec):" :arg1]
-				;bad-media:			["bad media data (corrupt image, sound, video)"]
+				bad-media:			["bad media data (corrupt image, sound, video)"]
 				;no-extension:		["cannot open extension:" :arg1]
 				;bad-extension:		["invalid extension format:" :arg1]
 				;extension-init:	["extension cannot be initialized (check version):" :arg1]

--- a/modules/view/backends/platform.red
+++ b/modules/view/backends/platform.red
@@ -566,12 +566,13 @@ system/view/platform: context [
 		]
 
 		font: as red-object! values + gui/FACE_OBJ_FONT
-		hFont: either TYPE_OF(font) = TYPE_OBJECT [
+		hFont: null
+		if TYPE_OF(font) = TYPE_OBJECT [
 			state: as red-block! (object/get-values font) + gui/FONT_OBJ_STATE
-			either TYPE_OF(state) <> TYPE_BLOCK [gui/make-font face font][gui/get-font-handle font 0]
-		][
-			null
+			if TYPE_OF(state) <> TYPE_BLOCK [hFont: gui/get-font-handle font 0]
+			if null? hFont [hFont: gui/make-font face font]
 		]
+
 		pair: as red-pair! stack/arguments
 		pair/header: TYPE_PAIR
 		

--- a/modules/view/backends/windows/base.reds
+++ b/modules/view/backends/windows/base.reds
@@ -681,6 +681,7 @@ update-base-text: func [
 	GdipCreateStringFormat fflags or 80000000h 0 :format 	;-- 1 << 31 = GDI passthrough
 	GdipSetStringFormatAlign format h-align
 	GdipSetStringFormatLineAlign format v-align
+	GdipSetStringFormatTrimming format 0	;-- TrimmingNone
 
 	rect/x: as float32! 0.0
 	rect/y: as float32! 0.0

--- a/modules/view/backends/windows/base.reds
+++ b/modules/view/backends/windows/base.reds
@@ -182,6 +182,19 @@ clip-layered-window: func [
 		flags	[integer!]
 ][
 	flags: GetWindowLong hWnd wc-offset - 12
+	if all [						;-- delete window clip region
+		BASE_FACE_CLIPPED and flags <> 0
+		zero? x
+		zero? y
+		size/width = new-width
+		size/height = new-height
+	][
+		SetWindowRgn hWnd null false
+		child: as handle! GetWindowLong hWnd wc-offset - 20
+		if child <> null [SetWindowRgn child null false]
+		SetWindowLong hWnd wc-offset - 12 flags and FFFFFFFEh
+		exit
+	]
 	if any [
 		not zero? x
 		not zero? y
@@ -198,13 +211,6 @@ clip-layered-window: func [
 			SetWindowRgn child rgn false
 		]
 	]
-	if all [
-		BASE_FACE_CLIPPED and flags <> 0
-		zero? x
-		zero? y
-		size/width = new-width
-		size/height = new-height
-	][SetWindowLong hWnd wc-offset - 12 flags and FFFFFFFEh]
 ]
 
 process-layered-region: func [

--- a/modules/view/backends/windows/draw.reds
+++ b/modules/view/backends/windows/draw.reds
@@ -682,11 +682,17 @@ draw-short-curves: func [
 		pt: pt + 1
 		pt/x: ( 2 * ctx/other/path-last-point/x ) - control/x
 		pt/y: ( 2 * ctx/other/path-last-point/y ) - control/y
-		control/x: pt/x
-		control/y: pt/y
+		if nr-points = 1 [
+			control/x: pt/x
+			control/y: pt/y
+		]
 		pt: pt + 1
 		pt/x: either rel? [ ctx/other/path-last-point/x + pair/x ][ pair/x ]
 		pt/y: either rel? [ ctx/other/path-last-point/y + pair/y ][ pair/y ]
+		if nr-points = 2 [
+			control/x: pt/x
+			control/y: pt/y
+		]
 		pt: pt + 1
 		loop nr-points - 1 [ pair: pair + 1 ]
 		if pair <= end [

--- a/modules/view/backends/windows/events.reds
+++ b/modules/view/backends/windows/events.reds
@@ -32,6 +32,8 @@ flags-blk/head:		0
 flags-blk/node:		alloc-cells 4
 flags-blk/header:	TYPE_BLOCK
 
+last-mouse-pt: 0
+
 char-keys: [
 	1000C400h C0FF0080h E0FFFF7Fh 0000F7FFh 00000000h 3F000000h 1F000080h 00FC7F38h
 ]
@@ -1450,6 +1452,9 @@ process: func [
 	switch msg/msg [
 		WM_MOUSEMOVE [
 			lParam: msg/lParam
+			if last-mouse-pt = lParam [return EVT_NO_DISPATCH]
+			last-mouse-pt: lParam
+
 			x: WIN32_LOWORD(lParam)
 			y: WIN32_HIWORD(lParam)
 			if any [

--- a/modules/view/backends/windows/events.reds
+++ b/modules/view/backends/windows/events.reds
@@ -417,15 +417,15 @@ check-extra-keys: func [
 		key [integer!]
 ][
 	key: 0
-	if (GetAsyncKeyState VK_CONTROL)  and 8000h <> 0 [key: EVT_FLAG_CTRL_DOWN]
-	if (GetAsyncKeyState VK_SHIFT)    and 8000h <> 0 [key: key or EVT_FLAG_SHIFT_DOWN]
-	if (GetAsyncKeyState VK_MENU)     and 8000h <> 0 [key: key or EVT_FLAG_MENU_DOWN]	;-- ALT key
+	if (GetKeyState VK_CONTROL)  and 8000h <> 0 [key: EVT_FLAG_CTRL_DOWN]
+	if (GetKeyState VK_SHIFT)    and 8000h <> 0 [key: key or EVT_FLAG_SHIFT_DOWN]
+	if (GetKeyState VK_MENU)     and 8000h <> 0 [key: key or EVT_FLAG_MENU_DOWN]	;-- ALT key
 	
 	unless only? [
-		if (GetAsyncKeyState 01h) and 8000h <> 0 [key: key or EVT_FLAG_DOWN] 	   ;-- VK_LBUTTON
-		if (GetAsyncKeyState 02h) and 8000h <> 0 [key: key or EVT_FLAG_ALT_DOWN]   ;-- VK_RBUTTON
-		if (GetAsyncKeyState 04h) and 8000h <> 0 [key: key or EVT_FLAG_MID_DOWN]   ;-- VK_MBUTTON
-		if (GetAsyncKeyState 05h) and 8000h <> 0 [key: key or EVT_FLAG_AUX_DOWN]   ;-- VK_XBUTTON1
+		if (GetKeyState 01h) and 8000h <> 0 [key: key or EVT_FLAG_DOWN] 	   ;-- VK_LBUTTON
+		if (GetKeyState 02h) and 8000h <> 0 [key: key or EVT_FLAG_ALT_DOWN]   ;-- VK_RBUTTON
+		if (GetKeyState 04h) and 8000h <> 0 [key: key or EVT_FLAG_MID_DOWN]   ;-- VK_MBUTTON
+		if (GetKeyState 05h) and 8000h <> 0 [key: key or EVT_FLAG_AUX_DOWN]   ;-- VK_XBUTTON1
 	]
 	key
 ]

--- a/modules/view/backends/windows/font.reds
+++ b/modules/view/backends/windows/font.reds
@@ -128,7 +128,7 @@ OS-make-font: func [
 	blk: as red-block! values + FONT_OBJ_STATE
 	either TYPE_OF(blk) <> TYPE_BLOCK [
 		block/make-at blk 3
-		handle/make-in blk as-integer hFont
+		either scaling? [handle/make-in blk as-integer hFont][none/make-in blk]
 		none/make-in blk								;-- DWrite font
 		either scaling? [
 			none/make-in blk

--- a/modules/view/backends/windows/win32.reds
+++ b/modules/view/backends/windows/win32.reds
@@ -2358,6 +2358,11 @@ XFORM!: alias struct! [
 			align		[integer!]
 			return:		[integer!]
 		]
+		GdipSetStringFormatTrimming: "GdipSetStringFormatTrimming" [
+			format		[integer!]
+			trimming	[integer!]
+			return:		[integer!]
+		]
 		GdipCreateFontFromDC: "GdipCreateFontFromDC" [
 			hdc			[integer!]
 			font		[int-ptr!]

--- a/red.r
+++ b/red.r
@@ -616,8 +616,11 @@ redc: context [
 	do-build: func [args [block!] /local cmd src][
 		switch/default args/1 [
 			"libRed" [
-				if all [encap? not exists? %libRed/][
-					make-dir path: %libRed/
+				path: %libRed/
+
+				if encap? [
+					unless exists? %libRed/ [make-dir path]
+
 					foreach file [
 						%libRed.def
 						%libRed.red
@@ -627,6 +630,7 @@ redc: context [
 					]
 					write/binary path/libRed.lib read-cache path/libRed.lib
 				]
+
 				cmd: copy "-r libRed/libRed.red"
 				if all [not tail? next args args/2 = "stdcall"][
 					insert at cmd 3 { --config "[export-ABI: 'stdcall]"}

--- a/runtime/datatypes/binary.reds
+++ b/runtime/datatypes/binary.reds
@@ -1158,7 +1158,7 @@ binary: context [
 		]
 		
 		type: TYPE_OF(value)
-		either ANY_LIST(type) [
+		either ANY_LIST?(type) [
 			src: as red-block! value
 			s2: GET_BUFFER(src)
 			cell:  s2/offset + src/head

--- a/runtime/datatypes/binary.reds
+++ b/runtime/datatypes/binary.reds
@@ -1113,6 +1113,7 @@ binary: context [
 			data	  [byte-ptr!]
 			s		  [series!]
 			s2		  [series!]
+			type      [integer!]
 			int-value [integer!]
 			dup-n	  [integer!]
 			cnt		  [integer!]
@@ -1155,8 +1156,9 @@ binary: context [
 			(as-integer s/tail - s/offset) >> (log-b GET_UNIT(s)) = bin/head
 			append?
 		]
-
-		either TYPE_OF(value) = TYPE_BLOCK [		;@@ replace it with: typeset/any-block?
+		
+		type: TYPE_OF(value)
+		either ANY_LIST(type) [
 			src: as red-block! value
 			s2: GET_BUFFER(src)
 			cell:  s2/offset + src/head

--- a/runtime/datatypes/block.reds
+++ b/runtime/datatypes/block.reds
@@ -1374,7 +1374,20 @@ block: context [
 			table: hash/table
 		]
 
-		if OPTION?(part-arg) [
+		values?: all [
+			not only?									;-- /only support
+			any [
+				TYPE_OF(value) = TYPE_BLOCK				;@@ replace it with: typeset/any-block?
+				TYPE_OF(value) = TYPE_PATH				;@@ replace it with: typeset/any-block?
+				TYPE_OF(value) = TYPE_GET_PATH			;@@ replace it with: typeset/any-block?
+				TYPE_OF(value) = TYPE_SET_PATH			;@@ replace it with: typeset/any-block?
+				TYPE_OF(value) = TYPE_LIT_PATH			;@@ replace it with: typeset/any-block?
+				TYPE_OF(value) = TYPE_PAREN				;@@ replace it with: typeset/any-block?
+				TYPE_OF(value) = TYPE_HASH				;@@ replace it with: typeset/any-block?	
+			]
+		]
+
+		if all [OPTION?(part-arg) values?][
 			part: either TYPE_OF(part-arg) = TYPE_INTEGER [
 				int: as red-integer! part-arg
 				int/value
@@ -1390,24 +1403,13 @@ block: context [
 				b/head - src/head
 			]
 		]
+
 		if OPTION?(dup-arg) [
 			int: as red-integer! dup-arg
 			cnt: int/value
 			if negative? cnt [return as red-value! blk]
 		]
 		
-		values?: all [
-			not only?									;-- /only support
-			any [
-				TYPE_OF(value) = TYPE_BLOCK				;@@ replace it with: typeset/any-block?
-				TYPE_OF(value) = TYPE_PATH				;@@ replace it with: typeset/any-block?
-				TYPE_OF(value) = TYPE_GET_PATH			;@@ replace it with: typeset/any-block?
-				TYPE_OF(value) = TYPE_SET_PATH			;@@ replace it with: typeset/any-block?
-				TYPE_OF(value) = TYPE_LIT_PATH			;@@ replace it with: typeset/any-block?
-				TYPE_OF(value) = TYPE_PAREN				;@@ replace it with: typeset/any-block?
-				TYPE_OF(value) = TYPE_HASH				;@@ replace it with: typeset/any-block?	
-			]
-		]
 		size: either values? [
 			src: as red-block! value
 			rs-length? src

--- a/runtime/datatypes/context.reds
+++ b/runtime/datatypes/context.reds
@@ -46,6 +46,25 @@ _context: context [
 		-1												;-- search failed
 	]
 	
+	get-any: func [
+		symbol  [integer!]
+		node	[node!]
+		return:	[red-value!]
+		/local
+			ctx	   [red-context!]
+			values [series!]
+			index  [integer!]
+	][
+		#if debug? = yes [if verbose > 0 [print-line "_context/get-any"]]
+
+		ctx: TO_CTX(node)
+		if ON_STACK?(ctx) [ctx: TO_CTX(global-ctx)]
+		values: as series! ctx/values/value
+		index: find-word ctx symbol yes
+		assert index <> -1
+		values/offset + index
+	]
+	
 	set-global: func [
 		symbol	[integer!]
 		value	[red-value!]

--- a/runtime/datatypes/float.reds
+++ b/runtime/datatypes/float.reds
@@ -506,7 +506,7 @@ float: context [
 		either seed? [
 			s: f/value
 			sp: as int-ptr! :s
-			_random/srand sp/value
+			_random/srand sp/1 xor sp/2
 			f/header: TYPE_UNSET
 		][
 			s: (as-float _random/rand) / 2147483647.0

--- a/runtime/datatypes/float.reds
+++ b/runtime/datatypes/float.reds
@@ -499,12 +499,14 @@ float: context [
 		return: [red-float!]
 		/local
 			s	[float!]
+			sp	[int-ptr!]
 	][
 		#if debug? = yes [if verbose > 0 [print-line "float/random"]]
 
 		either seed? [
 			s: f/value
-			_random/srand as-integer s
+			sp: as int-ptr! :s
+			_random/srand sp/value
 			f/header: TYPE_UNSET
 		][
 			s: (as-float _random/rand) / 2147483647.0

--- a/runtime/datatypes/image.reds
+++ b/runtime/datatypes/image.reds
@@ -829,7 +829,7 @@ image: context [
 
 		img: as red-image! stack/arguments
 		offset: img/head + 1
-		if IMAGE_WIDTH(img/size) * IMAGE_HEIGHT(img/size) > offset  [
+		if IMAGE_WIDTH(img/size) * IMAGE_HEIGHT(img/size) >= offset [
 			img/head: offset
 		]
 		img
@@ -850,16 +850,18 @@ image: context [
 	tail?: func [
 		return:	  [red-value!]
 		/local
-			img	  [red-image!]
-			state [red-logic!]
+			img	   [red-image!]
+			state  [red-logic!]
+			offset [integer!]
 	][
 		#if debug? = yes [if verbose > 0 [print-line "image/tail?"]]
 
-		img:   as red-image! stack/arguments
-		state: as red-logic! img
+		img:    as red-image! stack/arguments
+		state:  as red-logic! img
+		offset: img/head + 1
 
 		state/header: TYPE_LOGIC
-		state/value:  IMAGE_WIDTH(img/size) * IMAGE_HEIGHT(img/size) <= (img/head + 1)
+		state/value:  not IMAGE_WIDTH(img/size) * IMAGE_HEIGHT(img/size) >= offset
 		as red-value! state
 	]
 

--- a/runtime/datatypes/image.reds
+++ b/runtime/datatypes/image.reds
@@ -153,6 +153,7 @@ image: context [
 		format	[integer!]
 		return: [red-value!]
 	][
+		if zero? image/size [fire [TO_ERROR(access bad-media)]]
 		if TYPE_OF(dst) = TYPE_NONE [dst: stack/push*]
 		OS-image/encode image dst format
 	]

--- a/runtime/datatypes/image.reds
+++ b/runtime/datatypes/image.reds
@@ -232,6 +232,7 @@ image: context [
 		/local
 			offset	[integer!]
 			sz		[integer!]
+			bin-sz	[integer!]
 			s		[series!]
 			p		[byte-ptr!]
 			stride	[integer!]
@@ -256,11 +257,16 @@ image: context [
 
 		type: TYPE_OF(bin)
 		either type = TYPE_BINARY [
+			bin-sz: binary/rs-length? bin
 			s: GET_BUFFER(bin)
 			p: as byte-ptr! s/offset
 			either method = EXTRACT_ARGB [
-				copy-memory as byte-ptr! data p sz * 4
+				sz: sz * 4
+				if bin-sz < sz [sz: bin-sz]
+				copy-memory as byte-ptr! data p sz
 			][
+				if method = EXTRACT_RGB [bin-sz: bin-sz / 3]	;-- number of pixels
+				if bin-sz < sz [end: data + bin-sz]
 				while [data < end][
 					pixel: data/value
 					either method = EXTRACT_ALPHA [

--- a/runtime/datatypes/image.reds
+++ b/runtime/datatypes/image.reds
@@ -778,15 +778,17 @@ image: context [
 				][
 					res: 1
 				][
-					type: 0
-					bmp1: OS-image/lock-bitmap arg1 no
-					bmp2: OS-image/lock-bitmap arg2 no
-					res: compare-memory
-						as byte-ptr! OS-image/get-data bmp1 :type
-						as byte-ptr! OS-image/get-data bmp2 :type
-						IMAGE_WIDTH(arg1/size) * IMAGE_HEIGHT(arg2/size) * 4
-					OS-image/unlock-bitmap arg1 bmp1
-					OS-image/unlock-bitmap arg2 bmp2
+					either zero? arg1/size [res: 0][
+						type: 0
+						bmp1: OS-image/lock-bitmap arg1 no
+						bmp2: OS-image/lock-bitmap arg2 no
+						res: compare-memory
+							as byte-ptr! OS-image/get-data bmp1 :type
+							as byte-ptr! OS-image/get-data bmp2 :type
+							IMAGE_WIDTH(arg1/size) * IMAGE_HEIGHT(arg2/size) * 4
+						OS-image/unlock-bitmap arg1 bmp1
+						OS-image/unlock-bitmap arg2 bmp2
+					]
 				]
 			]
 			default [

--- a/runtime/datatypes/integer.reds
+++ b/runtime/datatypes/integer.reds
@@ -78,18 +78,20 @@ integer: context [
 		return: [integer!]
 		/local
 			s	   [series!]
+			hd     [byte-ptr!]
 			p	   [byte-ptr!]
 			len	   [integer!]
 			i	   [integer!]
 			factor [integer!]
 	][
 		s: GET_BUFFER(bin)
-		len: (as-integer s/tail - s/offset) + bin/head
+		hd: binary/rs-head bin
+		len: binary/rs-length? bin
 		if len > 4 [len: 4]								;-- take first 32 bits only
 
 		i: 0
 		factor: 0
-		p: (as byte-ptr! s/offset) + bin/head + len - 1
+		p: hd + len - 1
 
 		loop len [
 			i: i + ((as-integer p/value) << factor)

--- a/runtime/datatypes/object.reds
+++ b/runtime/datatypes/object.reds
@@ -1135,7 +1135,6 @@ object: context [
 			save-ctx [node!]
 			save-idx [integer!]
 			on-set?  [logic!]
-			rebind?	 [logic!]
 	][
 		#if debug? = yes [if verbose > 0 [print-line "object/eval-path"]]
 		
@@ -1143,9 +1142,7 @@ object: context [
 		if TYPE_OF(word) <> TYPE_WORD [fire [TO_ERROR(script invalid-path) path element]]
 
 		ctx: GET_CTX(parent)
-
-		rebind?: word/ctx <> parent/ctx
-		if rebind? [									;-- bind the word to object's context
+		if word/ctx <> parent/ctx [						;-- bind the word to object's context
 			save-idx: word/index
 			save-ctx: word/ctx
 			word/index: _context/find-word ctx word/symbol yes
@@ -1173,10 +1170,6 @@ object: context [
 					fire [TO_ERROR(script no-value) res]
 				]
 			]
-		]
-		if rebind? [
-			word/index: save-idx
-			word/ctx: save-ctx
 		]
 		res
 	]

--- a/runtime/datatypes/object.reds
+++ b/runtime/datatypes/object.reds
@@ -1115,7 +1115,7 @@ object: context [
 		
 		string/concatenate-literal buffer "make object! ["
 		part: serialize obj buffer no all? flat? arg part - 14 yes indent + 1 yes
-		if indent > 0 [part: do-indent buffer indent part]
+		if all [not flat? indent > 0][part: do-indent buffer indent part]
 		string/append-char GET_BUFFER(buffer) as-integer #"]"
 		part - 1
 	]

--- a/runtime/datatypes/object.reds
+++ b/runtime/datatypes/object.reds
@@ -524,7 +524,7 @@ object: context [
 			evt1	[integer!]
 			evt2	[integer!]
 			id		[integer!]
-			blank	[byte!]
+			blank	[integer!]
 	][
 		ctx: 	GET_CTX(obj)
 		syms:   as series! ctx/symbols/value
@@ -540,13 +540,13 @@ object: context [
 
 		either flat? [
 			indent?: no
-			blank: space
+			blank: as-integer space
 		][
 			if mold? [
 				string/append-char GET_BUFFER(buffer) as-integer lf
 				part: part - 1
 			]
-			blank: lf
+			blank: as-integer lf
 		]
 		cycles/push obj/ctx
 
@@ -569,7 +569,7 @@ object: context [
 				part: actions/mold value buffer only? all? flat? arg part tabs
 
 				if any [indent? sym + 1 < s-tail][			;-- no final LF when FORMed
-					string/append-char GET_BUFFER(buffer) as-integer blank
+					string/append-char GET_BUFFER(buffer) blank
 					part: part - 1
 				]
 			]

--- a/runtime/datatypes/url.reds
+++ b/runtime/datatypes/url.reds
@@ -89,7 +89,7 @@ url: context [
 		#if debug? = yes [if verbose > 0 [print-line "url/make"]]
 		
 		type2: TYPE_OF(spec)
-		either all [type = TYPE_URL ANY_LIST(type2)][ ;-- file! inherits from url!
+		either all [type = TYPE_URL ANY_LIST?(type2)][ ;-- file! inherits from url!
 			to proto spec type
 		][
 			as red-url! string/make as red-string! proto spec type
@@ -166,7 +166,7 @@ url: context [
 		#if debug? = yes [if verbose > 0 [print-line "url/to"]]
 
 		type2: TYPE_OF(spec)
-		either all [type = TYPE_URL ANY_LIST(type2)][ ;-- file! inherits from url!
+		either all [type = TYPE_URL ANY_LIST?(type2)][ ;-- file! inherits from url!
 			buffer: string/make-at proto 16 1
 			buffer/header: TYPE_URL
 			

--- a/runtime/datatypes/word.reds
+++ b/runtime/datatypes/word.reds
@@ -19,6 +19,11 @@ Red/System [
 word: context [
 	verbose: 0
 	
+	duplicate: func [w [red-word!] return: [red-word!]][
+		assert red/boot?
+		as red-word! copy-cell as red-value! w ALLOC_TAIL(root)
+	]
+	
 	load-in: func [
 		str 	[c-string!]
 		blk		[red-block!]

--- a/runtime/dtoa.reds
+++ b/runtime/dtoa.reds
@@ -1774,7 +1774,7 @@ dtoa: context [
 							STRTOD_BREAK
 						]
 					]
-					not all [zero? (w0 and BNDRY_MASK) zero? w1][
+					all [zero? (w0 and BNDRY_MASK) zero? w1][
 						STRTOD_DROP_DOWN
 					]
 					true []

--- a/runtime/hashtable.reds
+++ b/runtime/hashtable.reds
@@ -1125,6 +1125,7 @@ _hashtable: context [
 		while [n > 0][
 			index: indexes + head
 			i: index/value
+			assert i <> -1
 			keys/i: keys/i + offset
 			head: head + 1
 			n: n - 1

--- a/runtime/interpreter.reds
+++ b/runtime/interpreter.reds
@@ -749,6 +749,9 @@ interpreter: context [
 			ctx	  [node!]
 	][
 		name: as red-word! either null? slot [pc - 1][slot]
+;if path <> null [
+;	name: as red-word! (block/rs-tail as red-block! path) - 1
+;]
 		if TYPE_OF(name) <> TYPE_WORD [name: words/_anon]
 		saved: stack/push value							;-- prevent word's value slot to be corrupted #2199
 		

--- a/runtime/macros.reds
+++ b/runtime/macros.reds
@@ -426,7 +426,7 @@ Red/System [
 	]
 ]
 
-#define ANY_LIST(type)	[
+#define ANY_LIST?(type)	[
 	any [
 		type = TYPE_BLOCK
 		type = TYPE_PAREN

--- a/runtime/parse.reds
+++ b/runtime/parse.reds
@@ -1514,7 +1514,7 @@ parser: context [
 						]
 						sym = words/copy [				;-- COPY
 							cmd: cmd + 1
-							if any [cmd = tail TYPE_OF(cmd) <> TYPE_WORD][
+							if any [cmd + 1 >= tail TYPE_OF(cmd) <> TYPE_WORD][
 								PARSE_ERROR [TO_ERROR(script parse-end) words/_copy]
 							]
 							min:   R_NONE
@@ -1827,7 +1827,7 @@ parser: context [
 						]
 						sym = words/set [				;-- SET
 							cmd: cmd + 1
-							if any [cmd = tail TYPE_OF(cmd) <> TYPE_WORD][
+							if any [cmd + 1 >= tail TYPE_OF(cmd) <> TYPE_WORD][
 								PARSE_ERROR [TO_ERROR(script parse-end) words/_set]
 							]
 							min:   R_NONE

--- a/runtime/platform/image-gdiplus.reds
+++ b/runtime/platform/image-gdiplus.reds
@@ -528,10 +528,12 @@ OS-image: context [
 		len		[integer!]
 		return: [node!]
 		/local
-			hMem [integer!]
-			p	 [byte-ptr!]
-			s	 [integer!]
-			bmp  [integer!]
+			hMem	[integer!]
+			p		[byte-ptr!]
+			s		[integer!]
+			bmp		[integer!]
+			sthis	[this!]
+			stream	[IStream]
 	][
 		hMem: GlobalAlloc GMEM_MOVEABLE len
 		p: GlobalLock hMem
@@ -542,6 +544,9 @@ OS-image: context [
 		bmp: 0
 		CreateStreamOnHGlobal hMem true :s
 		GdipCreateBitmapFromStream s :bmp
+		sthis: as this! s
+		stream: as IStream sthis/vtbl
+		stream/Release sthis				;-- the hMem will also be released
 		as node! bmp
 	]
 

--- a/runtime/simple-io.reds
+++ b/runtime/simple-io.reds
@@ -1945,8 +1945,8 @@ simple-io: context [
 				either lines? [
 					bin: as red-binary! lines-to-block buf len
 				][
-					bin/header: TYPE_UNSET
 					bin/node: unicode/load-utf8 as c-string! buf len
+					bin/head: 0
 					bin/_pad: 0
 					bin/header: TYPE_STRING
 				]

--- a/runtime/stack.reds
+++ b/runtime/stack.reds
@@ -355,7 +355,7 @@ stack: context [										;-- call stack
 			sym: base/header >> 8 and FFFFh
 			
 			if all [sym <> body-symbol sym <> anon-symbol][
-				fun: _context/get-global sym
+				fun: _context/get-any sym base/ctx
 				if any [level > 1 TYPE_OF(fun) = TYPE_FUNCTION][
 					part: word/form 
 						word/make-at sym value
@@ -370,7 +370,7 @@ stack: context [										;-- call stack
 				]
 			]
 			base: base + 1
-			base >= top									;-- defensive test
+			base >= top									;-- defensive exit condition
 		]
 		part
 	]

--- a/system/utils/libRedRT-exports.r
+++ b/system/utils/libRedRT-exports.r
@@ -114,6 +114,7 @@
 	red/word/from
 	red/word/load
 	red/word/push-local
+	red/word/duplicate
 
 	red/get-word/get
 	red/set-word/push-local

--- a/tests/source/compiler/preprocessor-test.r
+++ b/tests/source/compiler/preprocessor-test.r
@@ -116,12 +116,12 @@ REBOL [
 			prin "*test11* " probe preprocessor/fetch-next [a: o b: 1]
 			prin "*test12* " probe preprocessor/fetch-next [f o f 1]
 			prin "*test13* " probe preprocessor/fetch-next [b/o/f o b/o/f/x 1 2 3]
-			i: make image! 10x10 s: "abcd"
-			b: reduce [i s]
-			w1: 'i w2: 's w3: 3
-			prin "*test14* " probe preprocessor/fetch-next [i/size s/3]
+			p: 10x20 s: "abcd"
+			b: reduce [p s]
+			w1: 'p w2: 's w3: 3
+			prin "*test14* " probe preprocessor/fetch-next [p/y s/3]
 			prin "*test15* " probe preprocessor/fetch-next [s/3]
-			prin "*test16* " probe preprocessor/fetch-next [b/:w1/size b/(w2)/:w3]
+			prin "*test16* " probe preprocessor/fetch-next [b/:w1/y b/(w2)/:w3]
 			prin "*test17* " probe preprocessor/fetch-next [b/(w2)/:w3]
 		}
 		

--- a/tests/source/compiler/preprocessor-test.r
+++ b/tests/source/compiler/preprocessor-test.r
@@ -116,6 +116,13 @@ REBOL [
 			prin "*test11* " probe preprocessor/fetch-next [a: o b: 1]
 			prin "*test12* " probe preprocessor/fetch-next [f o f 1]
 			prin "*test13* " probe preprocessor/fetch-next [b/o/f o b/o/f/x 1 2 3]
+			i: make image! 10x10 s: "abcd"
+			b: reduce [i s]
+			w1: 'i w2: 's w3: 3
+			prin "*test14* " probe preprocessor/fetch-next [i/size s/3]
+			prin "*test15* " probe preprocessor/fetch-next [s/3]
+			prin "*test16* " probe preprocessor/fetch-next [b/:w1/size b/(w2)/:w3]
+			prin "*test17* " probe preprocessor/fetch-next [b/(w2)/:w3]
 		}
 		
 		--assert-printed? "*test1* []"
@@ -131,5 +138,9 @@ REBOL [
 		--assert-printed? "*test11* [1]"
 		--assert-printed? "*test12* [1]"
 		--assert-printed? "*test13* [1 2 3]"
+		--assert-printed? "*test14* [s/3]"
+		--assert-printed? "*test15* []"
+		--assert-printed? "*test16* [b/(w2)/:w3]"
+		--assert-printed? "*test17* []"
 
 ~~~end-file~~~ 

--- a/tests/source/compiler/preprocessor-test.r
+++ b/tests/source/compiler/preprocessor-test.r
@@ -96,4 +96,40 @@ REBOL [
 		--assert-printed? "*test9*"
 		--assert-printed? "*test10* foo 5 9"
 
+	--test-- "fetch-next"
+		--compile-and-run-this {
+			Red []
+			prin "*test1* " probe preprocessor/fetch-next []
+			prin "*test2* " probe preprocessor/fetch-next [1 2]
+			prin "*test3* " probe preprocessor/fetch-next [1 + 2 3]
+			prin "*test4* " probe preprocessor/fetch-next [a: 1 + b: 2 3]
+			prin "*test5* " probe preprocessor/fetch-next [+ 1 2 3]
+			b: reduce ['o make object! [f: func [/x y z][]]]
+			prin "*test6* " probe preprocessor/fetch-next [a: 1 + b/o/f 2 3 4]
+			prin "*test7* " probe preprocessor/fetch-next [a: 1 + b/o/f/x 2 3 4]
+			prin "*test8* " probe preprocessor/fetch-next [a: 1 + b/o/f/x 2 3 * 4 * 5 6]
+			b: reduce ['o make object! [f: func [/x 'y :z][]]]
+			f: func [x][]
+			prin "*test9* " probe preprocessor/fetch-next [a: 1 + b/o/f/x f f 4 5 6]
+			prin "*test10* " probe preprocessor/fetch-next [a: 1 + b/o/f/x + * 4 5 6]
+			o: make op! func ['x 'y][]
+			prin "*test11* " probe preprocessor/fetch-next [a: o b: 1]
+			prin "*test12* " probe preprocessor/fetch-next [f o f 1]
+			prin "*test13* " probe preprocessor/fetch-next [b/o/f o b/o/f/x 1 2 3]
+		}
+		
+		--assert-printed? "*test1* []"
+		--assert-printed? "*test2* [2]"
+		--assert-printed? "*test3* [3]"
+		--assert-printed? "*test4* [3]"
+		--assert-printed? "*test5* [2 3]"
+		--assert-printed? "*test6* [2 3 4]"
+		--assert-printed? "*test7* [4]"
+		--assert-printed? "*test8* [6]"
+		--assert-printed? "*test9* [4 5 6]"
+		--assert-printed? "*test10* [4 5 6]"
+		--assert-printed? "*test11* [1]"
+		--assert-printed? "*test12* [1]"
+		--assert-printed? "*test13* [1 2 3]"
+
 ~~~end-file~~~ 

--- a/tests/source/units/convert-test.red
+++ b/tests/source/units/convert-test.red
@@ -92,6 +92,13 @@ Red [
 	--test-- "to-integer!-21"		--assert 32400 == to integer! 09:00
 	--test-- "to-integer!-22"		--assert 86399 == to integer! 23:59:59
 	--test-- "to-integer!-23"		--assert 86400 == to integer! 23:59:59.999999
+	--test-- "to-integer!-24"		--assert 0 == to integer! #{}
+	--test-- "to-integer!-25"		--assert 255 == to integer! #{FF}
+	--test-- "to-integer!-26"		--assert -559038737 == to integer! #{DEADBEEF BADCAFEE}
+	--test-- "to-integer!-27"							;-- #4325
+		--assert 0 == to integer! next #{}
+		--assert 255 == to integer! next #{00FF}
+		--assert -559038737 == to integer! skip #{BADCAFEE DEADBEEF} 4
 	
 ===end-group===
 

--- a/tests/source/units/convert-test.red
+++ b/tests/source/units/convert-test.red
@@ -463,6 +463,9 @@ Red [
 		--assert #{00} = to binary! make bitset! #{00}
 	--test-- "issue #3636"
 		--assert 97 = pick to binary! append/dup a: "" "a" 1100000 1
+	--test-- "issue #4272"
+		--assert #{DEADBEEF} = to binary! quote (222 173 190 239)
+		--assert #{BADCAFEE} = to binary! make hash! [186 220 175 238]
 ===end-group===
 ===start-group=== "to-block!"
 	--test-- "to-block!-char!"

--- a/tests/source/units/insert-test.red
+++ b/tests/source/units/insert-test.red
@@ -306,6 +306,11 @@ Red [
 	--test-- "iri5 - issue #3705"
 	--assert 5000 = length? head insert/dup #{} #{20} 5000
 
+	--test-- "iri6 - issue #4335"
+	t: make hash! []
+	repeat i 3 [insert/part t s: "abc" at s i]
+	forall t [--assert t/1 = "abc"]
+
 ===end-group===
 
 ~~~end-file~~~

--- a/tests/source/units/parse-test.red
+++ b/tests/source/units/parse-test.red
@@ -2734,6 +2734,11 @@ Red [
 		--assert parse [a/b] ['a/b]
 		--assert error? try [parse [a/b] [a/b]]
 
+	--test-- "#4318"
+		--assert error? try [parse [][copy x4318]]
+		--assert error? try [parse [][set x4318]]
+		--assert unset? :x4318
+
 ===end-group===
     
 ~~~end-file~~~

--- a/tests/source/units/parse-test.red
+++ b/tests/source/units/parse-test.red
@@ -2735,9 +2735,10 @@ Red [
 		--assert error? try [parse [a/b] [a/b]]
 
 	--test-- "#4318"
+		x4318: 0
 		--assert error? try [parse [][copy x4318]]
 		--assert error? try [parse [][set x4318]]
-		--assert unset? :x4318
+		--assert zero? x4318
 
 ===end-group===
     

--- a/tests/source/units/recycle-test.red
+++ b/tests/source/units/recycle-test.red
@@ -644,11 +644,12 @@ Red [
 			d: [ "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20" ]
 			e: [ "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20" ]
 		]
-		clear ro2-o/a
-		clear ro2-o/b
-		clear ro2-o/c
-		clear ro2-o/d
-		clear ro2-o/e
+		clear select ro2-o 'a
+		clear select ro2-o 'b
+		clear select ro2-o 'c
+		clear select ro2-o 'd
+		clear select ro2-o 'e
+		ro2-o: none
 		recycle
 		
 		ro2-mem2: stats

--- a/tests/source/units/regression-test-red.red
+++ b/tests/source/units/regression-test-red.red
@@ -2841,6 +2841,14 @@ comment {
 		]
 }
 
+	--test-- "#4056"
+		i4056: either unset? :image! [[1 2]][make image! 2x2]
+		--assert tail? tail i4056
+		--assert tail? next next next tail i4056
+		--assert not tail? i4056
+		--assert tail? next next next next i4056
+		--assert tail? next back next tail i4056
+
 ===end-group===
 
 ~~~end-file~~~

--- a/utils/preprocessor.r
+++ b/utils/preprocessor.r
@@ -136,13 +136,20 @@ preprocessor: context [
 		arity
 	]
 
-	value-path?: func [path [path!] /local value i] [
+	value-path?: func [path [path!] /local value i item] [
 		repeat i length? path [
-			set/any 'value either i = 1 [get/any first path][select value pick path i]
-			unless any [								;-- select-able types
-				series? get/any 'value
-				find [object! port! error! map!] type?/word get/any 'value
-			][
+			set/any 'value either i = 1 [get/any first path][
+				set/any 'item pick path i
+				case [
+					get-word? :item [set/any 'item get/any to word! item]
+					paren?    :item [set/any 'item do item]
+				]
+				either integer? :item [pick value item][select value :item]
+			]
+			unless find [								;-- select-able types
+				block! paren! path! lit-path! set-path! get-path!
+				object! port! error! map!
+			] type?/word get/any 'value [
 				path: copy/part path i
 				break
 			]

--- a/utils/preprocessor.r
+++ b/utils/preprocessor.r
@@ -99,11 +99,13 @@ preprocessor: context [
 		do-safe/with bind to block! code exec cmd
 	]
 	
-	count-args: func [spec [block!] /local total][
-		total: 0
+	count-args: func [spec [block!] /block /local total pos][
+		total: either block [copy []][0]
 		parse spec [
 			any [
-				[word! | lit-word! | get-word!] (total: total + 1)
+				pos: [word! | lit-word! | get-word!] (
+					either block [append total type? pos/1] [total: total + 1]
+				)
 				| refinement! (return total)
 				| skip
 			]
@@ -111,8 +113,12 @@ preprocessor: context [
 		total
 	]
 	
-	func-arity?: func [spec [block!] /with path [path!] /local arity pos][
-		arity: count-args spec
+	arg-mode?: func [spec [block!] idx [integer!]][
+		pick count-args/block spec idx
+	]
+	
+	func-arity?: func [spec [block!] /with path [path!] /block /local arity pos][
+		arity: either block [count-args/block spec] [count-args spec]
 		if path [
 			foreach word next path	[
 				unless pos: find/tail spec to refinement! word [
@@ -122,39 +128,82 @@ preprocessor: context [
 					]
 					do-quit
 				]
-				arity: arity + count-args pos
+				either block
+					[append arity count-args/block pos]
+					[arity: arity + count-args pos]
 			]
 		]
 		arity
 	]
-	
-	fetch-next: func [code [block! paren!] /local base arity value path][
-		base: code
-		arity: 1
-		
-		while [arity > 0][
-			arity: arity + either all [
-				not tail? next code
-				word? value: code/2
-				op? get/any value
+
+	value-path?: func [path [path!] /local value i] [
+		repeat i length? path [
+			set/any 'value either i = 1 [get/any first path][select value pick path i]
+			unless any [								;-- select-able types
+				series? get/any 'value
+				any-object? get/any 'value
+				map? get/any 'value
 			][
-				code: next code
-				1
-			][
-				either all [
-					find [word! path!] type?/word value: code/1
-					value: either word? value [value][first path: value]
-					any-function? get/any value
-				][
-					either path [
-						func-arity?/with spec-of get value path
-					][
-						func-arity? spec-of get value
-					]
-				][0]
+				path: copy/part path i
+				break
 			]
+		]
+		reduce [path get/any 'value]
+	]
+
+	fetch-next: func [code [block! paren!] /local i left item item2 value fn-spec path f-arity at-op? op-mode][
+		left: reduce [yes]
+		
+		while [all [not tail? left not tail? code]] [
+			either not left/1 [							;-- skip quoted argument
+				remove left
+			][
+				item: first code
+				f-arity: any [
+					all [									;-- a ...
+						word? :item
+						any-function? set/any 'value get/any :item
+						func-arity?/block fn-spec: spec-of get/any :item
+					]
+					all [									;-- a/b ...
+						path? :item
+						set/any [path value] value-path? :item
+						any-function? get/any 'value
+						func-arity?/block/with
+							fn-spec: spec-of :value
+							at :item length? :path
+					]
+				]
+
+				if at-op?: all [							;-- a * b
+					1 < length? code
+					word? item2: second code
+					op? get/any :item2
+				] [
+					op-mode: arg-mode? spec-of get/any :item2 1
+					if all [f-arity  op-mode = word!] [		;-- check if function's lit/get-arg takes priority
+						at-op?: word! = arg-mode? fn-spec 1
+					]
+				]
+
+				case [
+					at-op? [								;-- a * b
+						code: next code						;-- skip `a *` part
+						left/1: word! = arg-mode? spec-of get/any :item2 2
+					]
+
+					f-arity [								;-- a ... / a/b ...
+						if op? get/any 'value [return skip code 2]	;-- starting with op is an error
+						remove left
+						repeat i length? f-arity [insert at left i word! = f-arity/:i]
+					]
+
+					not find [set-word! set-path!] type?/word item [	;-- not a: or a/b:
+						remove left
+					]
+				]
+			];;either not left/1 [][
 			code: next code
-			arity: arity - 1
 		]
 		code
 	]

--- a/utils/preprocessor.r
+++ b/utils/preprocessor.r
@@ -136,7 +136,11 @@ preprocessor: context [
 		arity
 	]
 
-	value-path?: func [path [path!] /local value i item] [
+	value-path?: func [path [path!] /local value i item selectable] [
+		selectable: make typeset! [
+			block! paren! path! lit-path! set-path! get-path!
+			object! port! error! map!
+		]
 		repeat i length? path [
 			set/any 'value either i = 1 [get/any first path][
 				set/any 'item pick path i
@@ -146,10 +150,7 @@ preprocessor: context [
 				]
 				either integer? :item [pick value item][select value :item]
 			]
-			unless find [								;-- select-able types
-				block! paren! path! lit-path! set-path! get-path!
-				object! port! error! map!
-			] type?/word get/any 'value [
+			unless find selectable type? get/any 'value [
 				path: copy/part path i
 				break
 			]

--- a/utils/preprocessor.r
+++ b/utils/preprocessor.r
@@ -141,8 +141,7 @@ preprocessor: context [
 			set/any 'value either i = 1 [get/any first path][select value pick path i]
 			unless any [								;-- select-able types
 				series? get/any 'value
-				any-object? get/any 'value
-				map? get/any 'value
+				find [object! port! error! map!] type?/word get/any 'value
 			][
 				path: copy/part path i
 				break


### PR DESCRIPTION
This PR fixes the below issue:

When using encapped Red toolchain to build `libRed` (`red build libRed`), if there is already a folder named libRed, files inside the folder were not updated to the files in the repo, hence the `libRed.dll` built was not the latest.
