### PR TITLE
TESTS: regression-test-red.red - issue #4119

### DIFF
--- a/tests/source/units/lexer-test.red
+++ b/tests/source/units/lexer-test.red
@@ -734,8 +734,10 @@ Red [
 	--test-- "scan-68" --assert none!	 = scan "#[none]"
 	--test-- "scan-69" --assert integer! = scan "#[integer!]"
 	--test-- "scan-70" --assert error!	 = scan "#[int!]"
-	--test-- "scan-71"  --assert refinement! = scan "/v:"
-	--test-- "scan-72"  --assert refinement! = scan "/value:"
+	--test-- "scan-71" --assert refinement! = scan "/v:"
+	--test-- "scan-72" --assert refinement! = scan "/value:"
+	--test-- "scan-73" --assert error!   = scan "$non"
+	--test-- "scan-74" --assert error!   = scan "\non"
 
 ===end-group===
 ===start-group=== "scan/fast"

--- a/tests/source/units/regression-test-red.red
+++ b/tests/source/units/regression-test-red.red
@@ -2853,20 +2853,6 @@ comment {
 		--assert tail? next next next next i4056
 		--assert tail? next back next tail i4056
 
-	--test-- "#4119"
-		word-money-4119:  try [load {$non}]
-		block-money-4119: try [load {[$non]}]
-		--assert to-logic find to-string word-money-4119 "(line 1) invalid money at $non"
-		--assert to-logic find to-string block-money-4119 "(line 1) invalid money at $non]"
-		word-slash-4119:  try [load {\non}]
-		block-slash-4119: try [load {[\non]}]
-		--assert to-logic find to-string word-slash-4119 "(line 1) invalid character at \non"
-		--assert to-logic find to-string block-slash-4119 "(line 1) invalid character at \non]"
-		unset [
-			word-money-4119 block-money-4119 
-			word-slash-4119 block-slash-4119
-		]
-
 	--test-- "#4205 - seed random with precise time!"
 		anded4205: to integer! #{FFFFFFFF}
 		loop 10 [

--- a/tests/source/units/regression-test-red.red
+++ b/tests/source/units/regression-test-red.red
@@ -2853,6 +2853,20 @@ comment {
 		--assert tail? next next next next i4056
 		--assert tail? next back next tail i4056
 
+	--test-- "#4119"
+		word-money-4119:  try [load {$non}]
+		block-money-4119: try [load {[$non]}]
+		--assert to-logic find to-string word-money-4119 "(line 1) invalid money at $non"
+		--assert to-logic find to-string block-money-4119 "(line 1) invalid money at $non]"
+		word-slash-4119:  try [load {\non}]
+		block-slash-4119: try [load {[\non]}]
+		--assert to-logic find to-string word-slash-4119 "(line 1) invalid character at \non"
+		--assert to-logic find to-string block-slash-4119 "(line 1) invalid character at \non]"
+		unset [
+			word-money-4119 block-money-4119 
+			word-slash-4119 block-slash-4119
+		]
+
 	--test-- "#4205 - seed random with precise time!"
 		anded4205: to integer! #{FFFFFFFF}
 		loop 10 [


### PR DESCRIPTION
Expected:
```
>> [$non]
*** Syntax Error: (line 1) invalid money at $non]
*** Where: case
*** Stack: load 
```
(As opposed to a less readable error)