### PR TITLE
FEAT: scalable metered reactivity

### DIFF
--- a/environment/reactivity.red
+++ b/environment/reactivity.red
@@ -3,170 +3,267 @@ Red [
 	Author: "Nenad Rakocevic"
 	File: 	%reactivity.red
 	Tabs: 	4
-	Rights: "Copyright (C) 2016-2018 Red Foundation. All rights reserved."
+	Rights: "Copyright (C) 2016-2020 Red Foundation. All rights reserved."
 	License: {
 		Distributed under the Boost Software License, Version 1.0.
 		See https://github.com/red/red/blob/master/BSL-License.txt
 	}
 ]
 
-reactor!: context [
-	on-change*: function [word old new][
-		if system/reactivity/debug? [
-			print [
-				"-- on-change event --" lf
-				tab "word :" word		lf
-				tab "old  :" type? :old	lf
-				tab "new  :" type? :new
+system/reactivity: context [
+	;-- index format: [reaction [reactors..] ...]        -- required by react/unlink 'all, dump-reactions, clear-reactions, stop-reactor
+	index:       make hash! 1000						;-- hash speeds up unlinking noticeably
+
+	;-- queue format: [reactor reaction target done]
+	queue:		 make hash! 100
+
+	debug?: 	 no
+	metrics?:    no
+	source:		 []		;-- contains the initial [reactor reaction] that triggered a chain of subsequent reactions
+
+	metrics: context [
+		max-queue: max-index: max-reactors: max-relations: 0
+		events: fired: queued: skipped: 0
+		in-add: in-remove: in-react: in-check: in-eval: longest-flush: 0:0
+
+		reset: does [
+			set self 0
+			in-add: in-remove: in-react: in-check: in-eval: longest-flush: 0:0
+		]
+
+		show: does [
+			print "^/***** REACTIVITY METRICS REPORT *****"
+			print ["Metrics collection enabled?:" metrics?]
+			print  "Statistical counts:"
+			print ["    events triggered:   " events]
+			print ["    reactions fired:    " fired "(immediately:" fired - queued ", queued:" queued ")" ]
+			print ["    reactions skipped:  " skipped]
+			print ["Time spent in reactions:" in-eval]
+			print  "Time spent in reactivity:"
+			print ["    total:              " in-add + in-remove + in-react + in-check]
+			print ["    adding relations:   " in-add + in-react "(preparations:" in-react ")"]
+			print ["    removing relations: " in-remove]
+			print ["    dispatching:        " in-check]
+			print ["    longest queue flush:" longest-flush]
+			print  "Peak values:"
+			print ["    maximum queue size: " max-queue]
+			print ["    maximum index size: " max-index]
+			print ["    biggest relation:   " max-reactors "reactors"]
+			print ["    most used reactor:  " max-relations "relations"]
+		]
+		
+		start: target: none
+		time: func [/count 'into [word!] /save /local t] [
+			t: now/precise
+			case [
+				save  [set target (get target) + t: difference t start  t]
+				count [start: t  target: into]
 			]
 		]
+
+		++: make op! func ['word value] [set word add get word value]
+		peak:        func ['word value] [set word max get word value]
+
+		register: func ['counter value] [set counter max get counter value]
+	]
+
+	--measure--: func [code] [
+		if metrics? [do bind code metrics]
+	]
+
+	--debug-print--: function [blk [block!] /full /no-gui] [
 		all [
-			not empty? srs: system/reactivity/source
-			srs/1 = self
-			srs/2 = word
-			set-quiet in self word old					;-- force the old value
-			exit
+			debug?
+			any [not full  debug? = 'full]
+			not all [no-gui  attempt [system/console/gui?]]			;-- print in GUI console overflows stack in some places
+			(
+				limit: (any [all [system/console system/console/size/x] 72]) - 10
+				blk: reduce blk
+				forall blk [
+					x: :blk/1										;@@ workaround for #4517
+					unless string? :x [
+						if function? :x [x: body-of :x]
+						all [
+							object? :x
+							pos: find/same values-of system/words x
+							x: pick words-of system/words index? pos
+						]
+						change blk
+							replace/all
+								mold/flat/part :x limit
+								"make object!" "object"
+					]
+				]
+				if 1 < overshoot: (length? s: form blk) / limit [	;-- trim longest parts equally
+					foreach x next blk [							;-- don't trim the prefix
+						if 15 < n: length? x [
+							clear skip x to integer! n / overshoot
+						]
+					]
+					clear skip s: form blk limit
+				]
+				print s
+			)
 		]
-		unless all [block? :old block? :new same? head :old head :new][
-			if any [series? :old object? :old][modify old 'owned none]
-			if any [series? :new object? :new][modify new 'owned reduce [self word]]
-		]
-		system/reactivity/check/only self word
 	]
-]
 
-deep-reactor!: make reactor! [
-	on-deep-change*: function [owner word target action new index part][
-		system/reactivity/check/only owner word
+	relations-of: func [reactor [object!]] [first body-of :reactor/on-change*]
+
+	unique-objects: function [] [						;-- used by debug funcs only
+		unique collect [foreach [_ list] index [keep list]]
 	]
-]
+	
+	relations-count: function [] [
+		sum: 0
+		foreach obj unique-objects [sum: (length? relations-of obj) / 3 + sum]
+		sum
+	]
 
-reactor:	  function [spec [block!]][make reactor! spec]
-deep-reactor: function [spec [block!]][make deep-reactor! spec]
-
-
-system/reactivity: context [
-	relations:	 make block! 1000		;@@ change it to hash! once stable
-	;-- queue format: [reactor reaction target done]
-	queue:		 make block! 100
-	eat-events?: yes
-	debug?: 	 no
-	source:		 []
-
-	add-relation: func [
+	add-relation: function [
 		obj		 [object!]
-		word
+		word     [word!]
 		reaction [block! function!]
 		targets  [set-word! block! object! none!]
-		/local new-rel
 	][
-		new-rel: reduce [obj :word :reaction targets]
-		unless find/same/skip relations new-rel 4 [append relations new-rel]
+		--measure-- [time/count in-add]
+		new-rel: head reduce/into [:word :reaction targets] clear []
+		relations: relations-of obj
+		unless find/same/skip relations new-rel 3 [
+			append relations new-rel
+			unless objs: select/only/same/skip index :reaction 2 [
+				reduce/into [:reaction objs: make block! 10] tail index
+			]
+			unless find/same objs obj [append objs obj]
+			if block? targets [							;-- react/link func .. [func objects..] case
+				foreach obj next targets [
+					unless find/same objs obj [append objs obj]
+				]
+			]
+			--measure-- [
+				peak max-relations (length? relations) / 3
+				peak max-reactors   length? objs
+				peak max-index     (length? index) / 2
+			]
+			--debug-print-- ["-- react: added --" :reaction "FOR" word "IN" obj]
+		]
+		--measure-- [time/save]
 	]
 	
-	eval: function [code [block!] /safe][
+	eval: function [code [block!] /safe /local result saved][
+		--measure-- [
+			time/count in-eval
+			fired ++ 1
+		]
+		--debug-print--/full ["-- react: firing --" either function? first code [body-of first code][code]]
 		either safe [
-			if error? set/any 'result try/all code [
-				print :result
+			if error? error: try/all [set/any 'result do code  'ok] [
+				print :error
 				prin "*** Near: "
 				print mold/part/flat code 80
-				result: none
 			]
-			get/any 'result
 		][
-			do code
+			set/any 'result do code
 		]
+		--measure-- [time/save]
+		:result
 	]
 	
-	eval-reaction: func [reactor [object!] reaction [block! function!] target /mark][
-		if mark [repend queue [reactor :reaction target yes]]
-		
-		either set-word? target [
-			set/any target eval/safe :reaction
-		][
-			eval/safe any [all [block? :reaction reaction] target]
+	eval-reaction: func [reactor [object!] reaction [block! function!] target [set-word! block! object! none!]][
+		case [
+			set-word? target [set/any target eval/safe :reaction]
+			block? :reaction [eval/safe reaction]
+			'linked          [eval/safe target]
 		]
 	]
 	
 	pending?: function [reactor [object!] reaction [block! function!]][
-		q: queue
-		while [q: find/same/skip q reactor 4][
-			if same? :q/2 :reaction [return yes]
-			q: skip q 4
-		]
-		no
+		pattern: head reduce/into [reactor :reaction] clear []
+		none <> find/same/skip queue pattern 4
 	]
-	
-	check: function [reactor [object!] /only field [word! set-word!]][
-		unless empty? pos: relations [
-			while [pos: find/same/skip pos reactor 4][
-				reaction: :pos/3
-				if all [
-					any [not only pos/2 = field]
-					any [empty? queue  not pending? reactor :reaction]
-				][
-					either empty? queue [
-						if empty? source [
-							append source reactor
-							append source field
-						]
-						eval-reaction/mark reactor :reaction pos/4
-						
-						q: tail queue
-						until [
-							q: skip q': q -4
-							either q/4 [ 				;-- was already executed?
-								clear q 				;-- allow requeueing of it
-							][
-								eval-reaction q/1 :q/2 q/3
-								either tail? q' [ 		;-- queue wasn't extended
-									clear q 			;-- allow requeueing
-								][
-									q/4: yes 			;-- mark as executed
-									q: tail queue 		;-- jump to recently queued reactions
-								]
-							]
-							head? q
-						]
-						clear queue
-						clear source
-					][
-						unless all [
-							eat-events?
-							pending? reactor :reaction
+
+	check: function [reactor [object!] field [word! set-word!] /local word reaction target][
+		--debug-print--/full/no-gui ["-- react: checking --" field "IN" reactor]
+		--measure-- [time/count in-check]
+		pos: relations-of reactor
+		unless pos: find/skip pos field 3 [exit]
+		if initial?: tail? source [reduce/into [reactor field] source]
+		until [
+			set [word reaction target] pos
+			case [
+				pending? reactor :reaction [			;-- don't allow cycles
+					--measure-- [skipped ++ 1]
+					--debug-print--/no-gui ["-- react: skipped --" :reaction "FOR" field "IN" reactor]
+					'idle
+				]
+				not tail? queue [						;-- entered while another reaction is running
+					reduce/into [reactor :reaction target no] tail queue
+					--measure-- [
+						queued ++ 1
+						peak max-queue (length? queue) / 4
+					]
+					--debug-print--/no-gui ["-- react: queued --" :reaction "FOR" field "IN" reactor]
+				]
+				'else [
+					reduce/into [reactor :reaction target yes] queue
+					--measure-- [peak max-queue 1  time/save]
+					eval-reaction reactor :reaction target
+					q: tail queue
+					while [not head? q] [
+						q: skip q': q -4
+						either q/4 [ 					;-- was already executed?
+							clear q 					;-- allow requeueing of it
 						][
-							repend queue [reactor :reaction pos/4 no]
+							eval-reaction q/1 :q/2 q/3
+							either tail? q' [ 			;-- queue wasn't extended
+								clear q 				;-- allow requeueing
+							][
+								q/4: yes 				;-- mark as executed
+								q: tail q	 			;-- jump to recently queued reactions
+							]
 						]
 					]
+					--measure-- [time/count in-check]
 				]
-				pos: skip pos 4
 			]
+			none? pos: find/skip skip pos 3 field 3
 		]
+		if initial? [clear source]
+		--measure-- [peak longest-flush time/save]
 	]
 	
 	set 'stop-reactor function [
-		face [object!]
-		/deep
+		"Forget all relations involving reactor OBJ"
+		obj [object!] "Face or reactor"
+		/deep "Deeply remove all relations from child faces"
 	][
-		list: relations
-		while [not tail? list][
-			either any [
-				same? list/1 face
-				all [
-					block? list/4
-					pos: find/same list/4 face
-					empty? head remove pos
-				]
-			][
-				remove/part list 4
-			][
-				list: skip list 4
+		--measure-- [time/count in-remove]
+		relations: relations-of obj
+		reactions: unique extract/into next relations 3 clear []	;-- same reaction may be repeated many times for different words
+		foreach reaction reactions [
+			--debug-print-- ["-- react: removed --" :reaction "FROM" obj]
+			pos: find/same/only/skip index :reaction 2
+			remove find/same pos/2 obj
+			if tail? pos/2 [
+				change pos end: skip tail pos -2
+				clear end
 			]
 		]
-		if all [deep block? face/pane][foreach f face/pane [stop-reactor/deep f]]
+		clear relations
+		--measure-- [time/save]
+
+		if all [deep  block? :obj/pane] [
+			foreach f obj/pane [stop-reactor/deep f]
+		]
 	]
-	
-	set 'clear-reactions function ["Removes all reactive relations"][clear relations]
+
+	set 'clear-reactions function ["Remove all reactive relations"][
+		foreach obj unique-objects [
+			--debug-print-- ["-- react: clearing all relations -- FROM" obj]
+			relations: relations-of obj
+			clear relations
+		]
+		clear index
+	]
 	
 	set 'dump-reactions function [
 		"Output all the current reactive relations for debugging purpose"
@@ -174,52 +271,96 @@ system/reactivity: context [
 		limit: (any [all [system/console system/console/size/x] 72]) - 10
 		count: 0
 		
-		foreach [obj field reaction target] relations [
-			prin count: count + 1
-			prin ":---^/"
-			prin "  Source: object "
-			list: words-of obj
-			remove find list 'on-change*
-			remove find list 'on-deep-change*
-			print mold/part list limit - 5
-			prin "   Field: "
-			print form field
-			prin "  Action: "
-			print mold/flat/part :reaction limit
-			case [
-				block? target [
-					prin "    Args: "
-					print copy/part replace/all mold/flat next target "make object!" "object" limit
-				]
-				set-word? target [
-					prin "  Target: "
-					print form target
+		foreach reactor unique-objects [
+			foreach [field reaction target] relations-of reactor [
+				prin count: count + 1
+				prin ":---^/"
+				prin "  Source: object "
+				list: words-of reactor
+				remove find list 'on-change*
+				remove find list 'on-deep-change*
+				print mold/part list limit - 5
+				prin "   Field: "
+				print form field
+				prin "  Action: "
+				print mold/flat/part :reaction limit
+				case [
+					block? target [
+						prin "    Args: "
+						print copy/part replace/all mold/flat/part next target limit + 20 "make object!" "object" limit
+					]
+					set-word? target [
+						prin "  Target: "
+						print form target
+					]
 				]
 			]
 		]
 		()												;-- avoids returning anything in the console
 	]
-	
+
+	;-- `is` should support non-object paths, like `pair/x`, `time/second`, `block/3`
+	;;  as well as in-path references: `anything/(pair/x)`, `any/:x/thing`...
+	;;  parsing summary:
+	;;    word:     as first item in a path only (including inner paths)
+	;;    get-word: anywhere in a path, inside parens (including inner paths) e.g. `object/:x`
+	;;    get-words in lit-paths and set-paths? for now they are accepted; e.g. `obj/:x: y`
+	;;    lit-word: should be ignored? as it's a way to get around reactivity e.g. `set 'y get 'x`
+	;;    interop with react: react catches words after the object, not get-words; is - only first word in path
 	is~: function [
 		"Defines a reactive relation whose result is assigned to a word"
 		'field	 [set-word!]	"Set-word which will get set to the result of the reaction"
 		reaction [block!]		"Reactive relation"
+		/local item
 	][
+		--measure-- [time/count in-react]
 		obj: context? field
-		parse reaction rule: [
-			any [
-				item: word! (if in obj item/1 [add-relation obj item/1 reaction field])
-				| any-path! | any-string!
-				| into rule
-				| skip
+		if reactor? obj [								;-- skip global context (which would contain ALL words) and other normal objects -- let react handle them
+			words: clear []
+			=add=:       [(if in obj item [append words to word! item])]
+			=path=:      [[set item word! =add= | skip] =path-rest=]
+			=set-path=:  [skip =path-rest=]
+			=path-rest=: [
+				any [
+					set item get-word! =add=
+				|	ahead paren! into =block=			;-- no literal paths, strings, blocks in paths (can't be constructed lexically)
+				|	skip
+				]
 			]
+			parse reaction =block=: [
+				any [
+					set item [word! | get-word!] =add=
+				|	any-string!
+				|	ahead [path! | get-path! | lit-path!] into =path=
+				|	ahead set-path! into =set-path=
+				|	into =block=
+				|	skip
+				]
+			]
+			--measure-- [time/save]
+			foreach w words [add-relation obj w reaction field]
 		]
 		react/later/with reaction field
-		set field either block? :reaction/1 [do :reaction/1][eval reaction]
+		set field either block? :reaction/1 [do reaction/1][eval reaction]
 	]
 	
 	set 'is make op! :is~
 	
+	for-all-paths: function ['word [word!] reaction [block!] code [block!]] [
+		parse reaction rule: [
+			any [
+				item: [path! | lit-path! | get-path!] (
+					set word item/1
+					do code
+					parse item/1 rule					;-- process paren & inner paths
+				)
+			|	any-string!
+			|	into rule								;-- also enters set-path
+			|	skip
+			]
+		]
+	]
+
 	set 'react? function [
 		"Returns a reactive relation if an object's field is a reactive source"
 		reactor	[object!]	"Object to check"
@@ -227,22 +368,60 @@ system/reactivity: context [
 		/target				"Check if it's a target instead of a source"
 		return: [block! function! word! none!] "Returns reaction, type or NONE"
 	][
+		pos: relations-of reactor
 		either target [
-			pos: skip relations 3
-			while [pos: find/skip pos field 4][
-				if reactor = context? pos/1 [return pos/-1]
-				pos: skip pos 4
-			]
+			pos: at pos 3
+			if pos: find/skip pos field 3 [reaction: :pos/-1]	;-- looks for a set-word
 		][
-			pos: relations
-			while [pos: find/same/skip pos reactor 4][
-				if pos/2 = field [return pos/3]
-				pos: skip pos 4
-			]
+			if pos: find/skip pos field 3 [reaction: :pos/2]
+		]
+		all [				;-- have to verify that on-change* block wasn't just copied into this object from other reactor
+			:reaction
+			objs: select/same/only/skip index :reaction 2
+			find/same objs reactor
+			return :reaction
 		]
 		none
 	]
-	
+
+	get-object-path-length: function [path [any-path!] obj [word!]] [
+		either 2 = length? path [
+			set/any obj get/any path/1
+			1
+		][
+			part: length? path
+			set obj none
+			until [							;-- search for an object (deep first)
+				part: part - 1
+				path: copy/part path part
+				any [
+					object? set obj attempt [get path]
+					part = 1
+				]
+			]
+			part
+		]
+	]
+
+	unlink-reaction: function [reactor [object!] reaction [function! block!]] [
+		pos: next relations-of reactor
+		while [pos: find/same/only/skip pos :reaction 3][
+			--debug-print-- ["-- react: removed --" :reaction "FOR" pos/-1 "IN" reactor]
+			change  back found?: pos  end: skip tail pos -3
+			clear end
+		]
+		found?
+	]
+
+	set 'reactor? function ["Check if object is a reactor" obj [any-type!]] [
+		all [
+			object? :obj
+			oc: in obj 'on-change*
+			function? get/any oc						;-- can be unset when `is` is used in global context
+			any-block? relations-of obj					;-- is a reactor, not other object with on-change*
+		]
+	]
+
 	set 'react function [
 		"Defines a new reactive relation between two or more objects"
 		reaction	[block! function!]	"Reactive relation"
@@ -253,97 +432,130 @@ system/reactivity: context [
 		/later							"Run the reaction on next change instead of now"
 		/with							"Specifies an optional face object (internal use)"
 			ctx		[object! set-word! none!] "Optional context for VID faces or target set-word"
+		/local item
 		return:		[block! function! none!] "The reactive relation or NONE if no relation was processed"
 	][
 		case [
 			link [
+				--measure-- [time/count in-react]
 				unless function? :reaction [cause-error 'script 'react-bad-func []]
-				objs: parse spec-of :reaction [
-					collect some [keep word! | [refinement! | set-word!] break | skip]
+				args: clear []
+				parse spec-of :reaction [
+					collect into args some [keep word! | [refinement! | set-word!] break | skip]
 				]
-				if 2 > length? objs [cause-error 'script 'react-not-enough []]
+				if empty? args [cause-error 'script 'react-not-enough []]
 				objects: reduce objects
 				
-				if (length? objects) <> length? objs [cause-error 'script 'react-no-match []]
+				if (length? objects) <> length? args [cause-error 'script 'react-no-match []]
 				unless parse objects [some object!][cause-error 'script 'react-bad-obj []]
 				
 				insert objects :reaction
-				
-				found?: no
-				parse body-of :reaction rule: [
-					any [
-						item: [path! | lit-path! | get-path!] (
-							item: item/1
-							if pos: find objs item/1 [
-								obj: pick objects 1 + index? pos
-								add-relation obj item/2 :reaction objects
-								unless later [eval objects]
-								found?: yes
-							]
-						)
-						| set-path! | any-string!
-						| into rule
-						| skip
+				plan: clear []
+				for-all-paths item body-of :reaction [
+					all [
+						word? :item/2
+						pos: find args item/1
+						obj: pick objects 1 + index? pos
+						reactor? :obj
+						found?: repend plan [obj item/2]
 					]
 				]
+				--measure-- [time/save]
+				foreach [obj word] plan [add-relation obj word :reaction objects]
+				if all [found? not later] [eval objects]
 			]
 			unlink [
-				if block? src [src: reduce src]
-				pos: relations
-				found?: no
-				while [pos: find/same/only pos :reaction][
-					obj: pos/-2
-					either any [src = 'all src = obj all [block? src find/same src obj]][
-						pos: remove/part skip pos -2 4
-						found?: yes
-					][
-						break
+				--measure-- [time/count in-remove]
+				case [
+					object? src [
+						if found?: unlink-reaction src :reaction [
+							objs: select/only/same/skip index :reaction 2
+							remove find/same objs src
+						]
 					]
-				]
-			]
-			'else [
-				found?: no
-				parse reaction rule: [
-					any [
-						item: [path! | lit-path! | get-path!] (
-							saved: item/1
-							if unset? attempt [get/any item: saved][
-								cause-error 'script 'no-value [item]
-							]
-							either 2 = length? item [
-								set/any 'obj get/any item/1
-								part: 1
-							][
-								part: length? item
-								until [					;-- search for an object (deep first)
-									part: part - 1
-									path: copy/part item part
-									any [
-										tail? path
-										object? obj: attempt [get path]
-										part = 1
-									]
-								]
-							]
-							if all [
-								object? :obj			;-- rough checks for reactive object
-								in obj 'on-change*
-							][
-								part: part + 1
-								add-relation obj item/:part reaction ctx
-								unless later [eval reaction]
+					block? src [
+						objs: select/only/same/skip index :reaction 2
+						foreach obj src [
+							if unlink-reaction obj :reaction [
+								remove find/same objs obj
 								found?: yes
 							]
-							parse saved rule
-						)
-						| set-path! | any-string!
-						| into rule
-						| skip
+						]
+					]
+					src = 'all [
+						if pos: find/only/same/skip index :reaction 2 [
+							foreach obj pos/2 [
+								if unlink-reaction obj :reaction [found?: yes]
+							]
+							clear pos/2					;-- dissociate from all objects
+							change pos end: skip tail pos -2
+							clear end
+						]
+					]
+					'else [cause-error 'script 'invalid-arg [src]]
+				]
+				--measure-- [time/save]
+			]
+			'else [
+				--measure-- [time/count in-react]
+				unless block? :reaction [cause-error 'script 'invalid-arg [:reaction]]
+				plan: clear []
+				for-all-paths item reaction [
+					if unset? attempt [get/any item][
+						cause-error 'script 'no-value [item]
+					]
+					part: get-object-path-length item 'obj
+					all [
+						reactor? :obj
+						word? word: :item/(part + 1)
+						found?: repend plan [obj word]
 					]
 				]
+				--measure-- [time/save]
+				foreach [obj word] plan [add-relation obj word reaction ctx]
+				if all [found? not later] [eval reaction]
 			]
 		]
 		either found? [:reaction][none]					;-- returns NONE if no relation was processed
 	]
 ]
+
+reactor!: context [
+	on-change*: function [word old [any-type!] new [any-type!]] [
+		;-- relations format: [reactor word reaction targets]
+		;;  src-word [reaction] set-word            	 -- used by `is` (evaluates reaction, assigns to target)
+		;;  src-word function [func obj1 obj2...]   	 -- used by react/link (evaluates target), one relation for every reactor in both list and func's body
+		;;  src-word [reaction] none                	 -- used by react (evaluates reaction)
+		;;  src-word [reaction] set-word/object     	 -- used by react/with (evaluates reaction, assigns to a set-word only)
+		[]												;-- relations placeholder (hash is ~10x times slower)
+
+		sr: system/reactivity		
+		sr/--debug-print--/full ["-- react: on-change --" word "FROM" type? :old "TO" type? :new]
+		sr/--measure-- [events ++ 1]
+		if all [
+			not empty? srs: sr/source
+			srs/1 =? self
+			srs/2 = word
+		][
+			set-quiet in self word :old					;-- force the old value
+			sr/--measure-- [skipped ++ 1]
+			sr/--debug-print--/full ["-- react: protected --" word "VALUE" :old "IN" self]
+			exit
+		]
+		unless all [series? :old series? :new same? head :old head :new][
+			if any [series? :old object? :old][modify old 'owned none]
+			if any [series? :new object? :new][modify new 'owned reduce [self word]]
+		]
+		sr/check self word
+	]
+]
+
+deep-reactor!: make reactor! [
+	on-deep-change*: function [owner word target action new [any-type!] index part][
+		system/reactivity/check owner word
+	]
+]
+
+reactor:	  function [spec [block!]][make reactor!      spec]
+deep-reactor: function [spec [block!]][make deep-reactor! spec]
 

--- a/environment/reactivity.red
+++ b/environment/reactivity.red
@@ -540,7 +540,7 @@ reactor!: context [
 		][
 			set-quiet in self word :old					;-- force the old value
 			sr/--measure-- [skipped ++ 1]
-			sr/--debug-print--/full ["-- react: protected --" word "VALUE" :old "IN" self]
+			sr/--debug-print-- ["-- react: protected --" word "VALUE" :old "IN" self]
 			exit
 		]
 		unless all [series? :old series? :new same? head :old head :new][

--- a/environment/reactivity.red
+++ b/environment/reactivity.red
@@ -98,11 +98,18 @@ system/reactivity: context [
 								"make object!" "object"
 					]
 				]
-				if 1 < overshoot: (length? s: form blk) / limit [	;-- trim longest parts equally
+				if (length? s: form blk) > limit [					;-- trim longest parts equally
+					long: 0  count: 0
 					foreach x next blk [							;-- don't trim the prefix
-						if 15 < n: length? x [
-							clear skip x to integer! n / overshoot
+						if 15 < len: length? x [					;-- don't trim short values
+							long: long + len
+							count: count + 1
 						]
+					]
+					short: (len: length? s) - long
+					ratio: max 0 limit - short / (len - short)
+					foreach x next blk [
+						clear skip x max 15 to integer! ratio * length? x
 					]
 					clear skip s: form blk limit
 				]
@@ -117,7 +124,7 @@ system/reactivity: context [
 	]
 
 	relations-of: func [reactor [object!]] [select body-of :reactor/on-change* 'relations]
-	reactors-for:  func [reaction [block! function!]] [select/same/only/skip index :reaction IDX-PERIOD]
+	reactors-for: func [reaction [block! function!]] [select/same/only/skip index :reaction IDX-PERIOD]
 
 	unique-objects: function [] [						;-- used by debug funcs only
 		unique collect [foreach [_ list] index [keep list]]

--- a/environment/reactivity.red
+++ b/environment/reactivity.red
@@ -61,8 +61,9 @@ system/reactivity: context [
 			]
 		]
 
-		++: make op! func ['word value] [set word add get word value]
-		peak:        func ['word value] [set word max get word value]
+		incr: func ['word value] [set word add get word value]
+		peak: func ['word value] [set word max get word value]
+		++: make op! :incr								;@@ workaround for #4526
 
 		register: func ['counter value] [set counter max get counter value]
 	]
@@ -432,8 +433,8 @@ system/reactivity: context [
 		/later							"Run the reaction on next change instead of now"
 		/with							"Specifies an optional face object (internal use)"
 			ctx		[object! set-word! none!] "Optional context for VID faces or target set-word"
-		/local item
 		return:		[block! function! none!] "The reactive relation or NONE if no relation was processed"
+		/local item
 	][
 		case [
 			link [

--- a/environment/reactivity.red
+++ b/environment/reactivity.red
@@ -471,8 +471,6 @@ system/reactivity: context [
 
 		at-reaction: find-reaction :reaction
 		remove find/same objs: at-reaction/2 reactor
-		remove find/same at-reaction/2 reactor
-		remove find/same at-reaction/2 reactor
 		if empty? objs [remove-part at-reaction REACTIONS-PERIOD]		;-- don't lock it from GC
 		found?
 	]

--- a/environment/reactivity.red
+++ b/environment/reactivity.red
@@ -561,7 +561,7 @@ reactor!: context [
 		;;  src-word [reaction] none                	 -- used by react (evaluates reaction)
 		;;  src-word [reaction] set-word/object     	 -- used by react/with (evaluates reaction, assigns to a set-word only)
 		relations: []									;-- relations placeholder (hash is ~10x times slower)
-		system/reactivity/on-change-handler context? word word :old :new
+		system/reactivity/on-change-handler self word :old :new
 	]
 ]
 

--- a/environment/reactivity.red
+++ b/environment/reactivity.red
@@ -429,7 +429,7 @@ system/reactivity: context [
 		reactor	[object!]	"Object to check"
 		field	[word!]		"Field to check"
 		/target				"Check if it's a target instead of a source"
-		; return: [block! function! word! none!] "Returns reaction, type or NONE"
+		return: [block! function! word! none!] "Returns reaction, type or NONE"
 	][
 		if pos: relations-of reactor [
 			either target [
@@ -480,7 +480,7 @@ system/reactivity: context [
 	;-- used by `react` to determine valid reactive sources (should also support custom ones)
 	;-- which are: objects that define on-change* and eventually call `check`
 	;-- but last condition can't be verified, because check may be buried in other function calls, so..
-	set 'reactor? function ["Check if object is a reactor" obj [any-type!]] [
+	reactor?: function ["Check if object is a reactor" obj [any-type!]] [
 		all [
 			object? :obj
 			oc: in obj 'on-change*
@@ -498,7 +498,7 @@ system/reactivity: context [
 		/later							"Run the reaction on next change instead of now"
 		/with							"Specifies an optional face object (internal use)"
 			ctx		[object! set-word! none!] "Optional context for VID faces or target set-word"
-		; return:		[block! function! none!] "The reactive relation or NONE if no relation was processed"
+		return:		[block! function! none!] "The reactive relation or NONE if no relation was processed"
 		/local item
 	][
 		case [

--- a/modules/view/view.red
+++ b/modules/view/view.red
@@ -291,7 +291,7 @@ on-face-deep-change*: function ["Internal use only" owner word target action new
 					system/view/platform/on-change-facet owner word target action new index part
 				]
 			]
-			system/reactivity/check/only owner word
+			system/reactivity/check owner word
 		][
 			if any [								;-- drop multiple changes on same facet
 				none? state/3
@@ -351,7 +351,7 @@ update-font-faces: function ["Internal Use Only" parent [block! none!]][
 	if block? parent [
 		foreach f parent [
 			if f/state [
-				system/reactivity/check/only f 'font
+				system/reactivity/check f 'font
 				f/state/2: f/state/2 or 00080000h		;-- (1 << ((index? in f 'font) - 1))
 				if block? f/draw [						;-- force a redraw in case the font in draw block
 					f/state/2: f/state/2 or 00400000h	;-- (1 << ((index? in f 'draw) - 1))
@@ -388,6 +388,7 @@ face!: object [				;-- keep in sync with facet! enum
 	draw:		none
 	
 	on-change*: function [word old new][
+		[]
 		if debug-info? self [
 			print [
 				"-- on-change event --" lf
@@ -400,9 +401,11 @@ face!: object [				;-- keep in sync with facet! enum
 		if all [word <> 'state word <> 'extra][
 			all [
 				not empty? srs: system/reactivity/source
-				srs/1 = self
+				srs/1 =? self
 				srs/2 = word
-				set-quiet in self word old				;-- force the old value
+				set-quiet in self word :old				;-- force the old value
+				system/reactivity/--measure-- [skipped ++ 1]
+				system/reactivity/--debug-print--/full ["-- react: protected --" word "VALUE" :old "IN" self]
 				exit
 			]
 			if word = 'pane [
@@ -455,7 +458,7 @@ face!: object [				;-- keep in sync with facet! enum
 				]
 			]
 
-			system/reactivity/check/only self any [saved word]
+			system/reactivity/check self any [saved word]
 
 			either state [
 				;if word = 'type [cause-error 'script 'locked-word [type]]
@@ -538,7 +541,7 @@ para!: object [
 			block? parent
 		][
 			foreach f parent [
-				system/reactivity/check/only f 'para
+				system/reactivity/check f 'para
 				system/view/platform/update-para f (index? in self word) - 1 ;-- sets f/state flag too
 				if all [f/state f/state/1][show f]
 			]
@@ -1173,18 +1176,18 @@ insert-event-func [
 			drop-list	['selected]
 		][none]
 		
-		if facet [system/reactivity/check/only face facet]
+		if facet [system/reactivity/check face facet]
 	]
 	if event/face/type = 'window [
 		switch event/type [
-			move moving 	[system/reactivity/check/only event/face 'offset]
-			resize resizing [system/reactivity/check/only event/face 'size]
+			move moving 	[system/reactivity/check event/face 'offset]
+			resize resizing [system/reactivity/check event/face 'size]
 		]
 	]
 	if event/type = 'select [
 		face: event/face
 		if find [field area] face/type [
-			system/reactivity/check/only face 'selected
+			system/reactivity/check face 'selected
 		]
 	]
 	none
@@ -1201,6 +1204,7 @@ insert-event-func [
 			all [not empty? face/text attempt/safer [load face/text]]
 			all [face/options face/options/default]
 		]
-		system/reactivity/check/only face 'data
+		system/reactivity/check face 'data
 	]
+	none
 ]

--- a/modules/view/view.red
+++ b/modules/view/view.red
@@ -388,7 +388,7 @@ face!: object [				;-- keep in sync with facet! enum
 	draw:		none
 	
 	on-change*: function [word old new][
-		[]
+		relations: []									;-- used by reactivity
 		if debug-info? self [
 			print [
 				"-- on-change event --" lf

--- a/tests/source/units/reactivity-test.red
+++ b/tests/source/units/reactivity-test.red
@@ -101,70 +101,112 @@ Red [
 
 ===start-group=== "relations formation"
 
-	--test-- "rf-1" 	; sanity check
+	--test-- "rf-1" 									;-- sanity check
 		rf-1-r: make reactor! [a: 1 b: is [a * 2]]
-		--assert 0 < length? system/reactivity/relations
+		--assert 0 < system/reactivity/relations-count
 		clear-reactions
-		--assert empty? system/reactivity/relations
+		--assert 0 = system/reactivity/relations-count
 		unset [rf-1-r]
 
-	--test-- "rf-2" 	; shouldn't add duplicate relations
+	--test-- "rf-2" 									;-- shouldn't add duplicate relations
 		clear-reactions
 		rf-2-r: make reactor! [a: 1 b: is [a * a * a]]
-		--assert 1 * 4 = length? system/reactivity/relations
+		--assert 1 = system/reactivity/relations-count
 		unset [rf-2-r]
 
-	--test-- "rf-3" 	; same
+	--test-- "rf-3" 									;-- same
 		clear-reactions
-		do [	; FIXME: workaround for #3797
+		do [											;@@ FIXME: workaround for #3797
 			rf-3-r: make reactor! [a: b: 1  react [self/b: self/a * self/a * self/a]]
-			--assert 1 * 4 = length? system/reactivity/relations
+			--assert 1 = system/reactivity/relations-count
 			--assert (rf-3-r/a: 2  rf-3-r/b = 8)
 		]
 		unset [rf-3-r]
 
-	--test-- "rf-4"	; same
+	--test-- "rf-4"										;-- same
 		clear-reactions
-		do [	; FIXME: workaround for #3797
+		do [											;@@ FIXME: workaround for #3797
 			rf-4-r: make reactor! [a: b: c: 1  react [self/c: self/a * self/a * self/b * self/b]]
-			--assert 2 * 4 = length? system/reactivity/relations
+			--assert 2 = system/reactivity/relations-count
 			--assert (rf-4-r/a: 2  rf-4-r/c = 4)
 			--assert (rf-4-r/b: 2  rf-4-r/c = 16)
 		]
 		unset [rf-4-r]
 
-	--test-- "rf-5" 	; same
+	--test-- "rf-5" 									;-- same
 		clear-reactions
-		do [	; FIXME: workaround for #3797
+		do [											;@@ FIXME: workaround for #3797
 			rf-5-r: make reactor! [
 				a: b: c: d: 1
-				b: is [a + a] 											; +1
-				react [self/c: self/a * self/b * a * b]					; +2
-				react [self/d: self/a + self/b + self/c + a + b + c] 	; +3
+				b: is [a + a] 											;-- +1
+				react [self/c: self/a * self/b * a * b]					;-- +2
+				react [self/d: self/a + self/b + self/c + a + b + c] 	;-- +3
 			]
-			--assert 6 * 4 = length? system/reactivity/relations
+			--assert 6 = system/reactivity/relations-count
 			--assert (rf-5-r/a: 2  rf-5-r/b = 4)
 			--assert rf-5-r/c = 64
 			--assert rf-5-r/d = (2 + 4 + 64 * 2)
 		]
 		unset [rf-5-r]
 
-	--test-- "rf-6"	; #3333 where `is` produced an excessive reaction with the wrong target object
+	--test-- "rf-6"										;-- #3333 where `is` produced an excessive reaction with the wrong target object
 		clear-reactions
 		rf-6r: make reactor! [x: 1]
 		rf-6c: context [ x: is [rf-6r/x] ]
-		--assert 1 * 4 = length? system/reactivity/relations 	;-- should only be a single reaction
-		--assert rf-6r = :system/reactivity/relations/1 		;-- `r` should be the source object
+		--assert 1 = system/reactivity/relations-count 		;-- should only be a single reaction
+		--assert rf-6r =? :system/reactivity/index/2/1 		;-- `rf-6r` should be the source object
 		unset [rf-6c rf-6r]
 
-	--test-- "rf-7"	; #3333 triple-reaction case
+	--test-- "rf-7"										;-- #3333 triple-reaction case
 		clear-reactions
 		rf-7r: make reactor! [x: 1]
 		rf-7x: is [rf-7r/x]
-		--assert 1 * 4 = length? system/reactivity/relations 	;-- should only be a single reaction
-		--assert rf-7r = :system/reactivity/relations/1 		;-- `r` should be the source object
+		--assert 1 = system/reactivity/relations-count 		;-- should only be a single reaction
+		--assert rf-7r = :system/reactivity/index/2/1 		;-- `rf-7r` should be the source object
 		unset [rf-7r rf-7x]
 
+	--test-- "rf-8"										;-- correct path recognition
+		clear-reactions
+		rf-8r: make deep-reactor! [p: 1x1]					;-- deep-reactor to watch for p/x change
+		rf-8x: is [rf-8r/p/x]								;-- single reaction on `rf-8r/p`
+		--assert 1 = system/reactivity/relations-count
+		--assert (rf-8r/p: 2x2  rf-8x = 2)
+		--assert (rf-8r/p/x: 3  rf-8x = 3)
+		--assert rf-8r/p = 3x2
+		unset [rf-8r rf-8x]
+
+	--test-- "rf-9"										;-- correct non-object path recognition
+		clear-reactions
+		rf-9r: make deep-reactor! [p: 1x1  x: is [p/x]]		;-- `is` must register p in p/x
+		--assert 1 = system/reactivity/relations-count
+		--assert rf-9r/x = 1
+		--assert (rf-9r/p: 2x2  rf-9r/x = 2)
+		--assert (rf-9r/p/x: 3  rf-9r/x = 3)
+		--assert rf-9r/p = 3x2
+		unset [rf-9r]
+
+	--test-- "rf-10"									;-- correct non-object path recognition
+		clear-reactions
+		do [											;@@ FIXME: workaround for #3797
+			rf-10r: make reactor! [a: 1 b: 2 c: 3  w: 'a  x: is [self/:w]]		;-- `is` must register :w in p/x
+			--assert 1 = system/reactivity/relations-count
+			--assert rf-10r/x = 1
+			--assert (rf-10r/w: 'b  rf-10r/x = 2)
+			--assert (rf-10r/w: 'c  rf-10r/x = 3)
+		]
+		unset [rf-10r]
+
+	--test-- "rf-11"									;-- correct non-object path recognition; nested
+		clear-reactions
+		rf-11r: make deep-reactor! [
+			p: 1x1 b: [a [1 2] b [3 4]] w: 'a
+			x: is [b/:w/(p/x)]							;-- `is` must register b, :w, and p in p/x
+		]
+		--assert 3 = system/reactivity/relations-count
+		--assert rf-11r/x = 1
+		--assert (rf-11r/w:  'b  rf-11r/x = 3)
+		--assert (rf-11r/p/x: 2  rf-11r/x = 4)
+		unset [rf-11r]
 
 	;-- final group cleanup
 	clear-reactions
@@ -179,11 +221,86 @@ Red [
 		--assert a3091/c = 2
 
 	--test-- "#4022"
-		do [													;-- force through interpreter as
-			a4022: make reactor! [i: repeat i 2 [i]]			;-- `repeat` returns unset when compiled.
-			--assert a4022/i = 2
+		a4022: make reactor! [i: repeat i 2 [i]]
+		--assert a4022/i = 2
+
+	--test-- "#4166-1"
+		r4166: make reactor! [x: y: 1]
+		react b4166: [r4166/y: 2 * r4166/x]
+		--assert b4166 =? react? r4166 'x
+		clear-reactions
+
+	--test-- "#4166-2"
+		do [											;@@ FIXME: compiler can't swallow such `on-change*`
+			r4166: make reactor! [x: 1 y: is [x * 2]]
+			o4166: object [
+				on-change*: func spec-of :r4166/on-change* copy/deep body-of :r4166/on-change*
+				x: 1 y: 2
+			]
+			--assert block? react?/target r4166 'y
+			--assert not    react?/target o4166 'y		;-- should not be mistaken for r4166
 		]
-	
+		clear-reactions
+
+	--test-- "#4166-3"
+		do [											;@@ FIXME: compiler can't swallow such `on-change*`
+			r4166: make reactor! spec: [x: 1 y: is [x * 2]]
+			o4166: object [
+				on-change*: func spec-of :r4166/on-change* copy/deep body-of :r4166/on-change*
+				x: 1 y: 2
+			]
+			react/unlink last spec o4166
+			--assert (r4166/x: 3  r4166/y = 6)			;-- should not be unlinked
+		]
+		clear-reactions
+
+	--test-- "#4176"
+		r4176: make reactor! [n: 1 c: is [1x1 * n] x: is [c/x] t: is [n * 1:0:0] hms: is [rejoin [t/hour t/minute t/second]]]
+		r4176/n: 2
+		--assert r4176/c = 2x2
+		--assert r4176/x = 2
+		--assert r4176/t = 2:0:0
+		--assert none <> find/match r4176/hms "200"		;-- allow both "200" and "200.0"
+		clear-reactions
+
+	--test-- "#4471-1"
+		r4471: make reactor! [x: 1]
+		b4471: []
+		react [all [:r4471/x integer? r4471/x append b4471 r4471/x]]
+		r4471/x: 2
+		r4471/x: 3
+		--assert b4471 = [1 2 3]
+		clear-reactions
+
+	--test-- "#4471-2"
+		a4471: make deep-reactor! [text: 0]
+		b4471: make deep-reactor! [text: 0]
+		n4471: 0
+		react/link func [a b] [n4471: n4471 + 1 a/text b/text b/text b/text] [a4471 b4471]
+		--assert 1 = n4471
+		--assert (b4471/text: 1  2 = n4471)
+		clear-reactions
+
+	;@@ FIXME: this requires `print` mockup, else it outputs the dump
+	;@@ FIXME: this requires images to be garbage-collected, else they stay in RAM
+	; --test-- "#4507"
+	; 	a4507: make deep-reactor! [i: make image! 2000x2000]
+	; 	b4507: make deep-reactor! [i: make image! 2000x2000 a: a4507]
+	; 	react/link func [a b] [b/i] [a4507 b4507]
+	; 	t04507: now/precise
+	; 	dump-reactions
+	; 	dt4507: difference now/precise t04507
+	; 	--assert dt4507 < 0:0:1							;-- took ~10 sec originally
+	; 	clear-reactions
+
+	--test-- "#4510"
+		a4510: make deep-reactor! [data: 0]
+		b4510: make deep-reactor! [data: 0]
+		react/later [a4510/('data)]
+		react/link/later func [a b] [a/('data)] [a4510 b4510]
+		--assert 0 = system/reactivity/relations-count
+		clear-reactions
+
 
 ===end-group===
 

--- a/tests/source/units/reactivity-test.red
+++ b/tests/source/units/reactivity-test.red
@@ -7,8 +7,6 @@ Red [
 	License: "BSD-3 - https://github.com/red/red/blob/origin/BSD-3-License.txt"
 ]
 
-
-;#include %../../../environment/reactivity.red
 #include  %../../../quick-test/quick-test.red
 
 ~~~start-file~~~ "reactivity"

--- a/tests/source/units/reactivity-test.red
+++ b/tests/source/units/reactivity-test.red
@@ -223,8 +223,10 @@ Red [
 		--assert a3091/c = 2
 
 	--test-- "#4022"
-		a4022: make reactor! [i: repeat i 2 [i]]
-		--assert a4022/i = 2
+		do [											;@@ FIXME: compiler can't handle this - see comments in #1706
+			a4022: make reactor! [i: repeat i 2 [i]]
+			--assert a4022/i = 2
+		]
 
 	--test-- "#4166-1"
 		r4166: make reactor! [x: y: 1]

--- a/tests/source/units/reactivity-test.red
+++ b/tests/source/units/reactivity-test.red
@@ -7,6 +7,8 @@ Red [
 	License: "BSD-3 - https://github.com/red/red/blob/origin/BSD-3-License.txt"
 ]
 
+
+;#include %../../../environment/reactivity.red
 #include  %../../../quick-test/quick-test.red
 
 ~~~start-file~~~ "reactivity"
@@ -154,7 +156,7 @@ Red [
 		rf-6r: make reactor! [x: 1]
 		rf-6c: context [ x: is [rf-6r/x] ]
 		--assert 1 = system/reactivity/relations-count 		;-- should only be a single reaction
-		--assert rf-6r =? :system/reactivity/index/2/1 		;-- `rf-6r` should be the source object
+		--assert rf-6r =? :system/reactivity/reactions/2/1	;-- `rf-6r` should be the source object
 		unset [rf-6c rf-6r]
 
 	--test-- "rf-7"										;-- #3333 triple-reaction case
@@ -162,7 +164,7 @@ Red [
 		rf-7r: make reactor! [x: 1]
 		rf-7x: is [rf-7r/x]
 		--assert 1 = system/reactivity/relations-count 		;-- should only be a single reaction
-		--assert rf-7r = :system/reactivity/index/2/1 		;-- `rf-7r` should be the source object
+		--assert rf-7r = :system/reactivity/reactions/2/1	;-- `rf-7r` should be the source object
 		unset [rf-7r rf-7x]
 
 	--test-- "rf-8"										;-- correct path recognition


### PR DESCRIPTION
**TL;DR:** ~10x faster reactivity with O(1) complexity and multiple fixes here.

**Rationale.**

Since hash lookups are *very* cheap compared to Red token evaluation time, I decided to scratch the idea of putting relations into `on-change*` and use a central reactors index (hashtable). As I expected it's even faster than `select body-of :on-change* relations` approach I used before. Tests show further 20% speedup, but the number is not reliable as I'm on another PC which may have better optimized CPU cache.

**Performance**

Main source of speedup in this PR is avoiding O(n) lookup times by splitting the unstructured index into 2:
- `reactor [relations ...]`
- `reaction [source-objects ...]`

All operations become O(1) and it really scales.
You can see the benchmark results here: [for reactors](https://gist.github.com/hiiamboris/ad914d4e18c3e4400e8f0817bcda58e0), [for faces](https://gist.github.com/hiiamboris/5241fe596dfa05ec64659d16972cbddd) . I expect ~20-30% better timings with the fix for https://github.com/red/red/issues/4505 (it was fixed in this PR's snapshot).

There's still slight linearity O(n) for block reactions due to https://github.com/red/red/issues/4466 - once it is fixed I expect it to be nearly O(1) up to huge loads.

**Other notes**

Shallow reactors do not take ownership of assigned series anymore, so if some series is watched by a deep reactor, it can now safely be assigned to any number of shallow reactors

Objects not based on reactor! template can still use `reactivity/check` to embed themselves into reactivity framework (this part was also true in the original design)

I've also come to realize that `reactivity/check` should return blazingly fast for objects without relations.
E.g. in my Spaces project I'd like to make objects possibly reactive, but there may be thousands of objects, 99% of which won't be reactive, only a few top-level ones. And I need performance cost of adding reactivity on top of it to be negligible.
This implementation satisfies that need.

*Bonus* features are: better debugging output and the ability to collect statistics.

**Debugging** summary:
`system/reactivity/debug?` now can be:
- `off`/`none` to turn debug output off
- `true` or any other truthy value to turn it on for most interesting output, namely added, removed, skipped (most valuable!) and queued reactions
- `'full` (word) adds to `yes` a more extensive output: each fired reaction, checks for reactions, on-change events. Note: part of this output won't be shown in GUI console (as it'll crash with stack overflow). Use CLI console to see all the details.
- when it can find an object inside the global context, it will refer to it by word, not by the massive `object [....]` output, so it's much easier to tell what's what.

**Metering** summary:
- `system/reactivity/metrics?: true` turns on stats collection, `false` turns it off. Note: metering (when on) slows it down by ~20%, so use only when you need it.
- `system/reactivity/metrics/reset` zeroes all stats for a fresh start
- `system/reactivity/metrics/show` prints the full statistics, e.g.:
```
***** REACTIVITY METRICS REPORT *****
Metrics collection enabled?: true
Statistical counts:
    events triggered:    80015
    reactions fired:     50000 (immediately: 25005 , queued: 24995 )
    reactions skipped:   0
Time spent in reactions: 0:00:00
Time spent in reactivity:
    total:               0:00:09.55855
    adding relations:    0:00:03.80822 (preparations: 0:00:00.901052 )
    removing relations:  0:00:00.843048
    dispatching:         0:00:04.90728
    longest queue flush: 0:00:00.0020001
Peak values:
    maximum queue size:  5000
    maximum index size:  5000
    biggest relation:    2 reactors
    most used reactor:   5000 relations
```

I also made `is` much smarter:
https://github.com/red/red/blob/a77d72c37f55805b1122ccfee0c2046552081358/environment/reactivity.red#L302-L309

I have a lot of notes on pitfalls, tricks. If this PR gets approved, I will write them down to a wiki.

And along the way:
Fixes #4510, fixes #4507, fixes #4471, fixes #4176, fixes #4166, grants wish [REP#75](https://github.com/red/REP/issues/75)
