### PR TITLE
FEAT: minor additions to MONEY! datatype.

### DIFF
--- a/environment/system.red
+++ b/environment/system.red
@@ -66,6 +66,7 @@ system: context [
 			pair!	[x y]
 			;point!	[x y z]
 			time!	[hour minute second]
+			money!  [code amount]
 		]
 		
 		errors: context [

--- a/runtime/datatypes/money.reds
+++ b/runtime/datatypes/money.reds
@@ -1343,17 +1343,17 @@ money: context [
 			set-digit quotient index (get-digit quotient index) + 1
 		]
 		greater?: [
-			compare-slices
+			positive? compare-slices
 				start2 high2? count2
 				start1 high1? digits
 		]
 		greatest?: [
-			compare-slices
+			positive? compare-slices
 				start2 high2? count2
 				start1 high1? count1
 		]
-		;@@ TBD: bug with subroutines
-		until [either greater? > 0 [either greatest? > 0 [yes][shift no]][subtract increment no]]
+		
+		forever [either greater? [either greatest? [break][shift]][subtract increment]]
 		
 		unless remainder? [
 			unless only? [


### PR DESCRIPTION
Adds `money!` accessors to `system/catalog/accessors` and rewrites main division loop, thus avoiding a bug with subroutines that I mentioned at some point.