### PR TITLE
FIX: `copy some string to console` will crash

### DIFF
--- a/environment/console/CLI/input.red
+++ b/environment/console/CLI/input.red
@@ -71,13 +71,13 @@ unless system/console [
 		]
 
 		console?:	yes
-		buffer:		declare byte-ptr!
+		buf-size:	128
+		buffer:		allocate buf-size
 		pbuffer:	declare byte-ptr!
 		input-line: declare red-string!
 		prompt:		declare	red-string!
 		history:	declare red-block!
 		saved-line:	as red-string! 0
-		buf-size:	128
 		columns:	-1
 		rows:		-1
 		output?:	yes


### PR DESCRIPTION
sometimes get log like this:

```
>> lex: function [
[        event    [word!]                                    ;-- eve
*** Runtime Error 1: access violation
*** in file: /D/vmware/focal-share/red/runtime/unicode.reds
*** at line: 814
***
***   stack: red/unicode/cp-to-utf16 91 00000000h
***   stack: terminal/emit-red-char 91
***   stack: terminal/emit-red-string 0052AFD0h 120 false
***   stack: terminal/refresh
***   stack: terminal/console-edit 02975344h
***   stack: terminal/edit 02975344h false
***   stack: _read-input 02975344h false
***   stack: ask
***   stack: ctx||465~run 00EFB6E4h
***   stack: ctx||465~launch 00EFB6E4h
***   stack: ctx||484~launch 00EFB19Ch
```

sometimes just crash without callback stack
