### PR TITLE
FIX: issue #734 (lit-word variables decay to word when evaluated).

### DIFF
--- a/compiler.r
+++ b/compiler.r
@@ -405,7 +405,7 @@ red: context [
 	]
 	
 	emit-push-word: func [name [any-word!] original [any-word!] /local type ctx obj][
-		type: to word! form type? name
+		type: to word! form type? :name
 		name: to word! :name
 		
 		either all [

--- a/tests/source/units/regression-test-red.red
+++ b/tests/source/units/regression-test-red.red
@@ -828,7 +828,14 @@ Red [
 		parse "a" [collect rule727]
 		--assert equal? 1 x727
 		unset 'x727
-
+	
+	--test-- "#734"
+		foo: quote 'bar
+		--assert lit-word? quote 'bar
+		--assert lit-word? foo
+		--assert lit-word? :foo
+		unset 'foo
+		
 	--test-- "#757"
 		--assert not error? try [x757: "^(FF)"]
 		unset 'x757


### PR DESCRIPTION
Fixes #734 and provides a regression test. Regression itself occurred 7 years ago after refactoring of `emit-push-word` in https://github.com/red/red/commit/2b1ec3072f35f8690f4142845c7321ef98f12b50.

https://github.com/red/red/blob/02776dcf50c085b3fe9c207df88bdaceb8c5b3c0/compiler.r#L408

Innocently-looking line coupled with Rebol2 shenanigans is surely a recipe for disaster:
```rebol
>> rebol/version
== 2.7.8.3.1
>> foo: quote 'bar
== 'bar
>> reduce [:foo foo]
== ['bar bar]
```
So, in the line above, even though `name` is set to `lit-word!`, fetching it without using `get-word!` decays said `lit-word!` to `word!`, which in turn leads to an incorrectly inferred type.