### PR TITLE
FIX: typo in C-lib natural logarithm import

### DIFF
--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -1798,7 +1798,7 @@ natives: context [
 	][
 		#typecheck log-2
 		f: argument-as-float
-		f/value: (log-2 f/value) / 0.6931471805599453
+		f/value: (log-e f/value) / 0.6931471805599453
 	]
 
 	log-10*: func [
@@ -1818,7 +1818,7 @@ natives: context [
 	][
 		#typecheck log-e
 		f: argument-as-float
-		f/value: log-2 f/value
+		f/value: log-e f/value
 	]
 
 	exp*: func [

--- a/system/runtime/libc.reds
+++ b/system/runtime/libc.reds
@@ -135,7 +135,7 @@ Red/System [
 			value		[float!]
 			return:		[float!]
 		]
-		log-2:		"log" [
+		log-e:		"log" [
 			value		[float!]
 			return:		[float!]
 		]


### PR DESCRIPTION
From now on it's properly named as `log-e`. `log-b` compiler intrinsic can be used to take base-2 logarithm of integer values.