### PR TITLE
FIX: REF! cannot be used in ownership system.

### DIFF
--- a/runtime/datatypes/ref.reds
+++ b/runtime/datatypes/ref.reds
@@ -101,7 +101,7 @@ ref: context [
 			null			;create
 			null			;close
 			null			;delete
-			null			;modify
+			INHERIT_ACTION	;modify
 			null			;open
 			null			;open?
 			null			;query


### PR DESCRIPTION
Because of a missing `modify` action, `ref!`s owner could not be changed.

```red
>> reactor [foo: @bar]
*** Script Error: modify does not allow ref for its target argument
*** Where: modify
*** Stack: reactor
```

This is fixed by inheriting this action from `string!`, which allows usage of `ref!` in reactive code.

```red
>> r: deep-reactor [foo: @bar qux: is [last foo]]
== make object! [
    foo: @bar
    qux: #"r"
]
>> append r/foo "bara"
== @barbara
>> r/qux
== #"a"
```