### PR TITLE
FEAT: new semantics for ALL and ANY natives.

### DIFF
--- a/environment/natives.red
+++ b/environment/natives.red
@@ -36,14 +36,14 @@ either: make native! [[
 ]
 	
 any: make native! [[
-		"Evaluates, returning at the first that is true"
+		"Evaluates, returns the first truthy value, if any, else the last falsy value; defaults to NONE"
 		conds [block!]
 	]
 	#get-definition NAT_ANY
 ]
 
 all: make native! [[
-		"Evaluates, returning at the first that is not true"
+		"Evaluates, returns the first falsy value, if any, else the last truthy value; defaults to TRUE"
 		conds [block!]
 	]
 	#get-definition NAT_ALL

--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -98,14 +98,12 @@ natives: context [
 		value: block/rs-head as red-block! stack/arguments
 		tail:  block/rs-tail as red-block! stack/arguments
 		
+		if value = tail [RETURN_NONE]
+		
 		while [value < tail][
 			value: interpreter/eval-next value tail no
-			
-			bool: as red-logic! stack/arguments
-			type: TYPE_OF(bool)
-			unless any [type = TYPE_NONE all [type = TYPE_LOGIC not bool/value]][exit]
+			unless logic/false? [exit]
 		]
-		RETURN_NONE
 	]
 	
 	all*: func [
@@ -118,11 +116,11 @@ natives: context [
 		value: block/rs-head as red-block! stack/arguments
 		tail:  block/rs-tail as red-block! stack/arguments
 		
-		if value = tail [RETURN_NONE]
+		if value = tail [stack/reset logic/box true exit]
 		
 		while [value < tail][
 			value: interpreter/eval-next value tail no
-			if logic/false? [RETURN_NONE]
+			if logic/false? [exit]
 		]
 	]
 	

--- a/tests/source/units/conditional-test.red
+++ b/tests/source/units/conditional-test.red
@@ -121,6 +121,17 @@ Red [
   		
   	--test-- "any-9"
   		--assert 3 = any [1 = 2 3]
+		
+	--test-- "any-10"
+		--assert none == any []
+	
+	--test-- "any-11"
+		--assert 1 == any [1 no]
+		--assert 1 == any [none 1]
+	
+	--test-- "any-12"
+		--assert false == any [none no]
+		--assert none  == any [no none]
 
 ===end-group===
 
@@ -152,7 +163,18 @@ Red [
   		
   	--test-- "all-9"
   		--assert not all [1 = 2 3]
-
+	
+	--test-- "all-10"
+		--assert true == all []
+	
+	--test-- "all-11"
+		--assert false == all [1 no]
+		--assert none  == all [none 1]
+	
+	--test-- "all-12"
+		--assert 1    == all [on 1]
+		--assert true == all [1 on]
+	
 ===end-group===
 
     


### PR DESCRIPTION
* `any` evaluates expressions one-by-one and returns the first truthy value, if any, else the last falsy value; defaults to `none`;
* `all` evaluates expressions one-by-one and returns the first falsy value, if any, else the last truthy value; defaults to `true`.

This differs from previous behavior, where both `any` and `all` defaulted to `none` and coerced falsy values to `none`.

The PR is missing compiler's support: for static cases where `all`/`any` is followed by a `block!`, compiler unrolls nested chain of expressions into a conditional tree of `if ... [...]` or `either ... [...][...]`. Current behavior conflicts with that logic and I haven't quite figured out yet how to rewrite it.

Nevertheless, I decided to draft it out and see if it's worth completing or if I should give up on trying to improve these short-circuit evaluation primitives.