### PR TITLE
FIX: refactor conditional usages of typeset macros.

### DIFF
--- a/runtime/datatypes/binary.reds
+++ b/runtime/datatypes/binary.reds
@@ -1300,13 +1300,7 @@ binary: context [
 					src: GET_TUPLE_ARRAY(cell)
 				]
 				default [
-					either any [
-						type = TYPE_STRING				;@@ replace with ANY_STRING?
-						type = TYPE_FILE 
-						type = TYPE_URL
-						type = TYPE_EMAIL
-						type = TYPE_TAG
-					][
+					either ANY_STRING?(type) [
 						form-buf: as red-string! cell
 					][
 						;TBD: free previous form-buf node and series buffer

--- a/runtime/datatypes/block.reds
+++ b/runtime/datatypes/block.reds
@@ -328,18 +328,15 @@ block: context [
 			w	  [red-word!]
 			sym	  [integer!]
 			sym2  [integer!]
+			type  [integer!]
 	][
 		value: rs-head blk
 		tail:  rs-tail blk
 		sym:   either case? [word/symbol][symbol/resolve word/symbol]
 		
 		while [value < tail][
-			if any [									;@@ replace with ANY_WORD?
-				TYPE_OF(value) = TYPE_WORD
-				TYPE_OF(value) = TYPE_SET_WORD
-				TYPE_OF(value) = TYPE_GET_WORD
-				TYPE_OF(value) = TYPE_LIT_WORD
-			][
+			type: TYPE_OF(value)
+			if ANY_WORD?(type) [
 				w: as red-word! value
 				sym2: either case? [w/symbol][symbol/resolve w/symbol]
 				if sym = sym2 [
@@ -394,19 +391,14 @@ block: context [
 		size 	[integer!]								;-- number of cells to pre-allocate
 		return:	[red-block!]
 		/local
-			blk [red-block!]
+			blk  [red-block!]
+			type [integer!]
 	][
 		blk: either null? parent [
 			_root
 		][
-			assert any [
-				TYPE_OF(parent) = TYPE_BLOCK			;@@ replace with ANY_BLOCK
-				TYPE_OF(parent) = TYPE_PAREN
-				TYPE_OF(parent) = TYPE_PATH
-				TYPE_OF(parent) = TYPE_LIT_PATH
-				TYPE_OF(parent) = TYPE_SET_PATH
-				TYPE_OF(parent) = TYPE_GET_PATH
-			]
+			type: TYPE_OF(parent)
+			assert ANY_BLOCK?(type)
 			as red-block! ALLOC_TAIL(parent)
 		]
 		preallocate blk size yes
@@ -417,21 +409,16 @@ block: context [
 		size 	[integer!]								;-- number of cells to pre-allocate
 		return:	[red-block!]
 		/local
-			blk [red-block!]
+			blk  [red-block!]
+			type [integer!]
 	][
 		#if debug? = yes [if verbose > 0 [print-line "block/make-in"]]
 		
 		blk: either null? parent [
 			_root
 		][
-			assert any [
-				TYPE_OF(parent) = TYPE_BLOCK			;@@ replace with ANY_BLOCK
-				TYPE_OF(parent) = TYPE_PAREN
-				TYPE_OF(parent) = TYPE_PATH
-				TYPE_OF(parent) = TYPE_LIT_PATH
-				TYPE_OF(parent) = TYPE_SET_PATH
-				TYPE_OF(parent) = TYPE_GET_PATH
-			]
+			type: TYPE_OF(parent)
+			assert ANY_BLOCK?(type)
 			as red-block! ALLOC_TAIL(parent)
 		]
 		make-at blk size

--- a/runtime/datatypes/map.reds
+++ b/runtime/datatypes/map.reds
@@ -34,11 +34,7 @@ map: context [
 			TYPE_SET_WORD
 			TYPE_LIT_WORD [key/header: TYPE_SET_WORD]		;-- convert any-word! to set-word!
 			TYPE_BINARY
-			TYPE_STRING
-			TYPE_FILE
-			TYPE_URL
-			TYPE_TAG
-			TYPE_EMAIL	 [_series/copy as red-series! key as red-series! key null yes null]
+			TYPE_ANY_STRING [_series/copy as red-series! key as red-series! key null yes null]
 			TYPE_INTEGER TYPE_CHAR TYPE_FLOAT TYPE_DATE
 			TYPE_PERCENT TYPE_TUPLE TYPE_PAIR TYPE_TIME [0]
 			default		[fire [TO_ERROR(script invalid-type) datatype/push TYPE_OF(key)]]

--- a/runtime/datatypes/object.reds
+++ b/runtime/datatypes/object.reds
@@ -48,13 +48,10 @@ object: context [
 		return:	 [integer!]								;-- -1 if not found, else index
 		/local
 			word [red-word!]
+			type [integer!]
 	][
-		assert any [									;@@ replace with ANY_WORD?
-			TYPE_OF(value) = TYPE_WORD
-			TYPE_OF(value) = TYPE_LIT_WORD
-			TYPE_OF(value) = TYPE_GET_WORD
-			TYPE_OF(value) = TYPE_SET_WORD
-		]
+		type: TYPE_OF(value)
+		assert ANY_WORD?(type)
 		word: as red-word! value
 		 _context/find-word GET_CTX(obj) word/symbol yes
 	]
@@ -68,13 +65,10 @@ object: context [
 			ctx	   [red-context!]
 			values [series!]
 			id	   [integer!]
+			type   [integer!]
 	][
-		assert any [									;@@ replace with ANY_WORD?
-			TYPE_OF(value) = TYPE_WORD
-			TYPE_OF(value) = TYPE_LIT_WORD
-			TYPE_OF(value) = TYPE_GET_WORD
-			TYPE_OF(value) = TYPE_SET_WORD
-		]
+		type: TYPE_OF(value)
+		assert ANY_WORD?(type)
 		word: as red-word! value
 		ctx: GET_CTX(obj)
 		id: _context/find-word ctx word/symbol yes	
@@ -1361,15 +1355,8 @@ object: context [
 				switch TYPE_OF(value) [
 					TYPE_BLOCK
 					TYPE_PAREN
-					TYPE_PATH				;-- any-path!
-					TYPE_LIT_PATH
-					TYPE_SET_PATH
-					TYPE_GET_PATH
-					TYPE_STRING				;-- any-string!
-					TYPE_FILE
-					TYPE_URL
-					TYPE_TAG
-					TYPE_EMAIL [
+					TYPE_ANY_PATH
+					TYPE_ANY_STRING [
 						actions/copy 
 							as red-series! value
 							value						;-- overwrite the value
@@ -1414,12 +1401,7 @@ object: context [
 		#if debug? = yes [if verbose > 0 [print-line "object/select"]]
 		
 		type: TYPE_OF(value)
-		unless any [									;@@ replace with ANY_WORD?
-			type = TYPE_WORD
-			type = TYPE_LIT_WORD
-			type = TYPE_GET_WORD
-			type = TYPE_SET_WORD
-		][
+		unless ANY_WORD?(type) [
 			fire [TO_ERROR(script invalid-type) datatype/push type]
 		]
 		rs-select obj value

--- a/runtime/datatypes/string.reds
+++ b/runtime/datatypes/string.reds
@@ -894,14 +894,9 @@ string: context [
 				][no]
 			]
 			default  [
-				either all [								;@@ ANY_STRING - TAG
-					type <> TYPE_STRING
-					type <> TYPE_FILE
-					type <> TYPE_URL
-					type <> TYPE_EMAIL
-				][no][
+				either ANY_STRING?(type) [				;-- TYPE_TAG excluded
 					zero? equal? str as red-string! value op yes
-				]
+				][no]
 			]
 		]
 	]
@@ -1608,22 +1603,21 @@ string: context [
 		str2	[red-string!]							;-- second operand (any-string!)
 		op		[integer!]								;-- type of comparison
 		return:	[integer!]
+		/local
+			type1 type2 [integer!]
 	][
 		#if debug? = yes [if verbose > 0 [print-line "string/compare"]]
 		
+		type1: TYPE_OF(str1)
+		type2: TYPE_OF(str2)
+		
 		if all [
-			TYPE_OF(str2) <> TYPE_OF(str1)
+			type1 <> type2
 			any [
+				not ANY_STRING?(type2)
 				all [
 					op <> COMP_EQUAL
 					op <> COMP_NOT_EQUAL
-				]
-				all [
-					TYPE_OF(str2) <> TYPE_STRING		;@@ use ANY_STRING?
-					TYPE_OF(str2) <> TYPE_FILE
-					TYPE_OF(str2) <> TYPE_URL
-					TYPE_OF(str2) <> TYPE_TAG
-					TYPE_OF(str2) <> TYPE_EMAIL
 				]
 			]
 		][RETURN_COMPARE_OTHER]
@@ -1930,13 +1924,7 @@ string: context [
 			]
 		]
 
-		case?: either any [ 							;-- inverted case? meaning
-			type = TYPE_STRING							;@@ use ANY_STRING?
-			type = TYPE_FILE
-			type = TYPE_URL
-			type = TYPE_TAG
-			type = TYPE_EMAIL
-		][not case?][no]
+		case?: either ANY_STRING?(type) [not case?][no]
 		if same? [case?: no]
 		reverse?: any [reverse? last?]					;-- reduce both flags to one
 		step: step << (unit >> 1)
@@ -1961,11 +1949,7 @@ string: context [
 				bs?:   yes
 				case?: no
 			]
-			TYPE_STRING
-			TYPE_FILE
-			TYPE_URL
-			TYPE_TAG
-			TYPE_EMAIL
+			TYPE_ANY_STRING
 			TYPE_BINARY
 			TYPE_WORD [
 				either TYPE_OF(value) = TYPE_WORD [
@@ -2120,11 +2104,7 @@ string: context [
 		
 		if TYPE_OF(result) <> TYPE_NONE [
 			offset: switch TYPE_OF(value) [
-				TYPE_STRING
-				TYPE_FILE
-				TYPE_URL
-				TYPE_TAG
-				TYPE_EMAIL
+				TYPE_ANY_STRING
 				TYPE_WORD
 				TYPE_BINARY [
 					either TYPE_OF(value) = TYPE_WORD [
@@ -2407,11 +2387,9 @@ string: context [
 					]
 					added: added + 1
 				][
-					either any [
-						type = TYPE_STRING				;@@ replace with ANY_STRING?
-						type = TYPE_FILE 
-						type = TYPE_URL
-						type = TYPE_EMAIL
+					either all [
+						ANY_STRING?(type)
+						type <> TYPE_TAG				;-- preserve angle brackets
 					][
 						form-buf: as red-string! cell
 					][
@@ -2788,12 +2766,9 @@ string: context [
 				]
 				added: added + 1
 			][
-				either any [
-					type = TYPE_STRING				;@@ replace with ANY_STRING?
-					type = TYPE_FILE 
-					type = TYPE_URL
-					type = TYPE_TAG
-					type = TYPE_EMAIL
+				either all [
+					ANY_STRING?(type)
+					type <> TYPE_TAG				;-- preserve angle brackets
 				][
 					form-buf: as red-string! cell
 				][

--- a/runtime/hashtable.reds
+++ b/runtime/hashtable.reds
@@ -265,11 +265,7 @@ _hashtable: context [
 			TYPE_INTEGER [key/data2]
 			TYPE_WORD	[symbol/resolve key/data2]
 			TYPE_SYMBOL [hash-symbol as red-symbol! key]
-			TYPE_STRING
-			TYPE_FILE
-			TYPE_URL
-			TYPE_TAG
-			TYPE_EMAIL [
+			TYPE_ANY_STRING [
 				hash-string as red-string! key case?
 			]
 			TYPE_CHAR [key/data2]

--- a/runtime/macros.reds
+++ b/runtime/macros.reds
@@ -392,22 +392,11 @@ Red/System [
 
 #define ANY_SERIES?(type)	[
 	any [
-		type = TYPE_BLOCK
-		type = TYPE_HASH
-		type = TYPE_VECTOR
-		type = TYPE_PAREN
-		type = TYPE_PATH
-		type = TYPE_LIT_PATH
-		type = TYPE_SET_PATH
-		type = TYPE_GET_PATH
-		type = TYPE_STRING
-		type = TYPE_FILE
-		type = TYPE_URL
+		ANY_BLOCK?(type)
+		ANY_STRING?(type)
 		type = TYPE_BINARY
+		type = TYPE_VECTOR
 		type = TYPE_IMAGE
-		type = TYPE_TAG
-		type = TYPE_EMAIL
-		type = TYPE_REF
 	]
 ]
 
@@ -575,25 +564,6 @@ Red/System [
 
 #define RETURN_COMPARE_OTHER [
 	return -2
-]
-
-#define CHECK_COMPARE_OTHER(type) [
-	if all [
-		TYPE_OF(str2) <> type
-		any [
-			all [
-				op <> COMP_EQUAL
-				op <> COMP_NOT_EQUAL
-			]
-			all [
-				TYPE_OF(str2) <> TYPE_STRING		;@@ use ANY_STRING?
-				TYPE_OF(str2) <> TYPE_FILE
-				TYPE_OF(str2) <> TYPE_URL
-				TYPE_OF(str2) <> TYPE_TAG
-				TYPE_OF(str2) <> TYPE_EMAIL
-			]
-		]
-	][RETURN_COMPARE_OTHER]
 ]
 
 #define SIGN_COMPARE_RESULT(a b) [

--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -1192,6 +1192,7 @@ natives: context [
 			int	   [red-integer!]
 			res	   [red-value!]
 			cframe [byte-ptr!]
+			type   [integer!]
 	][
 		#typecheck [parse case? part trace]
 		op: either as logic! case? + 1 [COMP_STRICT_EQUAL][COMP_EQUAL]
@@ -1214,13 +1215,8 @@ natives: context [
 				limit/head
 			]
 			if part <= 0 [
-				logic/box zero? either any [
-					TYPE_OF(input) = TYPE_STRING		;@@ replace with ANY_STRING?
-					TYPE_OF(input) = TYPE_FILE
-					TYPE_OF(input) = TYPE_URL
-					TYPE_OF(input) = TYPE_TAG
-					TYPE_OF(input) = TYPE_EMAIL
-				][
+				type: TYPE_OF(input)
+				logic/box zero? either ANY_STRING?(type) [
 					string/rs-length? as red-string! input
 				][
 					block/rs-length? as red-block! input
@@ -2425,13 +2421,7 @@ natives: context [
 		value: name + 1
 
 		type: TYPE_OF(name)
-		unless any [						;-- any-word!
-			type = TYPE_STRING				;@@ replace with ANY_STRING?
-			type = TYPE_FILE 
-			type = TYPE_URL
-			type = TYPE_TAG
-			type = TYPE_EMAIL
-		][
+		unless ANY_STRING?(type) [
 			w: as red-word! name
 			s: GET_BUFFER(symbols)
 			name: as red-string! s/offset + w/symbol - 1
@@ -2460,12 +2450,7 @@ natives: context [
 		#typecheck get-env
 		name: as red-string! stack/arguments
 		type: TYPE_OF(name)
-		unless any [						;-- any-word!
-			type = TYPE_STRING				;@@ replace with ANY_STRING?
-			type = TYPE_FILE 
-			type = TYPE_URL
-			type = TYPE_EMAIL
-		][
+		unless ANY_STRING?(type) [
 			w: as red-word! name
 			s: GET_BUFFER(symbols)
 			name: word/as-string as red-word! name
@@ -3063,15 +3048,9 @@ natives: context [
 			return IMAGE_WIDTH(img/size) * IMAGE_HEIGHT(img/size) > img/head
 		]
 		s: GET_BUFFER(series)
-		either any [									;@@ replace with any-block?
-			type = TYPE_BLOCK
+		either any [
+			ANY_BLOCK?(type)
 			type = TYPE_MAP
-			type = TYPE_HASH
-			type = TYPE_PAREN
-			type = TYPE_PATH
-			type = TYPE_GET_PATH
-			type = TYPE_SET_PATH
-			type = TYPE_LIT_PATH
 		][
 			s/offset + series/head < s/tail
 		][
@@ -3148,29 +3127,17 @@ natives: context [
 			series	[red-series!]
 			pos		[red-series!]
 			part	[red-value!]
+			type    [integer!]
 	][
 		arg: stack/arguments
 		bool: as red-logic! arg
 		series: as red-series! arg - 2
 		part: either size = 1 [null][arg - 3]
+		type: TYPE_OF(series)
 		
-		assert any [									;@@ replace with any-block?/any-string? check
-			TYPE_OF(series) = TYPE_BLOCK
-			TYPE_OF(series) = TYPE_HASH
-			TYPE_OF(series) = TYPE_PAREN
-			TYPE_OF(series) = TYPE_PATH
-			TYPE_OF(series) = TYPE_GET_PATH
-			TYPE_OF(series) = TYPE_SET_PATH
-			TYPE_OF(series) = TYPE_LIT_PATH
-			TYPE_OF(series) = TYPE_STRING
-			TYPE_OF(series) = TYPE_FILE
-			TYPE_OF(series) = TYPE_URL
-			TYPE_OF(series) = TYPE_TAG
-			TYPE_OF(series) = TYPE_EMAIL
-			TYPE_OF(series) = TYPE_VECTOR
-			TYPE_OF(series) = TYPE_BINARY
-			TYPE_OF(series) = TYPE_MAP
-			TYPE_OF(series) = TYPE_IMAGE
+		assert any [
+			ANY_SERIES?(type)
+			type = TYPE_MAP
 		]
 
 		unless any [
@@ -3197,34 +3164,16 @@ natives: context [
 		series: as red-series! stack/arguments - 2
 
 		type: TYPE_OF(series)
-		assert any [									;@@ replace with any-block?/any-string? check
-			type = TYPE_BLOCK
-			type = TYPE_HASH
-			type = TYPE_PAREN
-			type = TYPE_PATH
-			type = TYPE_GET_PATH
-			type = TYPE_SET_PATH
-			type = TYPE_LIT_PATH
-			type = TYPE_STRING
-			type = TYPE_FILE
-			type = TYPE_URL
-			type = TYPE_TAG
-			type = TYPE_EMAIL
-			type = TYPE_VECTOR
-			type = TYPE_BINARY
+		assert any [
+			ANY_SERIES?(type)
 			type = TYPE_MAP
-			type = TYPE_IMAGE
 		]
 		assert TYPE_OF(blk) = TYPE_BLOCK
 
 		result: all [loop? series  size > 0]
 		if result [
 			switch type [
-				TYPE_STRING
-				TYPE_FILE
-				TYPE_URL
-				TYPE_TAG
-				TYPE_EMAIL
+				TYPE_ANY_STRING
 				TYPE_VECTOR
 				TYPE_BINARY [
 					set-many-string blk as red-string! series size
@@ -3257,28 +3206,16 @@ natives: context [
 		/local
 			series [red-series!]
 			word   [red-word!]
+			type   [integer!]
 			result [logic!]
 	][
 		word:   as red-word!   stack/arguments - 1
 		series: as red-series! stack/arguments - 2
-
-		assert any [									;@@ replace with any-block?/any-string? check
-			TYPE_OF(series) = TYPE_BLOCK
-			TYPE_OF(series) = TYPE_HASH
-			TYPE_OF(series) = TYPE_PAREN
-			TYPE_OF(series) = TYPE_PATH
-			TYPE_OF(series) = TYPE_GET_PATH
-			TYPE_OF(series) = TYPE_SET_PATH
-			TYPE_OF(series) = TYPE_LIT_PATH
-			TYPE_OF(series) = TYPE_STRING
-			TYPE_OF(series) = TYPE_FILE
-			TYPE_OF(series) = TYPE_URL
-			TYPE_OF(series) = TYPE_TAG
-			TYPE_OF(series) = TYPE_EMAIL
-			TYPE_OF(series) = TYPE_VECTOR
-			TYPE_OF(series) = TYPE_BINARY
-			TYPE_OF(series) = TYPE_MAP
-			TYPE_OF(series) = TYPE_IMAGE
+		type:   TYPE_OF(series)
+		
+		assert any [
+			ANY_SERIES?(type)
+			type = TYPE_MAP
 		]
 		assert TYPE_OF(word) = TYPE_WORD
 		
@@ -3318,25 +3255,15 @@ natives: context [
 		/local
 			series [red-series!]
 			word   [red-word!]
+			type   [integer!]
 	][
 		word: 	as red-word!   stack/arguments - 1
 		series: as red-series! stack/arguments - 2
+		type:   TYPE_OF(series)
 		
-		assert any [									;@@ replace with any-block?/any-string? check
-			TYPE_OF(series) = TYPE_BLOCK
-			TYPE_OF(series) = TYPE_HASH
-			TYPE_OF(series) = TYPE_PAREN
-			TYPE_OF(series) = TYPE_PATH
-			TYPE_OF(series) = TYPE_GET_PATH
-			TYPE_OF(series) = TYPE_SET_PATH
-			TYPE_OF(series) = TYPE_LIT_PATH
-			TYPE_OF(series) = TYPE_STRING
-			TYPE_OF(series) = TYPE_FILE
-			TYPE_OF(series) = TYPE_URL
-			TYPE_OF(series) = TYPE_TAG
-			TYPE_OF(series) = TYPE_EMAIL
-			TYPE_OF(series) = TYPE_VECTOR
-			TYPE_OF(series) = TYPE_BINARY
+		assert any [
+			ANY_SERIES?(type)
+			type = TYPE_MAP
 		]
 		assert TYPE_OF(word) = TYPE_WORD
 

--- a/runtime/parse.reds
+++ b/runtime/parse.reds
@@ -551,11 +551,7 @@ parser: context [
 			][
 				len: either any [type2 = TYPE_CHAR type2 = TYPE_BITSET][1][
 					unless any [
-						type2 = TYPE_STRING
-						type2 = TYPE_FILE
-						type2 = TYPE_URL
-						type2 = TYPE_TAG
-						type2 = TYPE_EMAIL
+						ANY_STRING?(type2)
 						type2 = TYPE_BINARY
 					][return no]
 					string/rs-length? as red-string! token

--- a/runtime/redbin.reds
+++ b/runtime/redbin.reds
@@ -366,12 +366,7 @@ redbin: context [
 			TYPE_LIT_WORD
 			TYPE_GET_WORD
 			TYPE_REFINEMENT [decode-word data table parent nl?]
-			TYPE_STRING
-			TYPE_FILE
-			TYPE_URL
-			TYPE_TAG
-			TYPE_REF
-			TYPE_EMAIL
+			TYPE_ANY_STRING
 			TYPE_BINARY		[decode-string data parent nl?]
 			TYPE_INTEGER	[
 				cell: as cell! integer/make-in parent data/2


### PR DESCRIPTION
This PR is informed mostly by `ref!`-related bugs and issues that come up time and again: it was implemented with an assumption that runtime relies on `TYPE_ANY_STRING` and `ANY_STRING?` macros. As can be seen in the applied changes, this did not hold in the majority of cases.

I also took the liberty to simplify `ANY_SERIES?` macro, remove dead `CHECK_COMPARE_OTHER` definition that wasn't used in the codebase, and refactor conditions that use `ANY_WORD?`.

Among the way the following inconsistency was fixed:
```red
>> head change "" <a>
== "a"
>> head insert "" <a>
== "<a>"
```

Now both actions preserve angle brackets of `tag!` values, the same way Rebol does.