### PR TITLE
[view] handle firing on-set functions properly when using self inside objec's method

### DIFF
--- a/compiler.r
+++ b/compiler.r
@@ -3370,14 +3370,24 @@ red: context [
 					object/fire-on-set*
 				] to logic! local-word? first back back tail path
 				
-				parent: either 2 < length? path [		;-- extract word from parent context
-					breaks: [-12 -9 -6 -1]
-					set [obj fpath] object-access? copy/part path (length? path) - 1
-					ctx: second obj: find objects obj
-					['word/from ctx get-word-index/with pick tail path -2 ctx]
-				][
-					breaks: [-10 -7 -4 -1]				;-- word is in global context
-					[decorate-symbol path/1]
+				parent: case [
+					2 < length? path [						;-- extract word from parent context
+						breaks: [-12 -9 -6 -1]
+						set [obj fpath] object-access? copy/part path (length? path) - 1
+						ctx: second obj: find objects obj
+						['word/from ctx get-word-index/with pick tail path -2 ctx]
+					]
+					self? [									;-- self/field
+						breaks: [-10 -7 -4 -1]
+						set [obj fpath] object-access? copy/part path 1
+						ctx: second obj: find objects obj
+						fire: 'object/loc-ctx-fire-on-set*
+						[ctx]
+					]
+					'else [
+						breaks: [-10 -7 -4 -1]				;-- word is in global context
+						[decorate-symbol path/1]
+					]
 				]
 				repend any [mark last output] compose [
 					fire

--- a/runtime/datatypes/object.reds
+++ b/runtime/datatypes/object.reds
@@ -355,6 +355,18 @@ object: context [
 			stack/top - 2
 	]
 	
+	loc-ctx-fire-on-set*: func [						;-- compiled code entry point
+		parent-ctx [node!]
+		field      [red-word!]
+		/local
+			s	[series!]
+			obj	[red-value!]
+	][
+		s: as series! parent-ctx/value
+		obj: as red-value! s/offset + 1
+		loc-fire-on-set* obj field
+	]
+	
 	fire-on-set*: func [								;-- compiled code entry point
 		parent [red-word!]
 		field  [red-word!]

--- a/system/utils/libRedRT-exports.r
+++ b/system/utils/libRedRT-exports.r
@@ -128,6 +128,7 @@
 	red/object/init-push
 	red/object/init-events
 	red/object/loc-fire-on-set*
+	red/object/loc-ctx-fire-on-set*
 	red/object/fire-on-set*
 	red/object/get-values
 

--- a/tests/source/compiler/regression-test-redc-1.r
+++ b/tests/source/compiler/regression-test-redc-1.r
@@ -1,7 +1,7 @@
 REBOL [
 	Title:   "Regression tests script for Red Compiler"
 	Author:  "Boleslav Březovský"
-	File: 	 %regression-test-redc.r
+	File: 	 %regression-test-redc-1.r
 	Rights:  "Copyright (C) 2016 Boleslav Březovský. All rights reserved."
 	License: "BSD-3 - https://github.com/red/red/blob/origin/BSD-3-License.txt"
 ]

--- a/tests/source/compiler/regression-test-redc-2.r
+++ b/tests/source/compiler/regression-test-redc-2.r
@@ -1,7 +1,7 @@
 REBOL [
 	Title:   "Regression tests script for Red Compiler"
 	Author:  "Boleslav Březovský"
-	File: 	 %regression-test-redc.r
+	File: 	 %regression-test-redc-2.r
 	Rights:  "Copyright (C) 2016 Boleslav Březovský. All rights reserved."
 	License: "BSD-3 - https://github.com/red/red/blob/origin/BSD-3-License.txt"
 ]

--- a/tests/source/compiler/regression-test-redc-3.r
+++ b/tests/source/compiler/regression-test-redc-3.r
@@ -1,7 +1,7 @@
 REBOL [
 	Title:   "Regression tests script for Red Compiler"
 	Author:  "Boleslav Březovský"
-	File: 	 %regression-test-redc.r
+	File: 	 %regression-test-redc-3.r
 	Rights:  "Copyright (C) 2016 Boleslav Březovský. All rights reserved."
 	License: "BSD-3 - https://github.com/red/red/blob/origin/BSD-3-License.txt"
 ]

--- a/tests/source/compiler/regression-test-redc-4.r
+++ b/tests/source/compiler/regression-test-redc-4.r
@@ -1,7 +1,7 @@
 REBOL [
 	Title:   "Regression tests script for Red Compiler"
 	Author:  "Boleslav Březovský"
-	File: 	 %regression-test-redc.r
+	File: 	 %regression-test-redc-4.r
 	Rights:  "Copyright (C) 2016 Boleslav Březovský. All rights reserved."
 	License: "BSD-3 - https://github.com/red/red/blob/origin/BSD-3-License.txt"
 ]

--- a/tests/source/compiler/regression-test-redc-5.r
+++ b/tests/source/compiler/regression-test-redc-5.r
@@ -1,7 +1,7 @@
 REBOL [
 	Title:   "Regression tests script for Red Compiler"
 	Author:  "Boleslav Březovský"
-	File: 	 %regression-test-redc.r
+	File: 	 %regression-test-redc-5.r
 	Rights:  "Copyright (C) 2016 Boleslav Březovský. All rights reserved."
 	License: "BSD-3 - https://github.com/red/red/blob/origin/BSD-3-License.txt"
 ]
@@ -204,6 +204,21 @@ test
 		--assert not crashed?
 		--assert syntax-error?
 
+
+===end-group===
+
+===start-group=== "Red regressions #4001 - #4500"
+
+	--test-- "#4190"
+		--compile-and-run-this-red {
+			fc: make face! [
+				fn: does [self/parent: 'boom]
+			]
+			fc/fn
+			print fc/parent
+		}
+		--assert not crashed?
+		--assert true? find qt/output "boom"
 
 ===end-group===
 


### PR DESCRIPTION
With tests.

Make compiler generate `object/loc-ctx-fire-on-set* ctx||459 exec/~parent` instead of `object/fire-on-set* ~self exec/~parent`