### PR TITLE
FEAT: update MONEY! comparison semantics.

### DIFF
--- a/runtime/datatypes/block.reds
+++ b/runtime/datatypes/block.reds
@@ -554,7 +554,11 @@ block: context [
 
 		if size1 <> size2 [										;-- shortcut exit for different sizes
 			if any [
-				op = COMP_STRICT_EQUAL_WORD op = COMP_EQUAL op = COMP_FIND op = COMP_STRICT_EQUAL op = COMP_NOT_EQUAL
+				op = COMP_FIND
+				op = COMP_EQUAL
+				op = COMP_NOT_EQUAL
+				op = COMP_STRICT_EQUAL
+				op = COMP_STRICT_EQUAL_WORD
 			][return 1]
 		]
 

--- a/runtime/datatypes/money.reds
+++ b/runtime/datatypes/money.reds
@@ -1611,6 +1611,7 @@ money: context [
 					COMP_GREATER
 					COMP_GREATER_EQUAL [
 						unless same-currencies? money value no [
+							cycles/reset
 							fire [TO_ERROR(script wrong-denom) money value]
 						]
 					]

--- a/runtime/datatypes/money.reds
+++ b/runtime/datatypes/money.reds
@@ -1596,10 +1596,8 @@ money: context [
 	][
 		#if debug? = yes [if verbose > 0 [print-line "money/compare"]]
 		
-		strict?: op = COMP_STRICT_EQUAL
-		if all [TYPE_OF(money) <> TYPE_OF(value) any [op = COMP_FIND strict?]][
-			return 1
-		]
+		strict?: any [op = COMP_STRICT_EQUAL op = COMP_SAME op = COMP_FIND]
+		if all [TYPE_OF(money) <> TYPE_OF(value) strict?][return 1]
 		
 		switch TYPE_OF(value) [
 			TYPE_MONEY [
@@ -1608,16 +1606,17 @@ money: context [
 					COMP_CASE_SORT [
 						return sort-money money value
 					]
-					COMP_SAME [
-						return as integer! not all [	;-- 0 if the same
-							same-currencies? money value yes
-							zero? compare-money money value
+					COMP_LESSER
+					COMP_LESSER_EQUAL
+					COMP_GREATER
+					COMP_GREATER_EQUAL [
+						unless same-currencies? money value no [
+							fire [TO_ERROR(script wrong-denom) money value]
 						]
 					]
 					default [
-						unless same-currencies? money value strict? [
-							fire [TO_ERROR(script wrong-denom) money value]
-						]
+						if op = COMP_FIND [strict?: not zero? get-currency value]
+						unless same-currencies? money value strict? [return 1]
 					]
 				]
 			]

--- a/tests/source/units/money-test.red
+++ b/tests/source/units/money-test.red
@@ -284,6 +284,10 @@ system/options/money-digits: 5						;-- enforce molding of the whole fractional 
 	--test-- "currencies-12" --assert USD$3 <= $3
 	--test-- "currencies-13" --assert error? try [USD$1 > EUR$1]
 	--test-- "currencies-14" --assert error? try [USD$0 >= EUR$0]
+	--test-- "currencies-15"
+		block: [EUR$1]
+		--assert error? try [block < [USD$1]]
+		--assert "[...]" <> mold block
 ===end-group===
 
 ===start-group=== "arithmetic"

--- a/tests/source/units/money-test.red
+++ b/tests/source/units/money-test.red
@@ -74,8 +74,8 @@ system/options/money-digits: 5						;-- enforce molding of the whole fractional 
 	--test-- "strict-equal-5" --assert strict-equal? -$1 -$1
 	--test-- "strict-equal-6" --assert strict-equal? +$1 +$1
 	--test-- "strict-equal-7" --assert strict-equal? +USD$1 +USD$1
-	--test-- "strict-equal-8" --assert error? try [strict-equal? +$1 +USD$1]
-	--test-- "strict-equal-9" --assert error? try [strict-equal? +EUR$1 +$1]
+	--test-- "strict-equal-8" --assert not strict-equal? +$1 +USD$1
+	--test-- "strict-equal-9" --assert not strict-equal? +EUR$1 +$1
 ===end-group===
 
 ===start-group=== "same?"
@@ -279,7 +279,11 @@ system/options/money-digits: 5						;-- enforce molding of the whole fractional 
 	--test-- "currencies-7"  --assert error? try [EUR$2 - USD$2]
 	--test-- "currencies-8"  --assert USD$1 == USD$1
 	--test-- "currencies-9"  --assert -USD$2 == -USD$2
-	--test-- "currencies-10" --assert error? try [EUR$123 <> USD$123]
+	--test-- "currencies-10" --assert EUR$123 <> USD$123
+	--test-- "currencies-11" --assert $1 < EUR$2
+	--test-- "currencies-12" --assert USD$3 <= $3
+	--test-- "currencies-13" --assert error? try [USD$1 > EUR$1]
+	--test-- "currencies-14" --assert error? try [USD$0 >= EUR$0]
 ===end-group===
 
 ===start-group=== "arithmetic"
@@ -608,6 +612,9 @@ system/options/money-digits: 5						;-- enforce molding of the whole fractional 
 	--test-- "find-4" --assert none == find [$1] 1
 	--test-- "find-5" --assert 3 = index? find [a b $1 c d] $1
 	--test-- "find-6" --assert last? find [a b c d $0.00001] $0.00001
+	--test-- "find-7" --assert head? find [USD$1 EUR$1] USD$1
+	--test-- "find-8" --assert head? find [USD$1 EUR$1] $1
+	--test-- "find-9" --assert none == find [$1 $2] EUR$2
 ===end-group===
 
 ===start-group=== "money?"


### PR DESCRIPTION
**TL;DR:** `=`, `<>` and `=?` always return `logic!` and differ only in the level of strictness. `<`, `<=`, `>`, `>=` error out if two different currencies are compared. `find` permits a level of flexibility by dispatching on presence/absence of currency code.

https://github.com/red/docs/pull/227

---

The previous design sketch of `money!` comparison aimed to minimize user mistakes when dealing with monetary amounts and financial calculations, all at the cost of being more ornery: comparison between two `money!` values of different currencies always resulted in an error, regardless of the comparison type.

This hinged on the idea that what is compared are not the Red values, but real-world monetary values that they denote: that is, the question of (in)equality of two currencies is meaningless without conversion rations, and answering it with either `true` or `false` is misleading.

All of that made sense when two given values were compared, but opened a lot of design questions (quantities, exchange rates, external oracles &c) and conflicted too much with an existing runtime: in particular, all natives and actions that somehow rely on equality comparison could potentially error out in a middle of computation, keeping some internal states unfinalized and causing inconvenience to the user.

```red
>> [$0.0] == block: [RED$0.65]
*** Script Error: $0.00 not same denomination as RED$0.65
*** Where: ==
*** Stack:  

>> block ; cycles stack wasn't reset
== [...]

>> parse [USD$1 EUR$2] [some [EUR$2 | USD$1]] ; uses lax comparison by default
*** Script Error: USD$1.00 not same denomination as EUR$2.00
*** Where: parse
*** Stack:  

>> greater? load %income-jan.red load %income-feb.red ; am I rich and famous?
*** Script Error: WUT$42.00 not same denomination as LOL$13.37
*** Where: greater?
*** Stack:  
```

So a change in perspective was in order. The question of identity/equality between two currencies is external to the runtime system, and cannot be answered reliably — viewed that way, throwing an error is an unhelpful way of saying "there's surely a way to do that, but it's not satisfying and boils down to trust; you shouldn't fully trust a machine to handle your funds".

What needs to be pursued, then, is internal consistency: `money!` values need to be treated just as a Red datatype, or, what is more, as a datatype that has a sub-type denoted by currency code "type tag".

Given that we don't have any reasonable defaults to fall-back on, such sub-type needs to follow conventions of a type system into which it is embedded: for any two incompatible (sub)types, equality comparisons return `false` and inequality comparisons error out.

This doesn't rock the boat too much and is balanced enough to permit building different solutions to this kind of problem on top: e.g. modules and packages that have different semantic in mind (like the one that was originally sketched out).