### PR TITLE
FIX: issue #4153 ([Parse] odd behavior of INSERT).

### DIFF
--- a/runtime/parse.reds
+++ b/runtime/parse.reds
@@ -810,6 +810,7 @@ parser: context [
 			saved	 [integer!]
 			before   [integer!]
 			fun-locs [integer!]
+			delta    [integer!]
 			upper?	 [logic!]
 			end?	 [logic!]
 			ended?	 [logic!]
@@ -824,7 +825,6 @@ parser: context [
 			done?	 [logic!]
 			saved?	 [logic!]
 			gc-saved [logic!]
-			word?    [logic!]
 	][
 		match?:	  yes
 		end?:	  no
@@ -1625,49 +1625,43 @@ parser: context [
 								TYPE_OF(w) = TYPE_WORD
 								words/only = symbol/resolve w/symbol
 							]
-							cmd: cmd + max
-							value: cmd + 1
-							if value >= tail [PARSE_ERROR [TO_ERROR(script parse-end) words/_insert]]
+							cmd: cmd + max + 1			;-- jump over optional ONLY
+							if cmd >= tail [PARSE_ERROR [TO_ERROR(script parse-end) words/_insert]]
 							
 							s-top: null
 							saved: input/head
-							word?: TYPE_OF(value) = TYPE_WORD
-							either word? [
-								new: as red-series! _context/get as red-word! value
+							
+							if TYPE_OF(cmd) = TYPE_WORD [
+								new: as red-series! _context/get as red-word! cmd
 								if all [TYPE_OF(new) = TYPE_OF(input) new/node = input/node][
-									cmd: value + 1		;-- INSERT position
-									if cmd >= tail [PARSE_ERROR [TO_ERROR(script parse-rule) words/_insert]]
-									switch TYPE_OF(cmd) [
-										TYPE_PAREN [
-											s-top: stack/top
-											value: eval cmd no saved?
-											PARSE_TRACE(_paren)
-										]
-										TYPE_WORD [
-											value: _context/get as red-word! cmd
-											if TYPE_OF(value) = TYPE_UNSET [
-												PARSE_ERROR [TO_ERROR(script no-value) cmd]
-											]
-										]
-										default	  [value: cmd]
-									]
+									cmd: cmd + 1		;-- INSERT position
 									input/head: new/head
 								]
-							][
-								cmd: value
-								if TYPE_OF(value) = TYPE_PAREN [
-									s-top: stack/top
-									value: eval value no saved?
-									PARSE_TRACE(_paren)
+								if cmd >= tail [
+									PARSE_ERROR [TO_ERROR(script parse-rule) words/_insert]
 								]
 							]
+							
+							switch TYPE_OF(cmd) [
+								TYPE_PAREN [
+									s-top: stack/top
+									value: eval cmd no saved?
+									PARSE_TRACE(_paren)
+								]
+								TYPE_WORD [
+									value: _context/get as red-word! cmd
+									if TYPE_OF(value) = TYPE_UNSET [
+										PARSE_ERROR [TO_ERROR(script no-value) cmd]
+									]
+								]
+								default [value: cmd]
+							]
+							
 							PARSE_SAVE_SERIES
 							before: input/head
-							if all [word? TYPE_OF(value) = TYPE_WORD][
-								value: _context/get as red-word! value
-							]
 							actions/insert input value null as-logic max null no
-							input/head: saved + (input/head - before)
+							delta: either before > saved [0][input/head - before]
+							input/head: saved + delta	;-- position might have shifted after insertion
 							if s-top <> null [stack/top: s-top]
 							PARSE_RESTORE_SERIES
 							state: ST_NEXT_ACTION

--- a/runtime/parse.reds
+++ b/runtime/parse.reds
@@ -1643,6 +1643,7 @@ parser: context [
 							]
 							
 							switch TYPE_OF(cmd) [
+								TYPE_PATH [PARSE_ERROR [TO_ERROR(script parse-rule) cmd]]
 								TYPE_PAREN [
 									s-top: stack/top
 									value: eval cmd no saved?

--- a/tests/source/units/parse-test.red
+++ b/tests/source/units/parse-test.red
@@ -597,7 +597,13 @@ Red [
 			| insert only mark letters insert mark letters 'a 'b 'c 'x 'y 'z block!
 		]
 		--assert series == [a b c x y z [x y z]]
-		
+	
+	--test-- "blk-ins 11"
+		series: [b]
+		digit:  2
+		--assert parse series [insert digit 'b]
+		--assert series == [2 b]
+	
 	--test-- "blk-chg1"
 		--assert parse blk: [1][change integer! 'a]
 		--assert blk = [a]

--- a/tests/source/units/parse-test.red
+++ b/tests/source/units/parse-test.red
@@ -564,7 +564,40 @@ Red [
 	--test-- "blk-ins5"	
 		--assert parse blk: [] [insert only [a b]]
 		--assert blk = [[a b]]
-
+	
+	--test-- "blk-ins6"
+		series: [a b c]
+		letter: 'x
+		--assert parse series [insert letter 'a 'b 'c]
+		--assert series == [x a b c]
+	
+	--test-- "blk-ins7"
+		series:  [a b c]
+		letters: [x y z]
+		--assert parse series ['a 'b insert letters insert only letters 'c]
+		--assert series == [a b x y z [x y z] c]
+	
+	--test-- "blk-ins8"
+		series:  [a b c]
+		letters: [x y z]
+		--assert parse series [mark: 'a insert mark letters insert only mark letters 'b 'c]
+		--assert series == [[x y z] x y z a b c]
+	
+	--test-- "blk-ins9"
+		series: [a b c]
+		letter: 'x
+		--assert parse series [mark: insert (letter) 'a 'b insert only mark (letter) 'c]
+		--assert series == [x x a b c]
+	
+	--test-- "blk-ins10"
+		series:  [a b c]
+		letters: [x y z]
+		--assert parse series [
+			to end mark: [fail]
+			| insert only mark letters insert mark letters 'a 'b 'c 'x 'y 'z block!
+		]
+		--assert series == [a b c x y z [x y z]]
+		
 	--test-- "blk-chg1"
 		--assert parse blk: [1][change integer! 'a]
 		--assert blk = [a]
@@ -1467,6 +1500,35 @@ Red [
 		--assert parse str: "test" [some [skip p: insert #"_"] :p remove skip]
 		--assert str = "t_e_s_t"
 
+	--test-- "str-ins5"
+		series: "abc"
+		--assert parse series ["a" mark: "b" insert mark space insert space "c"]
+		--assert series == "a b c"
+
+	--test-- "str-ins6"
+		series: "abc"
+		--assert parse series [
+			mark: "abc" insert only mark space mark: [fail]
+			| insert only mark space [space "abc" space]
+		]
+		--assert series == " abc "
+	
+	--test-- "str-ins7"
+		series: "abc"
+		--assert parse series [
+			insert space
+			insert only space "a"
+			insert (space)
+			insert only (space) "b"
+			mark: insert only mark space
+			mark: insert only mark (space) "c"
+			mark: [fail] |
+			insert mark space
+			insert only mark space
+			[2 space "a" 2 space "b" 2 space "c" 2 space]
+		]
+		--assert series == "  a  b  c  "
+	
 	--test-- "str-chg1"
 		--assert parse str: "1" [change skip #"a"]
 		--assert str = "a"
@@ -2724,7 +2786,7 @@ Red [
 
 	--test-- "#3951"
 		res: none
-		do "res: expand-directives/clean [[] #macro word! func [s e]['OK] WTF]()"
+		do "res: expand-directives/clean [[] #macro word! func [s e]['OK] WTF #reset]()"
 		--assert res = [[] OK]
 
 	--test-- "#3427"

--- a/tests/source/units/parse-test.red
+++ b/tests/source/units/parse-test.red
@@ -2804,6 +2804,8 @@ Red [
 	--test-- "#4101"
 		--assert parse [a/b] ['a/b]
 		--assert error? try [parse [a/b] [a/b]]
+		
+		--assert error? try [parse [c d][insert a/b 2 word!]]
 
 	--test-- "#4318"
 		x4318: 0


### PR DESCRIPTION
Fixes #4153 by rewriting the logic of `insert` rule from scratch and provides relevant tests. Parse documentation is also updated: https://github.com/red/docs/pull/241. Also partially fixes #4101 as a follow-up to https://github.com/red/red/pull/4620.

As it turns out, `insert` supported a positional mode (like `remove` and `change`) where it can insert value at previously marked position instead of the current one. This mode was never properly implemented, however, and there were several oversights inside `insert`'s logic: both of these factors contributed to the reported issue.

Here, for example, `insert` scans the value in rule block to check if it's an input position: and if it is, then `cmd` pointer is properly updated.
https://github.com/red/red/blob/e01760493eaac0c1f5dee7cb8e9149b859fc685c/runtime/parse.reds#L1634-L1638

But if `word!` is not an input position, then `cmd` is retained, which means that this `word!` suddenly turns into a Parse rule which gets applied right after insertion; this explains the case like this one:
```red
>> x: 2  probe parse s: [y y][insert x 'y]  s
true ; not false
== [2 y y]
```
`2` was inserted, and then treated as a rule `2 'y`.

Further down the line `value` is re-fetched second time.
https://github.com/red/red/blob/e01760493eaac0c1f5dee7cb8e9149b859fc685c/runtime/parse.reds#L1666-L1668

In normal mode that's OK since the first fetch never took place, but in positional mode this results in
```red
>> x: 'y  y: 'z  probe parse s: [b c][insert s x 'b 'c]  s
true
== [z b c] ; not [x b c]
```

Finally, after insertion, the input position wasn't properly restored
https://github.com/red/red/blob/e01760493eaac0c1f5dee7cb8e9149b859fc685c/runtime/parse.reds#L1669-L1670

This counters only the case where insertion happened before or at the current position, by adding up to `saved` series index the number of elements inserted — this compensates for a "shift" in elements, as in:
```red
>> s: [a b c d]
== [a b c d]
>> x: at s 3
== [c d]
>> insert s 'y
== [a b c d]
>> x
== [b c d] ; shift by 1
```
But if insertion happened after current position, then input will be shifted forward when it should stay unmodified:
```red
>> parse [a b c][to end mark: [fail] | insert mark [x y] here: (probe here) to end]
[c x y] ; not [a b c x y]
== true
````