### PR TITLE
FIX: encode-url copy problem

### DIFF
--- a/environment/networking.red
+++ b/environment/networking.red
@@ -165,8 +165,7 @@ url-parser: object [
 	; present and was immediately followed by the next component separator or
 	; the end of the reference.
 	set 'encode-url function [url-obj [object!] "What you'd get from decode-url"][
-		;result: make url! 256			; pre-allocate for reasonably sized-urls?
-		result: clear url-buffer://
+		result: make url! 60
 
 		if url-obj/scheme [
 			append result url-obj/scheme


### PR DESCRIPTION
This PR fixes below issue:

```
>> u1: encode-url decode-url http://a.com/
== http://a.com/
>> u2: encode-url decode-url ftp://b.com/
== ftp://b.com/
>> u1
== ftp://b.com/
```

I also use `make url! 60`, with a rough idea of average URL size.
I could only find a ten years old research on this:
http://www.supermind.org/blog/559/average-length-of-a-url
http://www.supermind.org/blog/740/average-length-of-a-url-part-2
