### PR TITLE
FIX: issue #2812 (image: alpha channel not correctly displayed)

### DIFF
--- a/runtime/datatypes/image.reds
+++ b/runtime/datatypes/image.reds
@@ -49,7 +49,7 @@ image: context [
 			pixel and 00FF0000h >> 16
 			pixel and FF00h >> 8
 			pixel and FFh
-			255 - (pixel >>> 24)
+			pixel >>> 24
 		]
 	]
 
@@ -209,7 +209,7 @@ image: context [
 			while [i <= sz][
 				pixel: data/i
 				either type = EXTRACT_ALPHA [
-					p/1: as-byte 255 - (pixel >>> 24)
+					p/1: as-byte pixel >>> 24
 					p: p + 1
 				][
 					p/1: as-byte pixel and 00FF0000h >> 16
@@ -270,7 +270,7 @@ image: context [
 				while [data < end][
 					pixel: data/value
 					either method = EXTRACT_ALPHA [
-						pixel: pixel and 00FFFFFFh or ((255 - as-integer p/1) << 24)
+						pixel: pixel and 00FFFFFFh or ((as-integer p/1) << 24)
 						p: p + 1
 					][
 						pixel: pixel and FF000000h
@@ -300,8 +300,6 @@ image: context [
 				]
 			]
 			either method = EXTRACT_ARGB [
-				mask: 255 - (color >>> 24) << 24
-				color: color >> 16 and FFh or (color and FF00h) or (color and FFh << 16) or mask
 				until [
 					data/value: color
 					data: data + 1
@@ -314,7 +312,7 @@ image: context [
 					color >> 16 or (color and FF00h) or (color and FFh << 16)
 				][
 					mask: 00FFFFFFh
-					255 - color << 24
+					color << 24
 				]
 				while [data < end][
 					data/value: data/value and mask or color
@@ -569,7 +567,7 @@ image: context [
 			count: 0
 			while [data < end][
 				pixel: data/value
-				string/concatenate-literal buffer string/byte-to-hex 255 - (pixel >>> 24)
+				string/concatenate-literal buffer string/byte-to-hex pixel >>> 24
 				unless flat? [
 					count: count + 1
 					if count % 10 = 0 [string/append-char GET_BUFFER(buffer) as-integer lf]
@@ -672,7 +670,7 @@ image: context [
 			r: as-integer p/1
 			g: as-integer p/2
 			b: as-integer p/3
-			a: either TUPLE_SIZE?(color) > 3 [255 - as-integer p/4][255]
+			a: either TUPLE_SIZE?(color) > 3 [as-integer p/4][255]
 			OS-image/set-pixel img/node offset a << 24 or (r << 16) or (g << 8) or b
 		]
 		ownership/check as red-value! img words/_poke data offset 1

--- a/runtime/platform/image-gdiplus.reds
+++ b/runtime/platform/image-gdiplus.reds
@@ -499,7 +499,7 @@ OS-image: context [
 
 		either null? color [
 			while [scan0 < end][
-				either null? alpha [a: 255][a: 255 - as-integer alpha/1 alpha: alpha + 1]
+				either null? alpha [a: 255][a: as-integer alpha/1 alpha: alpha + 1]
 				either null? rgb [r: 255 g: 255 b: 255][
 					r: as-integer rgb/1
 					g: as-integer rgb/2
@@ -511,7 +511,7 @@ OS-image: context [
 			]
 		][
 			r: color/array1
-			a: either TUPLE_SIZE?(color) = 3 [255][255 - (r >>> 24)]
+			a: either TUPLE_SIZE?(color) = 3 [255][r >>> 24]
 			r: r >> 16 and FFh or (r and FF00h) or (r and FFh << 16) or (a << 24)
 			while [scan0 < end][
 				scan0/value: r

--- a/runtime/platform/image-quartz.reds
+++ b/runtime/platform/image-quartz.reds
@@ -569,7 +569,7 @@ OS-image: context [
 				x: 0
 				while [x < width][
 					pos: width * y + x + 1
-					either null? alpha [a: 255][a: 255 - as-integer alpha/1 alpha: alpha + 1]
+					either null? alpha [a: 255][a: as-integer alpha/1 alpha: alpha + 1]
 					either null? rgb [r: 255 g: 255 b: 255][
 						r: as-integer rgb/1
 						g: as-integer rgb/2
@@ -583,7 +583,7 @@ OS-image: context [
 			]
 		][
 			r: color/array1
-			a: either TUPLE_SIZE?(color) = 3 [255][255 - (r >>> 24)]
+			a: either TUPLE_SIZE?(color) = 3 [255][r >>> 24]
 			r: r >> 16 and FFh or (r and FF00h) or (r and FFh << 16) or (a << 24)
 			while [y < height][
 				x: 0

--- a/tests/source/units/image-test.red
+++ b/tests/source/units/image-test.red
@@ -21,19 +21,19 @@ img: make image! 2x2
 	--test-- "image range(integer index) 2"
 		--assert error? try [img/0: 1.2.3]
 	--test-- "image range(integer index) 3"
-		--assert img/1 = 255.255.255
+		--assert img/1 = 255.255.255.255
 	--test-- "image range(integer index) 4"
 		--assert 1.2.3 = img/1: 1.2.3
 	--test-- "image range(integer index) 5"
-		--assert img/2 = 255.255.255
+		--assert img/2 = 255.255.255.255
 	--test-- "image range(integer index) 6"
 		--assert 1.2.3 = img/2: 1.2.3
 	--test-- "image range(integer index) 7"
-		--assert img/3 = 255.255.255
+		--assert img/3 = 255.255.255.255
 	--test-- "image range(integer index) 8"
 		--assert 1.2.3 = img/3: 1.2.3
 	--test-- "image range(integer index) 9"
-		--assert img/4 = 255.255.255
+		--assert img/4 = 255.255.255.255
 	--test-- "image range(integer index) 10"
 		--assert 1.2.3 = img/4: 1.2.3
 	--test-- "image range(integer index) 11"
@@ -57,19 +57,19 @@ img: make image! 2x2
 	--test-- "image range(pair index) 6"
 		--assert error? try [img/(1x0): 1.2.3]
 	--test-- "image range(pair index) 7"
-		--assert img/(1x1) = 255.255.255
+		--assert img/(1x1) = 255.255.255.255
 	--test-- "image range(pair index) 8"
 		--assert 1.2.3 = img/(1x1): 1.2.3
 	--test-- "image range(pair index) 9"
-		--assert img/(1x2) = 255.255.255
+		--assert img/(1x2) = 255.255.255.255
 	--test-- "image range(pair index) 10"
 		--assert 1.2.3 = img/(1x2): 1.2.3
 	--test-- "image range(pair index) 11"
-		--assert img/(2x1) = 255.255.255
+		--assert img/(2x1) = 255.255.255.255
 	--test-- "image range(pair index) 12"
 		--assert 1.2.3 = img/(2x1): 1.2.3
 	--test-- "image range(pair index) 13"
-		--assert img/(2x2) = 255.255.255
+		--assert img/(2x2) = 255.255.255.255
 	--test-- "image range(pair index) 14"
 		--assert 1.2.3 = img/(2x2): 1.2.3
 	--test-- "image range(pair index) 15"
@@ -94,7 +94,7 @@ img: make image! 2x2
 	--test-- "image pixel 3-tuple assignment 1"
 		--assert 255.255.255 = img/1: 255.255.255
 	--test-- "image pixel 3-tuple assignment 2"
-		--assert 255.255.255.0 = img/1
+		--assert 255.255.255.255 = img/1
 	--test-- "image pixel 4-tuple assignment"
 		--assert 255.255.255.255 = img/2: 255.255.255.255
 	--test-- "image pixel 5-tuple assignment 1"
@@ -108,7 +108,7 @@ img: make image! 2x2
 	--test-- "image pixel junk assignment 3"
 		--assert error? try [img/1: 3.14]
 	--test-- "image pixel unaffected by junk assignments?"
-		--assert 255.255.255.0 = img/1
+		--assert 255.255.255.255 = img/1
 ===end-group===
 
 ===start-group=== "image copy"
@@ -179,7 +179,7 @@ img: make image! 2x2
 ===start-group=== "image issues"
 	--test-- "image issue 3651"
 		img: make image! 2x2
-		clrs: [255.0.0.0 0.255.0.0 0.0.255.0 255.255.255.0]
+		clrs: [255.0.0.0 0.255.0.0 0.0.255.0 255.255.255.255]
 		img/1: clrs/1
 		img/2: clrs/2
 		img/3: clrs/3


### PR DESCRIPTION
This PR changes the meaning of the alpha channel in color tuple.
R.G.B.A where A = 255 indicates full opacity and A = 0 full transparency.

Note: This change breaks the compatibility with Rebol. 