### PR TITLE
FEAT: improve Travis-CI notification on failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ matrix:
       --entrypoint /red/quick-test/runnable/arm-tests/red/run-all.sh
       balenalib/armv5e-debian:latest
     - >
-      docker run -v ${PWD}:/red
+      travis_wait 30 docker run -v ${PWD}:/red
       -e LD_LIBRARY_PATH='$LD_LIBRARY_PATH:/red/quick-test/runnable/arm-tests/system/'
       -w /red/quick-test/runnable/arm-tests/system/
       --entrypoint /red/quick-test/runnable/arm-tests/system/run-all.sh
@@ -81,7 +81,7 @@ matrix:
       --entrypoint /red/quick-test/runnable/arm-tests/red/run-all.sh
       balenalib/raspberry-pi2-debian:latest
     - >
-      docker run -v ${PWD}:/red
+      travis_wait 30 docker run -v ${PWD}:/red
       -e LD_LIBRARY_PATH='$LD_LIBRARY_PATH:/red/quick-test/runnable/arm-tests/system/'
       -w /red/quick-test/runnable/arm-tests/system/
       --entrypoint /red/quick-test/runnable/arm-tests/system/run-all.sh


### PR DESCRIPTION
Travis-CI will terminate a running script that doesn't output anything in 10 minutes and won't execute any `after_..` phases. In our case, it won't update the status badges.

Adding `travis_wait 30` before a command, will give it more time to execute (30 minutes) AND if the command take longer than that, it will be terminated BUT `after_..` phases will be executed.