### PR TITLE
FIX: issue #4574 (Remainder raises errors where should return a NaN).

### DIFF
--- a/runtime/datatypes/float.reds
+++ b/runtime/datatypes/float.reds
@@ -241,6 +241,7 @@ float: context [
 				]
 			]
 			OP_REM [
+				if any [left = -INF left = +INF right = 0.0][return QNaN]	;-- issue #4574
 				either all [0.0 = right not NaN? right][
 					fire [TO_ERROR(math zero-divide)]
 					0.0									;-- pass the compiler's type-checking

--- a/tests/source/units/float-test.red
+++ b/tests/source/units/float-test.red
@@ -447,6 +447,11 @@ Red [
 	--test-- "special-arithmetic-10" --assert "1.#NaN"  = to string! 1.#INF / 1.#INF
 	--test-- "special-arithmetic-11" --assert "1.#NaN"  = to string! 0.0 * 1.#INF
 	--test-- "special-arithmetic-12" --assert "1.#INF"  = to string! 1e308 + 1e308
+	;-- issue #4574
+	--test-- "special-arithmetic-13" --assert "1.#NaN"  = to string! 1.0 % 0.0
+	--test-- "special-arithmetic-14" --assert "1.#NaN"  = to string! 1.#inf % 1.0
+	--test-- "special-arithmetic-15" --assert "1.#NaN"  = to string! -1.#inf % 1.0
+	--test-- "special-arithmetic-16" --assert "1.#NaN"  = to string! 1.#inf % 0.0
 ===end-group===
 
 ===start-group=== "special value equality (NaNs and INF)"


### PR DESCRIPTION
Fixes #4574 by implementing the QNaN behavior proposed in the ticket. `float!` test suite is extended to cover the relevant `x % y` cases.

The fix covers only operations between `number!` values that can be casted to `float!`, things like ↓ are still there (and should stay there IMO, as the behavior is very datatype-specific):
```red
>> 1.2.3 % 0.0
== 0.0.0
>> 1x2 % 0.0
*** Math Error: attempt to divide by zero
*** Where: %
*** Stack:  
>> 0:0 % 0.0
== --2147483648:-2147483648:00 ; #3418 ?
```