### PR TITLE
FEAT: grant wish #4131 (as string! should work on binary!)

### DIFF
--- a/environment/natives.red
+++ b/environment/natives.red
@@ -844,8 +844,8 @@ sign?: make native! [[
 
 as: make native! [[
 		"Coerce a series into a compatible datatype without copying it"
-		type	[datatype! block! paren! any-path! any-string!] "The datatype or example value"
-		spec	[block! paren! any-path! any-string!] "The series to coerce"
+		type	[datatype! block! paren! binary! any-path! any-string!] "The datatype or example value"
+		spec	[block! paren! binary! any-path! any-string!] "The series to coerce"
 	]
 	#get-definition NAT_AS
 ]

--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -2528,7 +2528,10 @@ natives: context [
 		]
 		either any [
 			all [ANY_BLOCK_STRICT?(type) ANY_BLOCK_STRICT?(type2)]
-			all [ANY_STRING?(type) ANY_STRING?(type2)]
+			all [
+				any [type  = TYPE_BINARY ANY_STRING?(type)]
+				any [type2 = TYPE_BINARY ANY_STRING?(type2)]
+			]
 		][
 			copy-cell spec proto
 			set-type proto type


### PR DESCRIPTION
Fulfills and closes #4131. `as` now can coerce `any-string!` to `binary!` and vice versa. Use-cases and rationale for that are provided in the relevant ticket.