### PR TITLE
FIX: issue #4526 ([Compiler] Internal error `defer needs a value`). 

### DIFF
--- a/compiler.r
+++ b/compiler.r
@@ -1407,7 +1407,7 @@ red: context [
 		invalid-spec: [throw-error ["invalid argument function to make op!:" mold copy/part at pos 4 2]]
 		
 		name: to word! pos/1
-		if find functions name [exit]					;-- mainly intended for 'make (hardcoded)
+		if find functions name [return none]			;-- mainly intended for 'make (hardcoded)
 
 		switch type: pos/3 [
 			native! [nat?: yes if find intrinsics name [type: 'intrinsic!]]

--- a/tests/source/compiler/regression-test-redc-5.r
+++ b/tests/source/compiler/regression-test-redc-5.r
@@ -209,7 +209,7 @@ test
 			do bind [probe 1 ** 2] context [**: make op! func [x y][x + y]]
 		}
 		--assert compiled?
-		--assert qt/output = "3"
+		--assert 3 = load qt/output
 		
 ===end-group===
 

--- a/tests/source/compiler/regression-test-redc-5.r
+++ b/tests/source/compiler/regression-test-redc-5.r
@@ -202,8 +202,15 @@ test
 	--test-- "#3891"
 		--compile-and-run-this-red {probe load "a<=>"}
 		--assert not crashed?
-
-
+	
+	--test-- "#4526"
+		--compile-and-run-this {
+			Red []
+			do bind [probe 1 ** 2] context [**: make op! func [x y][x + y]]
+		}
+		--assert compiled?
+		--assert qt/output = "3"
+		
 ===end-group===
 
 ~~~end-file~~~ 


### PR DESCRIPTION
Fixes #4526 and provides a regression test for a compiler.

The issue was caused by one of the internal functions using `exit` and returning `unset`. I surmise this short-circuit path should rather yield a logical false.