### PR TITLE
FIX: missing copy in split function

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -780,7 +780,7 @@ split: function [
 	series [any-string!] dlm [string! char! bitset!] /local s
 ][
 	num: either string? dlm [length? dlm][1]
-	parse series [collect any [copy s [to [dlm | end]] keep (s) num skip [end keep ("") | none] ]]
+	parse series [collect any [copy s [to [dlm | end]] keep (s) num skip [end keep (copy "") | none] ]]
 ]
 
 dirize: func [

--- a/tests/source/environment/functions-test.red
+++ b/tests/source/environment/functions-test.red
@@ -390,6 +390,7 @@ Red [
 		--assert ["a" "b" "c"] = split "a-b-c" "-"
 		--assert ["a" "c"] = split "a-b-c" "-b-"
 		--assert ["a-b-c"] = split "a-b-c" "x"
+		--assert false = do compose [same? (second split "a," ",") (second split "b," ",")] ;PR #4381 missing copy in split function
 ===end-group===
 
 ===start-group=== "dirize tests"


### PR DESCRIPTION
This PR adds missing `copy` to `split` function to fix below bug:
```
>> a: split "a," ","
== ["a" ""]
>> b: split "b," ","
== ["b" ""]
>> same? a/2 b/2
== true
```