### PR TITLE
FIX: issue #4383 (to-hex is not doing proper bounds check for its `/size` value).

### DIFF
--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -1614,13 +1614,13 @@ natives: context [
 		/local
 			arg	  [red-integer!]
 			limit [red-integer!]
-			buf   [red-word!]
 			p	  [c-string!]
 			part  [integer!]
 	][
 		#typecheck [to-hex size]
 		arg: as red-integer! stack/arguments
 		limit: arg + size
+		unless positive? limit/value [fire [TO_ERROR(script invalid-arg) limit]]
 
 		p: string/to-hex arg/value no
 		part: either OPTION?(limit) [8 - limit/value][0]

--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -1620,10 +1620,12 @@ natives: context [
 		#typecheck [to-hex size]
 		arg: as red-integer! stack/arguments
 		limit: arg + size
-		unless positive? limit/value [fire [TO_ERROR(script invalid-arg) limit]]
-
+		
 		p: string/to-hex arg/value no
-		part: either OPTION?(limit) [8 - limit/value][0]
+		part: either not OPTION?(limit) [0][
+			unless positive? limit/value [fire [TO_ERROR(script invalid-arg) limit]]
+			8 - limit/value
+		]
 		if negative? part [part: 0]
 		issue/make-at stack/arguments p + part
 	]

--- a/tests/source/units/serialization-test.red
+++ b/tests/source/units/serialization-test.red
@@ -179,6 +179,10 @@ ser-formed: {1 none true false c red Red a/b 'a/b :a/b a/b: 1 + 2 a  a c d b e f
 		--assert  #FFFFFFFE = to-hex -2
 	--test-- "to-hex-3"
 		--assert  #0F = to-hex/size 15 2
+	--test-- "to-hex-4"
+		--assert #F = to-hex/size 15 1
+		--assert error? try [to-hex/size 15 0]
+		--assert error? try [to-hex/size 15 -1]
 ===end-group===
 
 ~~~end-file~~~


### PR DESCRIPTION
Fixes #4383 by throwing an error on non-positive `size` argument. FYI, Rebol3 does almost the same:
```red
>> to-hex/size 123 1
== #B

>> to-hex/size 123 0
== #???

>> to-hex/size 123 -1
** Script error: invalid argument: -1
** Where: to-hex
** Near: to-hex/size 123 -1
```