### PR TITLE
FIX: issue #4433 ([CRASH] when loading a big map)

### DIFF
--- a/runtime/datatypes/series.reds
+++ b/runtime/datatypes/series.reds
@@ -1155,7 +1155,7 @@ _series: context [
 		if offset > len [part: 0 offset: len]
 		if offset + part > len [part: len - offset]
 
-		new/header: TYPE_UNSET
+		if ser <> new [new/header: TYPE_UNSET]
 		part:	part << (log-b unit)
 		node:	alloc-bytes part
 		s: GET_BUFFER(ser)

--- a/runtime/lexer.reds
+++ b/runtime/lexer.reds
@@ -2279,24 +2279,10 @@ lexer: context [
 		]
 	]
 
-	on-gc-mark: func [/local s [state!] lex [state!]][
-		if root-state <> null [
-			s: root-state
-			until [
-				lex: s
-				s: s/next
-				null? s
-			]
-			collector/mark-values stash lex/tail
-		]
-	]
-
 	init: func [][
 		stash: as cell! allocate stash-size * size? cell!
 		utf8-buffer: allocate utf8-buf-size
 		utf8-buf-tail: utf8-buffer
-
-		collector/register as int-ptr! :on-gc-mark
 
 		;-- switch following tables to zero-based indexing
 		lex-classes: lex-classes + 1


### PR DESCRIPTION
Marks values in lexer's buffer.