### PR TITLE
FEAT: grant wish #3004 (/SKIP refinement for REVERSE).

### DIFF
--- a/environment/actions.red
+++ b/environment/actions.red
@@ -422,6 +422,8 @@ reverse: make action! [[
 		series	 [series! port! pair! tuple!]
 		/part "Limits to a given length or position"
 			length [number! series!]
+		/skip "Treat the series as fixed size records"
+			size [integer!]
 		return:  [series! port! pair! tuple!]
 	]
 	#get-definition ACT_REVERSE

--- a/runtime/actions.reds
+++ b/runtime/actions.reds
@@ -1284,15 +1284,18 @@ actions: context [
 
 	reverse*: func [
 		part [integer!]
+		skip [integer!]
 	][
 		reverse
 			as red-series! stack/arguments
 			stack/arguments + part
+			stack/arguments + skip
 	]
 
 	reverse: func [
 		series  [red-series!]
 		part	[red-value!]
+		skip    [red-value!]
 		return:	[red-value!]
 		/local
 			action-reverse
@@ -1302,10 +1305,11 @@ actions: context [
 		action-reverse: as function! [
 			series	[red-series!]
 			part	[red-value!]
+			skip    [red-value!]
 			return:	[red-value!]
 		] get-action-ptr as red-value! series ACT_REVERSE
 
-		action-reverse series part
+		action-reverse series part skip
 	]
 	
 	select*: func [

--- a/runtime/datatypes/pair.reds
+++ b/runtime/datatypes/pair.reds
@@ -424,6 +424,7 @@ pair: context [
 	reverse: func [
 		pair	[red-pair!]
 		part	[red-value!]
+		skip    [red-value!]
 		return:	[red-value!]
 		/local
 			tmp [integer!]

--- a/runtime/datatypes/port.reds
+++ b/runtime/datatypes/port.reds
@@ -552,6 +552,7 @@ port: context [
 	reverse: func [
 		port	[red-object!]
 		part	[red-value!]
+		skip    [red-value!]
 		return: [red-value!]
 		/local
 			actors [red-object!]

--- a/runtime/datatypes/series.reds
+++ b/runtime/datatypes/series.reds
@@ -878,6 +878,7 @@ _series: context [
 	reverse: func [
 		ser	 	 [red-series!]
 		part-arg [red-value!]
+		skip-arg [red-value!]
 		return:	 [red-series!]
 		/local
 			s		[series!]

--- a/runtime/datatypes/series.reds
+++ b/runtime/datatypes/series.reds
@@ -935,7 +935,7 @@ _series: context [
 		
 		skip?: OPTION?(skip-arg)
 		if skip? [
-			assert TYPE_OF(skip-arg) = TYPE_INTEGER
+			unless TYPE_OF(skip-arg) = TYPE_INTEGER [ERR_INVALID_REFINEMENT_ARG(refinements/_skip skip-arg)]
 			int:  as red-integer! skip-arg
 			skip: int/value								;-- 1/2 of series length max
 			

--- a/runtime/datatypes/tuple.reds
+++ b/runtime/datatypes/tuple.reds
@@ -623,17 +623,23 @@ tuple: context [
 		return:	 [red-value!]
 		/local
 			int  [red-integer!]
+			temp [red-value! value]						;-- enough to hold max tuple (payload)
 			part [integer!]
 			tmp  [byte!]
 			size [integer!]
+			skip [integer!]
 			n	 [integer!]
 			tp   [byte-ptr!]
+			head [byte-ptr!]
+			tail [byte-ptr!]
 	][
 		#if debug? = yes [if verbose > 0 [print-line "tuple/reverse"]]
 
-		tp: (as byte-ptr! tuple) + 4
+		tp:   as byte-ptr! :tuple/array1
 		size: TUPLE_SIZE?(tuple)
 		part: size
+		skip: 1
+		
 		if OPTION?(part-arg) [
 			either TYPE_OF(part-arg) = TYPE_INTEGER [
 				int: as red-integer! part-arg
@@ -645,16 +651,43 @@ tuple: context [
 				ERR_INVALID_REFINEMENT_ARG(refinements/_part part-arg)
 			]
 		]
+		
+		if OPTION?(skip-arg) [
+			unless TYPE_OF(skip-arg) = TYPE_INTEGER [ERR_INVALID_REFINEMENT_ARG(refinements/_skip skip-arg)]
+			int:  as red-integer! skip-arg
+			skip: int/value								;-- 1/2 of tuple size max
+			
+			if skip = part [return as red-value! tuple]	;-- early exit if nothing to reverse
+			if skip <= 0 [fire [TO_ERROR(script out-of-range) skip-arg]]
+			if any [skip > part part % skip <> 0][ERR_INVALID_REFINEMENT_ARG(refinements/_skip skip-arg)]
+		]
 
 		if part < size [size: part]
-		n: 1
-		while [n < size] [
-			tmp: tp/n
-			tp/n: tp/size
-			tp/size: tmp
-			n: n + 1
-			size: size - 1
+		
+		either skip = 1 [								;-- faster branch for general case
+			n: skip
+			while [n < size][
+				tmp: tp/n
+				tp/n: tp/size
+				tp/size: tmp
+				n: n + 1
+				size: size - 1
+			]
+		][
+			head: tp
+			tail: head + size - skip
+			tp:   as byte-ptr! :temp
+			
+			while [head < tail][
+				copy-memory tp   head skip
+				copy-memory head tail skip
+				copy-memory tail tp   skip
+				
+				head: head + skip
+				tail: tail - skip
+			]
 		]
+		
 		as red-value! tuple
 	]
 

--- a/runtime/datatypes/tuple.reds
+++ b/runtime/datatypes/tuple.reds
@@ -619,6 +619,7 @@ tuple: context [
 	reverse: func [
 		tuple	 [red-tuple!]
 		part-arg [red-value!]
+		skip-arg [red-value!]
 		return:	 [red-value!]
 		/local
 			int  [red-integer!]

--- a/tests/source/units/all-tests.txt
+++ b/tests/source/units/all-tests.txt
@@ -41,6 +41,7 @@ map-test.red
 pair-test.red
 date-test.red
 time-test.red
+tuple-test.red
 convert-test.red
 checksum-test.red
 reactivity-test.red

--- a/tests/source/units/series-test.red
+++ b/tests/source/units/series-test.red
@@ -1120,6 +1120,7 @@ Red [
 	--test-- "reverse/skip-1"
 		--assert error? try [reverse/skip [0]   0]
 		--assert error? try [reverse/skip [-1] -1]
+		--assert error? try [reverse/skip ["1"] "1"]
 	
 	--test-- "reverse/skip-2"
 		--assert error? try [reverse/skip [1 2 3] 2]

--- a/tests/source/units/series-test.red
+++ b/tests/source/units/series-test.red
@@ -1116,6 +1116,51 @@ Red [
 
 ===end-group===
 
+===start-group=== "reverse/skip"
+	--test-- "reverse/skip-1"
+		--assert error? try [reverse/skip [0]   0]
+		--assert error? try [reverse/skip [-1] -1]
+	
+	--test-- "reverse/skip-2"
+		--assert error? try [reverse/skip [1 2 3] 2]
+		--assert error? try [reverse/skip [1 2 3] 4]
+	
+	--test-- "reverse/skip-3"
+		--assert error? try [reverse/skip/part [a b c d e f] 6 2]
+		--assert error? try [reverse/skip/part [a b c d e f] 3 4]
+	
+	--test-- "reverse/skip-4"
+		--assert [a b c] == reverse/skip [a b c] 3
+		--assert <abc>   == reverse/skip <abc> 3
+		
+	--test-- "reverse/skip-5"
+		series: make vector! [integer! 16 [1 2 3 4]]
+		reverse/skip series 2
+		--assert series == make vector! [integer! 16 [3 4 1 2]]
+	
+	--test-- "reverse/skip-6"
+		series: make hash! [#"a" #"b" #"c" #"d"]
+		reverse/skip series 2
+		--assert series == make hash! [#"c" #"d" #"a" #"b"]
+	
+	--test-- "reverse/skip-7"
+		--assert [d e f a b c] == reverse/skip [a b c d e f] 3
+		--assert [e f c d a b] == reverse/skip [a b c d e f] 2
+		--assert [f e d c b a] == reverse/skip [a b c d e f] 1
+	
+	--test-- "reverse/skip-8"
+		--assert "🍇🍏🍑🍒🍉🍊🍌🍎" == reverse/skip "🍉🍊🍌🍎🍇🍏🍑🍒" 4
+		--assert "🍑🍒🍇🍏🍌🍎🍉🍊" == reverse/skip "🍉🍊🍌🍎🍇🍏🍑🍒" 2
+		--assert "🍒🍑🍏🍇🍎🍌🍊🍉" == reverse/skip "🍉🍊🍌🍎🍇🍏🍑🍒" 1
+	
+	--test-- "reverse/skip-9"
+		--assert [c d a b e f g h] == reverse/skip/part [a b c d e f g h] 2 4
+	
+	--test-- "reverse/skip-10"
+		series: <abcdefgh>
+		--assert <abefcdgh> == head reverse/part/skip skip series 2 skip series 6 2
+===end-group===
+
 ===start-group=== "take"
 
 	--test-- "take-blk-1"

--- a/tests/source/units/series-test.red
+++ b/tests/source/units/series-test.red
@@ -1142,6 +1142,10 @@ Red [
 		series: make hash! [#"a" #"b" #"c" #"d"]
 		reverse/skip series 2
 		--assert series == make hash! [#"c" #"d" #"a" #"b"]
+		--assert #"d" == series/(#"c")
+		--assert #"a" == select series #"d"
+		--assert #"b" == last series
+		--assert head? find series #"c"
 	
 	--test-- "reverse/skip-7"
 		--assert [d e f a b c] == reverse/skip [a b c d e f] 3
@@ -1159,6 +1163,11 @@ Red [
 	--test-- "reverse/skip-10"
 		series: <abcdefgh>
 		--assert <abefcdgh> == head reverse/part/skip skip series 2 skip series 6 2
+	
+	--test-- "reverse/skip-11"
+		--assert strict-equal?
+			reverse <abc>
+			reverse/skip <abc> 1
 ===end-group===
 
 ===start-group=== "take"

--- a/tests/source/units/tuple-test.red
+++ b/tests/source/units/tuple-test.red
@@ -12,50 +12,50 @@ Red [
 ~~~start-file~~~ "tuple"
 
 ===start-group=== "reverse"
-	--test-- "reverse-*"
+	--test-- "reverse-1"
 		--assert 3.2.1 == reverse 1.2.3
 
-	--test-- "reverse-*"
+	--test-- "reverse-2"
 		tuple: 1.2.3
 		reverse tuple
 		--assert 1.2.3 == tuple						;-- not reversed in-place
 	
-	--test-- "reverse-*"
+	--test-- "reverse-3"
 		tuple: reverse reverse 1.2.3.4.5.6.7.8.9.10.11.12
 		--assert 1.2.3.4.5.6.7.8.9.10.11.12 == tuple
 	
-	--test-- "reverse-*"
+	--test-- "reverse-4"
 		--assert 4.3.2.1 == reverse/part 1.2.3.4 4
 		--assert 3.2.1.4 == reverse/part 1.2.3.4 3
 		--assert 2.1.3.4 == reverse/part 1.2.3.4 2
 		--assert 1.2.3.4 == reverse/part 1.2.3.4 1
 		--assert 1.2.3.4 == reverse/part 1.2.3.4 0	;@@ should rather be forbidden?
 	
-	--test-- "reverse-*"
+	--test-- "reverse-5"
 		--assert error? try [reverse/part 1.2.3 -1]
 	
-	--test-- "reverse-*"
+	--test-- "reverse-6"
 		--assert error? try [reverse/skip/part 1.2.3.4.5.6 4 2]
 		--assert error? try [reverse/skip/part 1.2.3.4.5.6 3 4]
 	
-	--test-- "reverse-*"
+	--test-- "reverse-7"
 		--assert error? try [reverse/skip 1.2.3 0]
 		--assert error? try [reverse/skip 1.2.3 -1]
 		--assert error? try [reverse/skip 1.2.3 "4"]
 	
-	--test-- "reverse-*"
+	--test-- "reverse-8"
 		--assert error? try [reverse/skip 1.2.3 4]
 	
-	--test-- "reverse-*"
+	--test-- "reverse-9"
 		--assert 3.4.1.2.5.6 == reverse/skip/part 1.2.3.4.5.6 2 4
 		--assert 2.1.3.4.5.6 == reverse/skip/part 1.2.3.4.5.6 1 2
 	
-	--test-- "reverse-*"
+	--test-- "reverse-10"
 		--assert 4.5.6.1.2.3 == reverse/skip 1.2.3.4.5.6 3
 		--assert 5.6.3.4.1.2 == reverse/skip 1.2.3.4.5.6 2
 		--assert 6.5.4.3.2.1 == reverse/skip 1.2.3.4.5.6 1
 	
-	--test-- "reverse-*"
+	--test-- "reverse-11"
 		--assert 5.6.3.4.1.2.7.8.9.10.11.12 == reverse/skip/part 1.2.3.4.5.6.7.8.9.10.11.12 2 6
 		--assert 1.2.3.4.5.6.7.8.9.10.11.12 == reverse/skip/part 1.2.3.4.5.6.7.8.9.10.11.12 4 4
 		--assert 7.8.9.10.11.12.1.2.3.4.5.6 == reverse/skip/part 1.2.3.4.5.6.7.8.9.10.11.12 6 12

--- a/tests/source/units/tuple-test.red
+++ b/tests/source/units/tuple-test.red
@@ -1,0 +1,67 @@
+Red [
+	Title:   "Red tuple! datatype test script"
+	Author:  "Vladimir Vasilyev"
+	File: 	 %tuple-test.red
+	Tabs:	 4
+	Rights:  "Copyright (C) 2020 Red Foundation. All rights reserved."
+	License: "BSD-3 - https://github.com/red/red/blob/origin/BSD-3-License.txt"
+]
+
+#include  %../../../quick-test/quick-test.red
+
+~~~start-file~~~ "tuple"
+
+===start-group=== "reverse"
+	--test-- "reverse-*"
+		--assert 3.2.1 == reverse 1.2.3
+
+	--test-- "reverse-*"
+		tuple: 1.2.3
+		reverse tuple
+		--assert 1.2.3 == tuple						;-- not reversed in-place
+	
+	--test-- "reverse-*"
+		tuple: reverse reverse 1.2.3.4.5.6.7.8.9.10.11.12
+		--assert 1.2.3.4.5.6.7.8.9.10.11.12 == tuple
+	
+	--test-- "reverse-*"
+		--assert 4.3.2.1 == reverse/part 1.2.3.4 4
+		--assert 3.2.1.4 == reverse/part 1.2.3.4 3
+		--assert 2.1.3.4 == reverse/part 1.2.3.4 2
+		--assert 1.2.3.4 == reverse/part 1.2.3.4 1
+		--assert 1.2.3.4 == reverse/part 1.2.3.4 0	;@@ should rather be forbidden?
+	
+	--test-- "reverse-*"
+		--assert error? try [reverse/part 1.2.3 -1]
+	
+	--test-- "reverse-*"
+		--assert error? try [reverse/skip/part 1.2.3.4.5.6 4 2]
+		--assert error? try [reverse/skip/part 1.2.3.4.5.6 3 4]
+	
+	--test-- "reverse-*"
+		--assert error? try [reverse/skip 1.2.3 0]
+		--assert error? try [reverse/skip 1.2.3 -1]
+		--assert error? try [reverse/skip 1.2.3 "4"]
+	
+	--test-- "reverse-*"
+		--assert error? try [reverse/skip 1.2.3 4]
+	
+	--test-- "reverse-*"
+		--assert 3.4.1.2.5.6 == reverse/skip/part 1.2.3.4.5.6 2 4
+		--assert 2.1.3.4.5.6 == reverse/skip/part 1.2.3.4.5.6 1 2
+	
+	--test-- "reverse-*"
+		--assert 4.5.6.1.2.3 == reverse/skip 1.2.3.4.5.6 3
+		--assert 5.6.3.4.1.2 == reverse/skip 1.2.3.4.5.6 2
+		--assert 6.5.4.3.2.1 == reverse/skip 1.2.3.4.5.6 1
+	
+	--test-- "reverse-*"
+		--assert 5.6.3.4.1.2.7.8.9.10.11.12 == reverse/skip/part 1.2.3.4.5.6.7.8.9.10.11.12 2 6
+		--assert 1.2.3.4.5.6.7.8.9.10.11.12 == reverse/skip/part 1.2.3.4.5.6.7.8.9.10.11.12 4 4
+		--assert 7.8.9.10.11.12.1.2.3.4.5.6 == reverse/skip/part 1.2.3.4.5.6.7.8.9.10.11.12 6 12
+		--assert 4.5.6.1.2.3.7.8.9.10.11.12 == reverse/skip/part 1.2.3.4.5.6.7.8.9.10.11.12 3 6
+		--assert 3.2.1.4.5.6.7.8.9.10.11.12 == reverse/skip/part 1.2.3.4.5.6.7.8.9.10.11.12 1 3
+	
+===end-group===
+
+~~~end-file~~~

--- a/utils/redbin.r
+++ b/utils/redbin.r
@@ -177,8 +177,8 @@ context [
 		if nl? [header: header or nl-flag]
 		emit header
 		emit to integer! skip bin -4
-		emit to integer! copy/part skip bin -8 4
-		emit to integer! copy/part head bin 4
+		emit to integer! copy/part skip bin -4 -4
+		emit to integer! copy/part skip bin -8 -4
 	]
 	
 	emit-money: func [value [issue!] /local bin header][


### PR DESCRIPTION
Fulfills and closes #3004 (also closes https://github.com/red/REP/issues/28) by implementing `reverse/skip` for `series!` and `tuple!`. `port!` and `pair!` actions were modified to support an extra argument, but currently ignore it: `port!` because it's TBD, and `pair!` because it doesn't make much sense and it ignores all the refinements anyway.

`series!` tests were updated to cover this new feature; for `tuple!` I created a dedicated test suite.

Implementation follows `find/skip` semantics as a reasonable default, that is:
- `size` should be positive `integer!`;
- `size` should be less than or equal to `length` (either length of the `series!` or length specified by `/part`);
- `length` should be evenly divisible by `size`.

The basic logic of the algorithm (rotation by swapping) remains unchanged; the extra overhead comes from the cases where record's `size` is greater than 1 — in such scenarios an extra buffer needs to be allocated to hold temporary value during swapping. The maximum `size` then is 1/2 of value's length.