### PR TITLE
FEAT: relax format of function's return spec.

### DIFF
--- a/tests/source/units/function-test.red
+++ b/tests/source/units/function-test.red
@@ -813,8 +813,14 @@ if system/state/interpreted? [                      ;-- not yet supported by com
         --assert error? try [do [func [a return: b][]]]
 
 	--test-- "#3595"
+		--assert function? func [return: [block!]][]
 		--assert function? func [return: [block!] "string"][]
+		--assert function? func [return: [block!] /refinement][]
+		--assert function? func [return: [block!] /refinement word][]
+		--assert function? func [return: [block!] "string" /refinement][]
+		--assert function? func [return: [block!] "string" /refinement word][]
 		--assert error? try [do [func [return: [block!] "string" word][]]]
+		--assert error? try [do [func [return: [block!] "string" "string"][]]]
 ===end-group===
 
 ~~~end-file~~~


### PR DESCRIPTION
A follow-up to https://github.com/red/red/pull/4347. Now `return: [...]`, with or without a docstring, can be followed by a refinement; after that it's free-form.