### PR TITLE
FIX: quick-test typo in code handling --binary

### DIFF
--- a/run-all.r
+++ b/run-all.r
@@ -40,7 +40,7 @@ if args  [
 		bin-compiler: select args "--binary"
 		if any [
 			bin-compiler = "--batch"
-			bin-complier = "--each"
+			bin-compiler = "--each"
 		][
 			bin-compiler: none								;; use default
 		]


### PR DESCRIPTION
Using this command:

```
rebol -qs run-all.r --binary <path-to-compiler>
```

for running the quick-test framework resulted in this error:

```
** Script Error: bin-complier has no value
** Near: if any [
    bin-compiler = "--batch" 
    bin-complier = "--each"
] [
    bin-compiler: none
]
```

on account of a small typo.