### PR TITLE
FIX: issue #3595 (`return:` for func now chokes if it has a doc string (interpreter))

### DIFF
--- a/runtime/datatypes/function.reds
+++ b/runtime/datatypes/function.reds
@@ -772,7 +772,7 @@ _function: context [
 						value: value + 1
 					]
 				]
-				TYPE_SET_WORD [							;-- only return: is allowed as a set-word!
+				TYPE_SET_WORD [								 ;-- only return: is allowed as a set-word!
 					w: as red-word! value
 					if words/return* <> symbol/resolve w/symbol [
 						fire [TO_ERROR(script bad-func-def)	w]
@@ -781,10 +781,14 @@ _function: context [
 					next2: next + 1
 					unless all [
 						next < end
-						TYPE_OF(next) = TYPE_BLOCK		;-- return: must have a type spec
-						any [							;-- This allows a return: spec before each refinement
-							next2 = end
-							TYPE_OF(next2) = TYPE_REFINEMENT
+						TYPE_OF(next) = TYPE_BLOCK			 ;-- return: must have a type spec
+						any [
+							next2 = end						 ;-- return: with type spec is enough
+							TYPE_OF(next2) = TYPE_REFINEMENT ;-- This allows a return: spec before each refinement
+							all [							 ;-- docstring is allowed if at the tail
+								TYPE_OF(next2) = TYPE_STRING
+								next2 + 1 = end
+							]
 						]
 					][
 						fire [TO_ERROR(script bad-func-def) value]
@@ -804,7 +808,7 @@ _function: context [
 		]
 		check-duplicates spec
 	]
-
+	
 	count-locals: func [
 		node	[node!]
 		offset	[integer!]

--- a/tests/source/units/function-test.red
+++ b/tests/source/units/function-test.red
@@ -812,7 +812,9 @@ if system/state/interpreted? [                      ;-- not yet supported by com
 	--test-- "fsv16"
         --assert error? try [do [func [a return: b][]]]
 
-
+	--test-- "#3595"
+		--assert function? func [return: [block!] "string"][]
+		--assert error? try [do [func [return: [block!] "string" word][]]]
 ===end-group===
 
 ~~~end-file~~~


### PR DESCRIPTION
Resolves #3595. Docstring after `return:` spec is now allowed, but only if it is located at the tail of the function spec (see newly added tests for examples).