### PR TITLE
 FIX: issue #4272 (TO-BINARY with ANY-LIST argument behaves incorrectly except for BLOCKs)

### DIFF
--- a/runtime/datatypes/binary.reds
+++ b/runtime/datatypes/binary.reds
@@ -1158,7 +1158,7 @@ binary: context [
 		]
 		
 		type: TYPE_OF(value)
-		either ANY_LIST(type) [
+		either ANY_LIST?(type) [
 			src: as red-block! value
 			s2: GET_BUFFER(src)
 			cell:  s2/offset + src/head

--- a/runtime/datatypes/binary.reds
+++ b/runtime/datatypes/binary.reds
@@ -1113,6 +1113,7 @@ binary: context [
 			data	  [byte-ptr!]
 			s		  [series!]
 			s2		  [series!]
+			type      [integer!]
 			int-value [integer!]
 			dup-n	  [integer!]
 			cnt		  [integer!]
@@ -1155,8 +1156,9 @@ binary: context [
 			(as-integer s/tail - s/offset) >> (log-b GET_UNIT(s)) = bin/head
 			append?
 		]
-
-		either TYPE_OF(value) = TYPE_BLOCK [		;@@ replace it with: typeset/any-block?
+		
+		type: TYPE_OF(value)
+		either ANY_LIST(type) [
 			src: as red-block! value
 			s2: GET_BUFFER(src)
 			cell:  s2/offset + src/head

--- a/runtime/datatypes/url.reds
+++ b/runtime/datatypes/url.reds
@@ -89,7 +89,7 @@ url: context [
 		#if debug? = yes [if verbose > 0 [print-line "url/make"]]
 		
 		type2: TYPE_OF(spec)
-		either all [type = TYPE_URL ANY_LIST(type2)][ ;-- file! inherits from url!
+		either all [type = TYPE_URL ANY_LIST?(type2)][ ;-- file! inherits from url!
 			to proto spec type
 		][
 			as red-url! string/make as red-string! proto spec type
@@ -166,7 +166,7 @@ url: context [
 		#if debug? = yes [if verbose > 0 [print-line "url/to"]]
 
 		type2: TYPE_OF(spec)
-		either all [type = TYPE_URL ANY_LIST(type2)][ ;-- file! inherits from url!
+		either all [type = TYPE_URL ANY_LIST?(type2)][ ;-- file! inherits from url!
 			buffer: string/make-at proto 16 1
 			buffer/header: TYPE_URL
 			

--- a/runtime/macros.reds
+++ b/runtime/macros.reds
@@ -426,7 +426,7 @@ Red/System [
 	]
 ]
 
-#define ANY_LIST(type)	[
+#define ANY_LIST?(type)	[
 	any [
 		type = TYPE_BLOCK
 		type = TYPE_PAREN

--- a/tests/source/units/convert-test.red
+++ b/tests/source/units/convert-test.red
@@ -456,6 +456,9 @@ Red [
 		--assert #{00} = to binary! make bitset! #{00}
 	--test-- "issue #3636"
 		--assert 97 = pick to binary! append/dup a: "" "a" 1100000 1
+	--test-- "issue #4272"
+		--assert #{DEADBEEF} = to binary! quote (222 173 190 239)
+		--assert #{BADCAFEE} = to binary! make hash! [186 220 175 238]
 ===end-group===
 ===start-group=== "to-block!"
 	--test-- "to-block!-char!"


### PR DESCRIPTION
Fixes #4272. Conversion from `any-list!` to `binary!` internally relied on `insert` action, which for `hash!` and `paren!` cases inadvertently overflowed the stack by converting (and pushing) the same value slot over and over again. So the issue was a byproduct of a more serious problem:

```red
>> insert #{} quote (1 2 3)
*** Internal Error: stack overflow
*** Where: insert
*** Stack:  
```

It also renames `ANY_LIST` macro so that it is consistent with other macro definitions in the same group. A couple of tests are provided.