### PR TITLE
FIX: issue #2532 (Math doesn't follow the arithmetic precedence for %, **)

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -275,22 +275,21 @@ replace: function [
 ]
 
 math: function [
-	"Evaluates a block using math precedence rules, returning the last result"
-	body [block!] "Block to evaluate"
-	/safe		  "Returns NONE on error"
+	"Evaluates expression using math precedence rules"
+	datum [block! paren!] "Expression to evaluate"
+	/local match
 ][
-	parse body: copy/deep body rule: [
-		any [
-			pos: ['* (op: 'multiply) | quote / (op: 'divide)] 
-			[ahead sub: paren! (sub/1: math as block! sub/1) | skip] (
-				end: skip pos: back pos 3
-				pos: change/only/part pos as paren! copy/part pos end end
-			) :pos
-			| into rule
-			| skip
-		]
+	order: ['** ['* | '/ | '% | '//]]
+	infix: [skip operator [enter | skip]]
+	
+	tally: [any [enter [fail] | recur [fail] | count [fail] | skip]]
+	enter: [ahead paren! into tally]
+	recur: [if (operator = '**) skip operator tally]
+	count: [while ahead change only copy match infix (do match)]
+
+	do also datum: copy/deep datum foreach operator order [
+		parse datum tally
 	]
-	either safe [attempt body][do body]
 ]
 
 charset: func [

--- a/environment/functions.red
+++ b/environment/functions.red
@@ -279,7 +279,7 @@ math: function [
 	datum [block! paren!] "Expression to evaluate"
 	/local match
 ][
-	order: ['** ['* | '/ | '% | '//]]
+	order: ['** ['* | quote / | quote % | quote //]]	;@@ compiler's lexer chokes on '/, '% and '//
 	infix: [skip operator [enter | skip]]
 	
 	tally: [any [enter [fail] | recur [fail] | count [fail] | skip]]

--- a/tests/source/environment/functions-test.red
+++ b/tests/source/environment/functions-test.red
@@ -232,6 +232,8 @@ Red [
 		--assert 100000010 = math [10 + 10 ** 2 ** 3]
 		--assert 10 = math [10 + 10 % 2]
 		--assert 1 = math [8 / 5 % 2]
+		--assert 33 = math [1 + 2 ** 3 * 4]
+		--assert 4097 = math [1 + 2 ** (3 * 4)]
 ===end-group===
 
 ===start-group=== "charset tests"

--- a/tests/source/environment/functions-test.red
+++ b/tests/source/environment/functions-test.red
@@ -226,7 +226,12 @@ Red [
 		--assert 0.5 = math [1 / 2.0]
 		--assert 2 = math [(1 / 2.0) (2 * 1)]
 		--assert 8 = math [(1 / 2) (power 2 3)]
-		--assert none = math/safe [(1 / 0) (power 2 3)]
+		--assert none = attempt [math [(1 / 0) (power 2 3)]]
+		--assert 7 = math [1 + 2 * 3]
+		--assert 9 = math [(1 + 2) * 3]
+		--assert 100000010 = math [10 + 10 ** 2 ** 3]
+		--assert 10 = math [10 + 10 % 2]
+		--assert 1 = math [8 / 5 % 2]
 ===end-group===
 
 ===start-group=== "charset tests"


### PR DESCRIPTION
This complete rewrite of `math` dialect fixes #2532 and, hopefully, addresses the modest goal of evaluating given expression using PEMDAS precedence rules.

```red
>> math [1 + 2 * 3]
== 7
>> math [(1 + 2) * 3]
== 9
>> math [10 + 10 ** 2 ** 3]
== 100000010
>> math [10 + 10 % 2]
== 10
>> math [8 / 5 % 2]
== 1
```

Covering all edge-cases (like e.g. what `quote * 1` should do, or what if `/` isn't really bound to division `op!`, what if there's more than one right-associative operator of the same precedence level) is beyond the scope of this endeavor. `math`, as I see it, is intended to be a [stele](https://en.wikipedia.org/wiki/Stele) that engraves tricks of Parse trade and shows how one can make a dialect.

At least [Picosheet demo](https://github.com/red/code/blob/master/Showcase/picosheet.red) will need an update after this PR is merged.