### PR TITLE
FIX: issue #4627 (reported values in error messages are not properly displayed).

### DIFF
--- a/runtime/datatypes/error.reds
+++ b/runtime/datatypes/error.reds
@@ -130,14 +130,16 @@ error: context [
 		obj		[red-object!]
 		return: [red-block!]
 		/local
-			value  [red-value!]
-			tail   [red-value!]
-			buffer [red-string!]
-			type   [integer!]
+			value   [red-value!]
+			tail    [red-value!]
+			buffer  [red-string!]
+			type    [integer!]
+			syntax? [logic!]
 	][
 		value: block/rs-head blk
 		tail:  block/rs-tail blk
 		
+		syntax?: words/errors/syntax/symbol = get-type obj
 		while [value < tail][
 			type: TYPE_OF(value)
 			if any [
@@ -146,7 +148,11 @@ error: context [
 			][
 				buffer: string/rs-make-at stack/push* 16
 				stack/mark-native words/_body
-				actions/form object/rs-select obj value buffer null 0
+				either syntax? [
+					actions/form object/rs-select obj value buffer null 0
+				][
+					actions/mold object/rs-select obj value buffer no no yes null 0 0
+				]
 				stack/unwind
 				copy-cell as red-value! buffer value
 				stack/pop 1

--- a/tests/source/units/regression-test-red.red
+++ b/tests/source/units/regression-test-red.red
@@ -2899,7 +2899,16 @@ comment {
 			recycle/on
 			recycle
 		]
-
+	
+	--test-- "#4627"		
+		--assert to logic! find 
+			form try [transcode "]"]
+			"(line 1) missing [ at ]"
+		
+		--assert to logic! find 
+			form try [null < []]
+			%{#"^@" with []}%
+		
 ===end-group===
 
 ~~~end-file~~~


### PR DESCRIPTION
Fixes #4627 and provides a regression test. The issue was caused by a commit fdf7a3a introduced during the work on the new lexer. It slightly changed error processing to make syntax errors more readable:

https://github.com/red/red/blob/151e6088efec77cf87ed024e7fb5660f55fa3a0b/runtime/datatypes/error.reds#L149

That is, reported values are now `form`ed rather than `mold`ed. This makes sense, because with `mold` syntax errors would look like this:

```red
>> ]
*** Syntax Error: "(line 1)" missing #"[" at "]"
*** Where: transcode
*** Stack: load 
```

OTOH, once values are `form`ed, the other types of error messages become pretty obscure and uninformative:
```red
>> 1 < [2]
*** Script Error: cannot compare 1 with 2 ; Of course you can Red, believe in yourself!
*** Where: <
*** Stack: 
>> null > []
*** Script Error: cannot compare  with ; Wat?
*** Where: >
*** Stack:  
```

To keep the best of both worlds, I haven't come up with anything smarter than dispatching on the type of error: if it's a syntax error then we `form`, else we `mold`. Some syntax errors became a little bit too quirky because of that:
```red
>> do %scratch.txt
*** Syntax Error: script is missing a Red header: scratch.txt ; Instead of %scratch.txt.
*** Where: do
*** Stack: do-file cause-error  
```
But personally I can live with that.