### PR TITLE
FIX: issue #4174 (`replace/all/deep` hangs up).

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -211,10 +211,10 @@ replace: function [
 	"Replaces values in a series, in place"
     series [any-block! any-string! binary! vector!] "The series to be modified"	;-- series! barring image!
     pattern "Specific value or parse rule pattern to match"
-    value 	"New value, replaces pattern in the series" 
-    /all 	"Replace all occurrences, not just the first"
-    /deep 	"Replace pattern in all sub-lists as well"
-    /case 	"Case-sensitive replacement"
+    value "New value, replaces pattern in the series" 
+    /all  "Replace all occurrences, not just the first"
+    /deep "Replace pattern in all sub-lists as well"
+    /case "Case-sensitive replacement"
 ][
 	parse?: any [
 		system/words/all [deep any-list? series]

--- a/environment/functions.red
+++ b/environment/functions.red
@@ -249,7 +249,7 @@ replace: function [
 		]
 		rule:  [
 			any [
-				change pattern (value) if (not all) break
+				change pattern (value) [if (all) | break]
 				| if (deep?) ahead any-list! into rule
 				| skip
 			]

--- a/environment/functions.red
+++ b/environment/functions.red
@@ -245,10 +245,11 @@ replace: function [
 	]
 	
 	also series either parse? [
-		rule: [
+		deep?: every [deep not binary? series]			;-- don't match by any-list! datatype in binary!
+		rule:  [
 			any [
 				change pattern (value) if (not all) break
-				| if (deep) ahead any-list! into rule
+				| if (deep?) ahead any-list! into rule
 				| skip
 			]
 		]

--- a/environment/functions.red
+++ b/environment/functions.red
@@ -216,22 +216,20 @@ replace: function [
     /deep 	"Replace pattern in all sub-lists as well"
     /case 	"Case-sensitive replacement"
 ][
-	every: :system/words/all
-	
 	parse?: any [
-		every [deep any-list? series]
-		every [
+		system/words/all [deep any-list? series]
+		system/words/all [
 			any [binary? series any-string? series]
 			any [block? :pattern bitset? :pattern]
 		]
 	]
-	form?: every [
+	form?: system/words/all [
 		any-string? series
 		any [not any-string? :pattern tag? :pattern]	;-- search for a literal tag, including angle brackets
 		not block?  :pattern
 		not bitset? :pattern
 	]
-	quote?: every [
+	quote?: system/words/all [
 		not form?
 		parse?
 		not block?  :pattern
@@ -245,7 +243,10 @@ replace: function [
 	]
 	
 	also series either parse? [
-		deep?: every [deep not binary? series]			;-- don't match by any-list! datatype in binary!
+		deep?: system/words/all [						;-- don't match by any-list! datatype in binary!
+			deep
+			not binary? series
+		]
 		rule:  [
 			any [
 				change pattern (value) if (not all) break
@@ -257,11 +258,11 @@ replace: function [
 		parse series [case case rule]					;-- parse cannot process vector! and image!
 	][
 		many?: any [
-			every [
+			system/words/all [
 				any [binary? series any-string? series]
 				series? :pattern
 			]
-			every [
+			system/words/all [
 				any-list? series
 				any-list? :pattern
 			]
@@ -269,8 +270,8 @@ replace: function [
 		size: either many? [length? :pattern][1]
 		seek: reduce [pick [find/case find] case 'series quote :pattern]
 		
-		until [
-			not every [
+		until [											;-- find does not support image!
+			not system/words/all [
 				series: do seek
 				change/part series value size
 				all

--- a/environment/functions.red
+++ b/environment/functions.red
@@ -273,7 +273,7 @@ replace: function [
 		until [											;-- find does not support image!
 			not system/words/all [
 				series: do seek
-				change/part series value size
+				series: change/part series value size
 				all
 			]
 		]

--- a/tests/source/units/replace-test.red
+++ b/tests/source/units/replace-test.red
@@ -39,6 +39,7 @@ Red [
 	--test-- "replace/deep-4"	--assert [1 2 3 [8]] = replace/deep [1 2 3 [4 5]] [quote 4 quote 5] 8
 	--test-- "replace/deep-5"	--assert [1 2 a 4 5] = replace/deep [1 2 3 4 5] [quote 8 | quote 4 | quote 3] 'a
 	--test-- "replace/deep-6"	--assert [a g h c d] = replace/deep [a b c d] ['b | 'd] [g h]
+	--test-- "replace/deep-7"	--assert [x: 1 2 3] = replace/deep [a: 1 2 3] quote a: quote x:
 
 ===end-group===
 
@@ -53,6 +54,7 @@ Red [
 	--test-- "replace/all-7"	--assert #{640164} = replace/all #{000100} #{00} #{64}
 	--test-- "replace/all-8"	--assert %file.sub.ext = replace/all %file!sub!ext #"!" #"."
 	--test-- "replace/all-9"	--assert <tag body end> = replace/all <tag_body_end> "_" " "
+	--test-- "replace-all-10"	--assert [x: 123] = replace/all [a: 123] quote a: quote x:
 
 ===end-group===
 
@@ -62,6 +64,7 @@ Red [
 	--test-- "replace/deep/all-2"	--assert [1 8 9 3 [4 8 9]] = replace/deep/all [1 2 3 [4 5]] [quote 5 | quote 2] [8 9]
 	--test-- "replace/deep/all-3"	--assert [i j c [i j]] = replace/deep/all [a b c [d e]] ['d 'e | 'a 'b] [i j]
 	--test-- "replace/deep/all-4"	--assert [a [<tag> [<tag>]]] = replace/all/deep [a [b c [d b]]] ['d 'b | 'b 'c] <tag>
+	--test-- "replace/deep/all-5"	--assert [x: 123 [x: 123]] = replace/all/deep [a: 123 [a: 123]] quote a: quote x:
 
 ===end-group===
 


### PR DESCRIPTION
Closes #4174, provides regression tests, and replaces `replace` (no pun intended) by rewriting it from scratch in a more modular fashion. The existing semantics is hopefully preserved, but, looking at how complicated its internal dispatching logic is, I think a couple more tests might be in order.