### PR TITLE
 FIX: issue #4318 ([Parse] SET and COPY work even without a sub-rule)

### DIFF
--- a/runtime/parse.reds
+++ b/runtime/parse.reds
@@ -1514,7 +1514,7 @@ parser: context [
 						]
 						sym = words/copy [				;-- COPY
 							cmd: cmd + 1
-							if any [cmd = tail TYPE_OF(cmd) <> TYPE_WORD][
+							if any [cmd + 1 >= tail TYPE_OF(cmd) <> TYPE_WORD][
 								PARSE_ERROR [TO_ERROR(script parse-end) words/_copy]
 							]
 							min:   R_NONE
@@ -1827,7 +1827,7 @@ parser: context [
 						]
 						sym = words/set [				;-- SET
 							cmd: cmd + 1
-							if any [cmd = tail TYPE_OF(cmd) <> TYPE_WORD][
+							if any [cmd + 1 >= tail TYPE_OF(cmd) <> TYPE_WORD][
 								PARSE_ERROR [TO_ERROR(script parse-end) words/_set]
 							]
 							min:   R_NONE

--- a/tests/source/units/parse-test.red
+++ b/tests/source/units/parse-test.red
@@ -2734,6 +2734,11 @@ Red [
 		--assert parse [a/b] ['a/b]
 		--assert error? try [parse [a/b] [a/b]]
 
+	--test-- "#4318"
+		--assert error? try [parse [][copy x4318]]
+		--assert error? try [parse [][set x4318]]
+		--assert unset? :x4318
+
 ===end-group===
     
 ~~~end-file~~~

--- a/tests/source/units/parse-test.red
+++ b/tests/source/units/parse-test.red
@@ -2735,9 +2735,10 @@ Red [
 		--assert error? try [parse [a/b] [a/b]]
 
 	--test-- "#4318"
+		x4318: 0
 		--assert error? try [parse [][copy x4318]]
 		--assert error? try [parse [][set x4318]]
-		--assert unset? :x4318
+		--assert zero? x4318
 
 ===end-group===
     


### PR DESCRIPTION
Fixes #4318 by peeking a bit farther ahead during keyword processing and checking the presence of a sub-rule.