### PR TITLE
FEAT: grant wish #1956 (complement should be allowed on tuples)

### DIFF
--- a/environment/actions.red
+++ b/environment/actions.red
@@ -197,8 +197,8 @@ and~: make action! [[
 
 complement: make action! [[
 		"Returns the opposite (complementing) value of the input value"
-		value	[logic! integer! bitset! typeset! binary!]
-		return: [logic! integer! bitset! typeset! binary!]
+		value	[logic! integer! tuple! bitset! typeset! binary!]
+		return: [logic! integer! tuple! bitset! typeset! binary!]
 	]
 	#get-definition ACT_COMPLEMENT
 ]

--- a/runtime/datatypes/tuple.reds
+++ b/runtime/datatypes/tuple.reds
@@ -505,6 +505,22 @@ tuple: context [
 		#if debug? = yes [if verbose > 0 [print-line "tuple/xor~"]]
 		as red-value! do-math OP_XOR
 	]
+	
+	complement: func [
+		tp      [red-tuple!]
+		return: [red-value!]
+		/local
+			array [byte-ptr!]
+			size  [integer!]
+	][
+		#if debug? = yes [if verbose > 0 [print-line "tuple/complement"]]
+		
+		array: GET_TUPLE_ARRAY(tp)
+		size:  TUPLE_SIZE?(tp)
+		
+		loop size [array/value: not array/value array: array + 1]
+		as red-value! tp
+	]
 
 	length?: func [
 		tp		[red-tuple!]
@@ -670,7 +686,7 @@ tuple: context [
 			null			;odd?
 			;-- Bitwise actions --
 			:and~
-			null			;complement
+			:complement
 			:or~
 			:xor~
 			;-- Series actions --


### PR DESCRIPTION
Fulfills and closes #1956. `complement` on `tuple!` values is now allowed and matches Rebol behavior:
```red
>> complement 254.252.252.248
== 1.3.3.7
```

I didn't find any `tuple!`-specific test suite and don't know where else to put them (if that's needed at all).