### PR TITLE
FEAT: garbage collect images on Win32 backend

### DIFF
--- a/modules/view/backends/windows/base.reds
+++ b/modules/view/backends/windows/base.reds
@@ -109,6 +109,7 @@ render-base: func [
 		graphic	[integer!]
 		type	[integer!]
 		res		[logic!]
+		inode	[img-node!]
 ][
 	graphic: 0
 	res: paint-background hWnd hDC
@@ -119,11 +120,10 @@ render-base: func [
 
 	GetClientRect hWnd :rc
 	if TYPE_OF(img) = TYPE_IMAGE [
+		inode: as img-node! (as series! img/node/value) + 1
 		GdipCreateFromHDC hDC :graphic
 		if zero? GdipDrawImageRectI
-			graphic
-			as-integer img/node
-			0 0
+			graphic inode/handle 0 0
 			rc/right - rc/left rc/bottom - rc/top [res: true]
 		GdipDeleteGraphics graphic
 	]
@@ -583,9 +583,12 @@ update-base-image: func [
 	img			[red-image!]
 	width		[integer!]
 	height		[integer!]
+	/local
+		inode	[img-node!]
 ][
 	if TYPE_OF(img) = TYPE_IMAGE [
-		GdipDrawImageRectI graphic as-integer img/node 0 0 width height
+		inode: as img-node! (as series! img/node/value) + 1
+		GdipDrawImageRectI graphic inode/handle 0 0 width height
 	]
 ]
 

--- a/modules/view/backends/windows/button.reds
+++ b/modules/view/backends/windows/button.reds
@@ -28,6 +28,7 @@ init-button: func [
 		sz		[integer!]
 		bitmap	[integer!]
 		hlist	[integer!]
+		inode	[img-node!]
 ][
 	BIL:  declare BUTTON_IMAGELIST
 	imgs: as red-block! facets + FACE_OBJ_IMAGE
@@ -81,7 +82,8 @@ init-button: func [
 				img: img-1
 			]
 			bitmap: 0
-			GdipCreateHBITMAPFromBitmap as-integer img/node :bitmap 0
+			inode: as img-node! (as series! img/node/value) + 1
+			GdipCreateHBITMAPFromBitmap inode/handle :bitmap 0
 			ImageList_Add hlist bitmap 0
 			DeleteObject as handle! bitmap
 			if all [i > 0 i < num][image/delete img]

--- a/modules/view/backends/windows/draw.reds
+++ b/modules/view/backends/windows/draw.reds
@@ -284,6 +284,7 @@ draw-begin: func [
 		graphics [integer!]
 		ptrn	 [red-image!]
 		ratio	 [float32!]
+		inode    [img-node!]
 ][
 	zero-memory as byte-ptr! ctx size? draw-ctx!
 	alloc-context ctx
@@ -334,7 +335,8 @@ draw-begin: func [
 			graphics: as-integer img
 		][
 			graphics: 0
-			OS-image/GdipGetImageGraphicsContext as-integer img/node :graphics
+			inode: as img-node! (as series! img/node/value) + 1
+			OS-image/GdipGetImageGraphicsContext inode/handle :graphics
 		]
 		dc: CreateCompatibleDC hScreen
 		SelectObject dc default-font
@@ -1925,8 +1927,10 @@ OS-draw-image: func [
 		color	[integer!]
 		crop2	[red-pair!]
 		pts		[tagPOINT]
+		inode	[img-node!]
 ][
 	attr: 0
+	inode: as img-node! (as series! image/node/value) + 1
 	if key-color <> null [
 		attr: ctx/image-attr
 		if zero? attr [GdipCreateImageAttributes :attr]
@@ -1963,14 +1967,14 @@ OS-draw-image: func [
 				start: start + 1
 			]
 			GdipDrawImagePointsRectI
-				ctx/graphics as-integer image/node ctx/other/edges 3
+				ctx/graphics inode/handle ctx/other/edges 3
 				0 0 w h GDIPLUS_UNIT_PIXEL attr 0 0
 			exit
 		]
 		true [exit]							;@@ TBD four control points
 	]
 	GdipDrawImageRectRectI
-		ctx/graphics as-integer image/node
+		ctx/graphics inode/handle
 		x y width height src-x src-y w h
 		GDIPLUS_UNIT_PIXEL attr 0 0
 ]
@@ -2169,9 +2173,11 @@ OS-draw-brush-bitmap: func [
 		texture	[integer!]
 		wrap	[integer!]
 		result	[integer!]
+		inode	[img-node!]
 ][
 	width:  OS-image/width? img/node
 	height: OS-image/height? img/node
+	inode: as img-node! (as series! img/node/value) + 1
 	either crop-1 = null [
 		x: 0
 		y: 0
@@ -2198,7 +2204,7 @@ OS-draw-brush-bitmap: func [
 		]
 	]
 	texture: 0
-	result: GdipCreateTexture2I as-integer img/node wrap x y width height :texture
+	result: GdipCreateTexture2I inode/handle wrap x y width height :texture
 	either brush? [
 		ctx/brush?:         yes
 		ctx/gp-brush:       texture

--- a/modules/view/backends/windows/gui.reds
+++ b/modules/view/backends/windows/gui.reds
@@ -1223,6 +1223,7 @@ parse-common-opts: func [
 		img		[red-image!]
 		len		[integer!]
 		sym		[integer!]
+		inode	[img-node!]
 ][
 	SetWindowLong hWnd wc-offset - 28 0
 	if TYPE_OF(options) = TYPE_BLOCK [
@@ -1236,7 +1237,8 @@ parse-common-opts: func [
 					w: word + 1
 					either TYPE_OF(w) = TYPE_IMAGE [
 						img: as red-image! w
-						GdipCreateHICONFromBitmap as-integer img/node :sym
+						inode: as img-node! (as series! img/node/value) + 1
+						GdipCreateHICONFromBitmap inode/handle :sym
 					][
 						sym: symbol/resolve w/symbol
 						sym: case [
@@ -2603,7 +2605,7 @@ OS-to-image: func [
 	GdipCreateBitmapFromHBITMAP bmp 0 :bitmap
 
 	either zero? bitmap [img: as red-image! none-value][
-		img: image/init-image as red-image! stack/push* as int-ptr! bitmap
+		img: image/init-image as red-image! stack/push* as int-ptr! OS-image/make-node as node! bitmap
 	]
 
     if screen? [DeleteDC mdc]				;-- we delete it in Draw when print window

--- a/modules/view/backends/windows/gui.reds
+++ b/modules/view/backends/windows/gui.reds
@@ -2605,7 +2605,7 @@ OS-to-image: func [
 	GdipCreateBitmapFromHBITMAP bmp 0 :bitmap
 
 	either zero? bitmap [img: as red-image! none-value][
-		img: image/init-image as red-image! stack/push* as int-ptr! OS-image/make-node as node! bitmap
+		img: image/init-image as red-image! stack/push* OS-image/make-node as node! bitmap
 	]
 
     if screen? [DeleteDC mdc]				;-- we delete it in Draw when print window

--- a/runtime/collector.reds
+++ b/runtime/collector.reds
@@ -244,7 +244,7 @@ collector: context [
 						mark-block-node as node! native/code
 					]
 				]
-				#if OS = 'macOS [
+				#if any [OS = 'macOS OS = 'Windows] [
 				TYPE_IMAGE [
 					image: as red-image! value
 					keep image/node

--- a/runtime/datatypes/image.reds
+++ b/runtime/datatypes/image.reds
@@ -508,13 +508,15 @@ image: context [
 		string/concatenate-literal buffer formed
 		part: part - system/words/length? formed
 
-		if null? img/node [							;-- empty image
+		assert not null? img/node
+		if width * height = 0 [							;-- empty image
 			string/concatenate-literal buffer " #{}]"
 			return part - 5
 		]
 
 		stride: 0
 		bitmap: OS-image/lock-bitmap img no
+		assert not zero? bitmap
 		data: OS-image/get-data bitmap :stride
 		end: data + (width * height)
 		data: data + img/head

--- a/runtime/definitions.reds
+++ b/runtime/definitions.reds
@@ -36,6 +36,7 @@ Red/System [
 #define flag-owner			00010000h		;-- object is an owner (carried by object's context value)
 #define flag-native-op		00010000h		;-- operator is made from a native! function
 #define flag-extern-code	00008000h		;-- routine's body is from FFI
+#define flag-series-external 00008000h		;-- series contains an externally owned resource (e.g. an image)
 
 #define flag-new-line		40000000h		;-- if set, indicates that a new-line preceeds the value
 #define flag-nl-mask		BFFFFFFFh		;-- mask for new-line flag


### PR DESCRIPTION
Implementation of garbage collection of images for Win32.

Background: image data on Windows is stored outside of Red memory segment, in chunks allocated by the GDI+, to which the only links are the image handles. GC has no knowledge of any external resources associated with the data (in the future this can be audio/video data or anything).

I extend memory management with the ability to call a custom deallocation routine, when a node is about to be freed: 
https://github.com/red/red/blob/3ad9ed799f22687c402dca3f0f7af86e35690516/runtime/allocator.reds#L354-L359

For that I have to utilize another bit in series flags:
https://github.com/red/red/blob/3ad9ed799f22687c402dca3f0f7af86e35690516/runtime/definitions.reds#L39

Deallocator spec:
https://github.com/red/red/blob/3ad9ed799f22687c402dca3f0f7af86e35690516/runtime/allocator.reds#L21
Deallocator has to follow the series buffer. All the other series content is up to a specific datatype to define and use. Image type only holds an OS handle there.

So for it to work I have to:
1) hold image handle in the data referred by a node
2) make node a series to make GC aware of it (previously it was a bare GDI+ handle)

Image node on Win32 becomes a series with 2 values:
https://github.com/red/red/blob/3ad9ed799f22687c402dca3f0f7af86e35690516/runtime/platform/image-gdiplus.reds#L53-L56
This brings it closer to MacOS backend where image node is also a series.
It is formally empty here, as it's offset points to it's tail.

A node is created from a handle using:
https://github.com/red/red/blob/3ad9ed799f22687c402dca3f0f7af86e35690516/runtime/platform/image-gdiplus.reds#L512-L524

The rest just makes it all work together.

One unsolved trouble here is that I haven't found a good spot to place a trigger for `collector/do-cycle`. When `recycle` kicks in it collects images properly, but if I do not call it myself while allocating a lot of images, it may run out of memory because it's not aware of any memory used by the GDI+.
Currently `do-cycle` only runs when it fills current series frame and has to compact it, and since image is seen as 8-byte series it's not gonna happen. Putting `do-cycle` into `image/make` is an overkill - `do-cycle` is too slow for that. So for now, I'm leaving it up to the user.
