### PR TITLE
TESTS: float-test.red - issue #4250

### DIFF
--- a/tests/source/units/float-test.red
+++ b/tests/source/units/float-test.red
@@ -415,6 +415,10 @@ Red [
 		]
 		--assert 3.14 = fabs -3.14
 
+	--test-- "issue #4250"
+		--assert error?     try [to float! "12e"]
+		--assert not error? try [to float! "12e4"]
+
 ===end-group===
 
 ===start-group=== "almost equal"


### PR DESCRIPTION
Tests for expected:
```
>> to float! "12e"
*** Script Error: cannot MAKE/TO float from: 12e
*** Where: to
*** Stack:
```
(Throws error rather than crashes)