### PR TITLE
FIX: issue #4200 ([Parse] CHANGE <position> <expression> does not work properly with WORD! values)

### DIFF
--- a/runtime/parse.reds
+++ b/runtime/parse.reds
@@ -1719,7 +1719,6 @@ parser: context [
 									copy-cell as red-value! input base 	;@@ remove once OPTION? fixed
 									input/head: new/head
 									PARSE_SAVE_SERIES
-									if TYPE_OF(value) = TYPE_WORD [value: _context/get as red-word! value]
 									actions/change input value base as-logic max null
 									if s-top <> null [stack/top: s-top]
 									PARSE_RESTORE_SERIES

--- a/tests/source/units/parse-test.red
+++ b/tests/source/units/parse-test.red
@@ -2746,15 +2746,19 @@ Red [
 		x4200-mark:  x4200-block
 		
 		parse x4200-block [x4200-mark: change x4200-mark x4200-word]
-		--assert x4200-block = [foo]
+		--assert x4200-block = [foo]									;-- word's value
 		clear x4200-block
 		
 		parse x4200-block [x4200-mark: change x4200-mark (x4200-word)]
-		--assert x4200-block = [foo]
+		--assert x4200-block = [foo]									;-- result of expression
 		clear x4200-block
 		
 		parse x4200-block [x4200-mark: change x4200-mark ('foo)]
-		--assert x4200-block = [foo]
+		--assert x4200-block = [foo]									;-- result of expression
+		clear x4200-block
+		
+		parse x4200-block [x4200-mark: change x4200-mark #foo]
+		--assert x4200-block = [#foo]									;-- literal value
 		clear x4200-block
 
 ===end-group===

--- a/tests/source/units/parse-test.red
+++ b/tests/source/units/parse-test.red
@@ -2739,6 +2739,23 @@ Red [
 		--assert error? try [parse [][copy x4318]]
 		--assert error? try [parse [][set x4318]]
 		--assert zero? x4318
+	
+	--test-- "#4200"
+		x4200-word:  'foo
+		x4200-block: []
+		x4200-mark:  x4200-block
+		
+		parse x4200-block [x4200-mark: change x4200-mark x4200-word]
+		--assert x4200-block = [foo]
+		clear x4200-block
+		
+		parse x4200-block [x4200-mark: change x4200-mark (x4200-word)]
+		--assert x4200-block = [foo]
+		clear x4200-block
+		
+		parse x4200-block [x4200-mark: change x4200-mark ('foo)]
+		--assert x4200-block = [foo]
+		clear x4200-block
 
 ===end-group===
     


### PR DESCRIPTION
Fixes #4200.

The story unfolds as follows:
* `change` keyword can change input starting from a specified position;
* if you give `change` a `paren!` expression, it will change input with the result of that expression;
* if you give `change` a `word!` value, it will change input with the value to which this word is set.

But:
* If `change` changes input starting from a specified position;
* And if `paren!` returned a `word!`, or if `word!` was set to another `word!`;

Then this `word!` will be fetched **again**, and the result will be used to change the input.

The culprit was a single (now deleted) line that did exactly that — fetched word's value if that word was returned from `paren!` or fetched from another `word!`.

Relevant tests are provided.