### PR TITLE
FIX: leaking OS handle eats memory when converting face to image

### DIFF
--- a/modules/view/backends/windows/gui.reds
+++ b/modules/view/backends/windows/gui.reds
@@ -2641,7 +2641,7 @@ OS-to-image: func [
 		img: image/init-image as red-image! stack/push* as int-ptr! bitmap
 	]
 
-    if screen? [DeleteDC mdc]				;-- we delete it in Draw when print window
+    DeleteDC mdc
     DeleteObject bmp
     unless screen? [ReleaseDC hWnd dc]
 	img


### PR DESCRIPTION
This line is leaking memory on W7 in the branch https://github.com/red/red/pull/4300 where images are garbage collected
https://github.com/red/red/blob/master/modules/view/backends/windows/gui.reds#L2644

It comes from [this commit](https://github.com/red/red/commit/32c7f24c114919bdfc6bc3ebb442d941ce167ddf) which is quite old. I can't tell at a glance if Draw can delete this DC during WM_PAINT (what a mess!), but:
- draw only gets called for non-layered `base` (and I guess `rich-text`) face: see [here](https://github.com/red/red/blob/48eb6f749d731806fe7322a7bf2af160de718ecc/modules/view/backends/windows/base.reds#L487). Even then it's totally unclear if *all* branches will delete it. Even if they do, I suggest we decisively get rid of such non-locality as a primary source of bugs.
- W7 *requires* memory DC to *not* be destroyed in Draw [(see this line)](https://github.com/red/red/blob/48eb6f749d731806fe7322a7bf2af160de718ecc/modules/view/backends/windows/gui.reds#L2633)
- it won't hurt to try to delete DC twice anyway ☻
