### PR TITLE
FIX: issue #4364 (Extra indentation spaces in `mold/flat` output)

### DIFF
--- a/runtime/datatypes/object.reds
+++ b/runtime/datatypes/object.reds
@@ -1115,7 +1115,7 @@ object: context [
 		
 		string/concatenate-literal buffer "make object! ["
 		part: serialize obj buffer no all? flat? arg part - 14 yes indent + 1 yes
-		if indent > 0 [part: do-indent buffer indent part]
+		if all [not flat? indent > 0][part: do-indent buffer indent part]
 		string/append-char GET_BUFFER(buffer) as-integer #"]"
 		part - 1
 	]


### PR DESCRIPTION
Fixes #4364 by taking `flat?` flag into account when indenting content of a serialized buffer.