### PR TITLE
 FIX: issue #4325 (Runaway binary to integer conversion)

### DIFF
--- a/runtime/datatypes/integer.reds
+++ b/runtime/datatypes/integer.reds
@@ -78,18 +78,20 @@ integer: context [
 		return: [integer!]
 		/local
 			s	   [series!]
+			hd     [byte-ptr!]
 			p	   [byte-ptr!]
 			len	   [integer!]
 			i	   [integer!]
 			factor [integer!]
 	][
 		s: GET_BUFFER(bin)
-		len: (as-integer s/tail - s/offset) + bin/head
+		hd: binary/rs-head bin
+		len: binary/rs-length? bin
 		if len > 4 [len: 4]								;-- take first 32 bits only
 
 		i: 0
 		factor: 0
-		p: (as byte-ptr! s/offset) + bin/head + len - 1
+		p: hd + len - 1
 
 		loop len [
 			i: i + ((as-integer p/value) << factor)

--- a/tests/source/units/convert-test.red
+++ b/tests/source/units/convert-test.red
@@ -92,6 +92,13 @@ Red [
 	--test-- "to-integer!-21"		--assert 32400 == to integer! 09:00
 	--test-- "to-integer!-22"		--assert 86399 == to integer! 23:59:59
 	--test-- "to-integer!-23"		--assert 86400 == to integer! 23:59:59.999999
+	--test-- "to-integer!-24"		--assert 0 == to integer! #{}
+	--test-- "to-integer!-25"		--assert 255 == to integer! #{FF}
+	--test-- "to-integer!-26"		--assert -559038737 == to integer! #{DEADBEEF BADCAFEE}
+	--test-- "to-integer!-27"							;-- #4325
+		--assert 0 == to integer! next #{}
+		--assert 255 == to integer! next #{00FF}
+		--assert -559038737 == to integer! skip #{BADCAFEE DEADBEEF} 4
 	
 ===end-group===
 


### PR DESCRIPTION
Fixes #4325. Also adds a couple of tests for `binary!` to `integer!` conversion.