### PR TITLE
 FIX: issue #4591 (PARSE 0 0 <value> matches one value).

### DIFF
--- a/runtime/parse.reds
+++ b/runtime/parse.reds
@@ -1301,8 +1301,11 @@ parser: context [
 							if all [upper? int2/value < 0][
 								PARSE_ERROR [TO_ERROR(script out-of-range) int2]
 							]
-							state: either all [zero? int/value not upper?][
-								cmd: cmd + 1			;-- skip over sub-rule
+							state: either all [
+								zero? int/value
+								any [not upper? zero? int2/value]
+							][
+								cmd: cmd + 1 + as integer! upper?		;-- skip over sub-rule
 								ST_CHECK_PENDING
 							][
 								min:  int/value

--- a/tests/source/units/parse-test.red
+++ b/tests/source/units/parse-test.red
@@ -2742,7 +2742,16 @@ Red [
 		--assert error? try [parse [][copy x4318]]
 		--assert error? try [parse [][set x4318]]
 		--assert zero? x4318
-
+	
+	--test-- "#4591"
+		--assert not parse " " [0 0 space]
+		--assert not parse [x] [0 0 'x]
+		
+		--assert parse [][0 0 "ignore me"]
+		--assert parse [][0 0 [ignore me]]
+		--assert parse [][0   "ignore me"]
+		--assert parse [][0   [ignore me]]
+	
 ===end-group===
     
 ~~~end-file~~~


### PR DESCRIPTION
Fixes #4591 by extending the relevant conditional check in `ST_DO_ACTION` branch: prior to the fix it countered only the `0 <rule>` case by jumping over the sub-rule.† Tests are provided.

An interesting realization coming from this PR is that `0` can act as an ad-hoc comment construct in Parse rules, sort of:
```red
comment: 0
parse "Ratsnake" [to end comment "four claps - You did it!"]
```

† Which should be a single value (see #3679).