### PR TITLE
FIX: issue #2671 (Char in numeric form is not supported for values from 0 to 9).

### DIFF
--- a/lexer.r
+++ b/lexer.r
@@ -466,40 +466,38 @@ lexer: context [
 	paren-rule: [#"(" (stack/allocate paren! 10) any-value	#")" (value: stack/pop paren!)]
 	
 	escaped-char: [
-		pos: ["^^(" | #"^^"] :pos [						;-- quick look-ahead check
-			"^^(" [
-				[										;-- special case first
-					"null" 	 (value: #"^(00)")
-					| "back" (value: #"^(08)")
-					| "tab"  (value: #"^(09)")
-					| "line" (value: #"^(0A)")
-					| "page" (value: #"^(0C)")
-					| "esc"  (value: #"^(1B)")
-					| "del"	 (value: #"^~")
-				]
-				| pos: [1 6 hexa-char] e: (				;-- Unicode values allowed up to 10FFFFh
-					if e/1 <> #")" [throw-error]		;-- more than 6 hexadecimal digits
-					value: either rs? [
-						to-char to-integer to-issue copy/part pos e
-					][
-						encode-UTF8-char pos e
-					]
-				)
-				| (throw-error)							;-- invalid syntax
-			] #")"
-			| #"^^" [
-				[
-					#"/" 	(value: #"^/")
-					| #"-"	(value: #"^-")
-					| #"~" 	(value: #"^(del)")
-					| #"^^" (value: #"^^")				;-- caret escaping case
-					| #"{"	(value: #"{")
-					| #"}"	(value: #"}")
-					| #"^""	(value: #"^"")
-				]
-				| pos: caret-Uchar (value: pos/1 - 64)
-				| pos: caret-Lchar (value: pos/1 - 96)
+		"^^(" [
+			[										;-- special case first
+				"null" 	 (value: #"^(00)")
+				| "back" (value: #"^(08)")
+				| "tab"  (value: #"^(09)")
+				| "line" (value: #"^(0A)")
+				| "page" (value: #"^(0C)")
+				| "esc"  (value: #"^(1B)")
+				| "del"	 (value: #"^~")
 			]
+			| pos: [1 6 hexa-char] e: (				;-- Unicode values allowed up to 10FFFFh
+				if e/1 <> #")" [throw-error]		;-- more than 6 hexadecimal digits
+				value: either rs? [
+					to-char to-integer to-issue copy/part pos e
+				][
+					encode-UTF8-char pos e
+				]
+			)
+			| (throw-error)							;-- invalid syntax
+		] #")"
+		| #"^^" [
+			[
+				#"/" 	(value: #"^/")
+				| #"-"	(value: #"^-")
+				| #"~" 	(value: #"^(del)")
+				| #"^^" (value: #"^^")				;-- caret escaping case
+				| #"{"	(value: #"{")
+				| #"}"	(value: #"}")
+				| #"^""	(value: #"^"")
+			]
+			| pos: caret-Uchar (value: pos/1 - 64)
+			| pos: caret-Lchar (value: pos/1 - 96)
 		]
 	]
 	

--- a/system/tests/source/compiler/regression-test-rsc.r
+++ b/system/tests/source/compiler/regression-test-rsc.r
@@ -1352,6 +1352,46 @@ probe 1.836E13
 }
 		--assert not found? find qt/output "13.0"
 
+	--test-- "#2671"
+		--compile-and-run-this {
+Red/System []
+
+string: "^^(0)^^(1)^^(2)^^(3)^^(4)^^(5)^^(6)^^(7)^^(8)^^(9)^^(A)^^(B)^^(C)^^(D)^^(E)^^(F)"
+binary: #{000102030405060708090A0B0C0D0E0F}
+array:  [
+	#"^^(0)" #"^^(1)" #"^^(2)" #"^^(3)"
+	#"^^(4)" #"^^(5)" #"^^(6)" #"^^(7)"
+	#"^^(8)" #"^^(9)" #"^^(A)" #"^^(B)"
+	#"^^(C)" #"^^(D)" #"^^(E)" #"^^(F)"
+]
+
+this: compare-memory
+	as byte-ptr! string
+	binary
+	length? string
+
+that: compare-memory
+	array
+	binary
+	length? string
+
+probe [this that]
+}
+		
+		--assert 0 = load qt/output
+		
+		--compile-this {Red/System [] #"^^(0000001)"}
+		--assert syntax-error "Invalid char! value"
+
+		--compile-this {Red/System [] "^^(0000001)"}
+		--assert syntax-error "Invalid string! value"
+		
+		--compile-this {Red/System [] #"^^(skibadee-skibadanger)"}
+		--assert syntax-error "Invalid char! value"
+		
+		--compile-this {Red/System [] "^^(skibadee-skibadanger)"}
+		--assert syntax-error "Invalid string! value"
+		
 ===end-group===
 
 

--- a/tests/source/compiler/regression-test-redc-5.r
+++ b/tests/source/compiler/regression-test-redc-5.r
@@ -101,7 +101,14 @@ test
 	--test-- "#2538"
 		--compile-and-run-this-red {probe system/console/size}
 		--assert not crashed?
-
+	
+	--test-- "#2671"
+		--compile-this {Red [] "^^(0000001)"}
+		--assert syntax-error?
+		
+		--compile-this {Red [] "^^(skibadee-skibadanger)"}
+		--assert syntax-error?
+	
 ===end-group===
 
 ; ===start-group=== "Red regressions #3001 - #3500"

--- a/tests/source/compiler/regression-test-redc-5.r
+++ b/tests/source/compiler/regression-test-redc-5.r
@@ -103,11 +103,17 @@ test
 		--assert not crashed?
 	
 	--test-- "#2671"
+		--compile-this {Red [] #"^^(0000001)"}
+		--assert syntax-error "Invalid char! value"
+
 		--compile-this {Red [] "^^(0000001)"}
-		--assert syntax-error?
+		--assert syntax-error "Invalid string! value"
+		
+		--compile-this {Red [] #"^^(skibadee-skibadanger)"}
+		--assert syntax-error "Invalid char! value"
 		
 		--compile-this {Red [] "^^(skibadee-skibadanger)"}
-		--assert syntax-error?
+		--assert syntax-error "Invalid string! value"
 	
 ===end-group===
 

--- a/tests/source/units/regression-test-red.red
+++ b/tests/source/units/regression-test-red.red
@@ -2795,7 +2795,19 @@ b}
 	--test-- "#2253"
 		--assert not error? try [3151391351465.995 // 1.0]
 		unset 'true?
-
+	
+	--test-- "#2671"
+		--assert equal?
+			"^(0) ^(1) ^(2) ^(3) ^(4) ^(5) ^(6) ^(7) ^(8) ^(9) ^(A) ^(B) ^(C) ^(D) ^(E) ^(F)"
+			"^@ ^A ^B ^C ^D ^E ^F ^G ^H ^- ^/ ^K ^L ^M ^N ^O"
+		
+		--assert equal?
+			"^A ^A ^A ^A ^A ^A"
+			"^(1) ^(01) ^(001) ^(0001) ^(00001) ^(000001)"
+		
+		--assert error? try [transcode {"^^(0000001)"}]
+		--assert error? try [transcode {"^^(skibadee-skibadanger)"}]
+		
 	--test-- "#3603"
 		bu3603: reduce [()]
 		rest3603: none


### PR DESCRIPTION
Resolves #2671 for Red and Red/System compilers. Relevant regression tests are provided.

There are at least 3 different issues coalesced in here:
1. `%lexer.r` accepted only escaped `^(...)` characters with 2-6 digits;
1. If an escaped character was malformed, `%lexer.r` treated it as a non-escaped sequence of characters; e.g. `"^(foo)"` turned into `"(foo)"`, `"^(0)"` into `"(0)"`;
1. Red/System `byte!` literals were malformed if the number of their digits was not evenly divisible by 2 (same issue with `enbase` as in https://github.com/red/red/pull/4621).