### PR TITLE
FIX: issue #4204 (FIND/LAST does not honor /PART). 

### DIFF
--- a/runtime/datatypes/string.reds
+++ b/runtime/datatypes/string.reds
@@ -1887,13 +1887,9 @@ string: context [
 			if step < 1 [fire [TO_ERROR(script out-of-range) skip]]
 		]
 		if OPTION?(part) [
-			limit: either TYPE_OF(part) = TYPE_INTEGER [
+			sz: either TYPE_OF(part) = TYPE_INTEGER [
 				int: as red-integer! part
-				if int/value <= 0 [						;-- early exit if part <= 0
-					result/header: TYPE_NONE
-					return result
-				]
-				int/value << (unit >> 1)
+				int/value
 			][
 				str2: as red-string! part
 				unless all [
@@ -1902,10 +1898,15 @@ string: context [
 				][
 					ERR_INVALID_REFINEMENT_ARG(refinements/_part part)
 				]
-				str2/head - str/head << (unit >> 1)
+				str2/head - str/head
 			]
+			if sz <= 0 [								;-- early exit if part <= 0
+				result/header: TYPE_NONE
+				return result
+			]
+			if sz > len [sz: len]
 			part?: yes
-			if limit > len [limit: len]
+			limit: sz << (unit >> 1)
 		]
 		case [
 			last? [

--- a/runtime/datatypes/string.reds
+++ b/runtime/datatypes/string.reds
@@ -1907,8 +1907,8 @@ string: context [
 		case [
 			last? [
 				step: 0 - step
+				end: buffer
 				buffer: (as byte-ptr! either part? [buffer + limit][s/tail]) - unit
-				end: either part? [buffer - limit + unit][buffer]
 			]
 			reverse? [
 				step: 0 - step

--- a/runtime/datatypes/string.reds
+++ b/runtime/datatypes/string.reds
@@ -1908,7 +1908,7 @@ string: context [
 			last? [
 				step: 0 - step
 				end: either part? [buffer - limit + unit][buffer]
-				buffer: (as byte-ptr! s/tail) - unit
+				buffer: (as byte-ptr! either part? [buffer + limit][s/tail]) - unit
 			]
 			reverse? [
 				step: 0 - step

--- a/runtime/datatypes/string.reds
+++ b/runtime/datatypes/string.reds
@@ -1845,6 +1845,7 @@ string: context [
 			step	[integer!]
 			sz		[integer!]
 			sz2		[integer!]
+			len     [integer!]
 			sbits	[series!]
 			pbits	[byte-ptr!]
 			pos		[byte-ptr!]								;-- required by BS_TEST_BIT
@@ -1862,6 +1863,7 @@ string: context [
 		unit: GET_UNIT(s)
 		buffer: (as byte-ptr! s/offset) + (str/head << (unit >> 1))
 		end: as byte-ptr! s/tail
+		len: rs-length? str
 
 		if any [							;-- early exit if string is empty or at tail
 			s/offset = s/tail
@@ -1903,6 +1905,7 @@ string: context [
 				str2/head - str/head << (unit >> 1)
 			]
 			part?: yes
+			if limit > len [limit: len]
 		]
 		case [
 			last? [

--- a/runtime/datatypes/string.reds
+++ b/runtime/datatypes/string.reds
@@ -1907,8 +1907,8 @@ string: context [
 		case [
 			last? [
 				step: 0 - step
-				end: either part? [buffer - limit + unit][buffer]
 				buffer: (as byte-ptr! either part? [buffer + limit][s/tail]) - unit
+				end: either part? [buffer - limit + unit][buffer]
 			]
 			reverse? [
 				step: 0 - step

--- a/tests/source/units/series-test.red
+++ b/tests/source/units/series-test.red
@@ -797,6 +797,9 @@ Red [
 		--assert [x b x c] = find/last/part [a x b x c] 'x 3
 		--assert [x b x c] = find/last/part skip [x x x a x b x c] 3 'x 3
 	
+	--test-- "series-find-108"
+		--assert none? find/last/part "abc" #"^(01)" 20 + 1
+	
 ===end-group===
 
 ===start-group=== "remove"

--- a/tests/source/units/series-test.red
+++ b/tests/source/units/series-test.red
@@ -798,7 +798,7 @@ Red [
 		--assert [x b x c] = find/last/part skip [x x x a x b x c] 3 'x 3
 	
 	--test-- "series-find-108"
-		--assert none? find/last/part "abc" #"^(01)" 20 + 1
+		;--assert none? find/last/part "abc" #"^(01)" 20 + 1
 	
 ===end-group===
 

--- a/tests/source/units/series-test.red
+++ b/tests/source/units/series-test.red
@@ -798,7 +798,7 @@ Red [
 		--assert [x b x c] = find/last/part skip [x x x a x b x c] 3 'x 3
 	
 	--test-- "series-find-108"
-		;--assert none? find/last/part "abc" #"^(01)" 20 + 1
+		--assert none? find/last/part "abc" #"^(01)" 100
 	
 ===end-group===
 

--- a/tests/source/units/series-test.red
+++ b/tests/source/units/series-test.red
@@ -789,7 +789,14 @@ Red [
 		put sf-105 'a 1
 		--assert (make hash! [a 1]) = find sf-105 'a
 
-		
+	--test-- "series-find-106"
+		--assert " b c" = find/last/part "a b c" space 3
+		--assert " b c" = find/last/part skip "xyza b c" 3 space 3
+	
+	--test-- "series-find-107"
+		--assert [x b x c] = find/last/part [a x b x c] 'x 3
+		--assert [x b x c] = find/last/part skip [x x x a x b x c] 3 'x 3
+	
 ===end-group===
 
 ===start-group=== "remove"


### PR DESCRIPTION
Fixes #4204 and extends `series!` test suite.

With `find/last` the search happens backward, from end to start, but in case of `last` combined with `part` the upper limit was incorrectly calculated: it always happened from the series end rather than from the boundary delineated by `/part` argument.

What's more important is that the other limit wasn't correctly calculated either:

https://github.com/red/red/blob/20aded310d83709cb22294a4861c313495c80333/runtime/datatypes/string.reds#L1908-L1912

Note the `buffer - limit` part. This means that the lower boundary resides outside the series buffer, somewhere in `series!` meta info or even before it. Knowing that this meta info is 20 bytes in width and likely contains `01` byte in the header (a bit flag that specifies that series is used), we can, then, using Latin1 string:
```red
>> find/last/part "Cthulhu fhtagn!" #"^(01)" 20 + 1
== "^A^@^@ ^XÅm^B^P^@^@^@ðÈ^W^CÿÈ^W^CCthulhu fhtagn!"
```

Conceptually, one boundary is always fixed at the index of the series, and the other is either located at the tail or shifted by `/part` to a specific position. Provided fix implements this logic.