### PR TITLE
FIX: TO-CSV can encode block of maps/object properly

### DIFF
--- a/environment/codecs/csv.red
+++ b/environment/codecs/csv.red
@@ -154,10 +154,9 @@ context [
 		data		[block!] "Block of maps/objects"
 		delimiter	[char! string!]	"Delimiter to use in CSV string"
 	][
-		; this is block of maps/objects
 		columns: get-columns data
-		output: to-csv-line columns delimiter
-		append output collect/into [
+		collect/into [
+			keep to-csv-line columns delimiter
 			foreach value data [
 				; construct block
 				line: collect [
@@ -168,7 +167,6 @@ context [
 				keep to-csv-line line delimiter
 			]		
 		] make string! 1000
-		output
 	]
 
 	encode-flat: function [

--- a/tests/source/units/csv-test.red
+++ b/tests/source/units/csv-test.red
@@ -40,6 +40,9 @@ Red [
 		--assert {"x x"^/} = to-csv l: ["x x"]
 		--assert l = ["x x"] ; we need to make sure original was not modified
 		unset 'l
+	--test-- "to-csv-block-of-keyval"
+		--assert {a,b^/1,2^/3,4^/} = to-csv reduce [object [a: 1 b: 2] object [a: 3 b: 4]]
+		--assert {a,b^/1,2^/3,4^/} = to-csv reduce [make map! [a: 1 b: 2] make map! [a: 3 b: 4]]
 ===end-group===
 
 ===start-group=== "load-csv"


### PR DESCRIPTION
When fixing #4424 I found other problem. So here's a fix for that one.