### PR TITLE
FEAT: Add NetBSD Target

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Cross-compilation targets:
     macOS        : macOS Intel, applications bundles
     Syllable     : Syllable OS, x86
     FreeBSD      : FreeBSD, x86
+    NetBSD       : NetBSD, x86
     Android      : Android, ARMv5
     Android-x86  : Android, x86
 

--- a/build/includes.r
+++ b/build/includes.r
@@ -164,6 +164,7 @@ write %build/bin/sources.r set-cache [
 			%android.reds
 			%darwin.reds
 			%freebsd.reds
+			%netbsd.reds
 			%linux.reds
 			%POSIX.reds
 			%syllable.reds
@@ -292,6 +293,7 @@ write %build/bin/sources.r set-cache [
 			%darwin.reds
 			%debug.reds
 			%freebsd.reds
+			%netbsd.reds
 			%libc.reds
 			%lib-names.reds
 			%lib-natives.reds

--- a/environment/codecs/BMP.red
+++ b/environment/codecs/BMP.red
@@ -17,7 +17,7 @@ put system/codecs 'bmp context [
 	suffixes: [%.bmp]
 	
 	encode: routine [img [image!] where [any-type!]][
-		#if not find [Android Linux FreeBSD Syllabe] OS [
+		#if not find [Android Linux FreeBSD NetBSD Syllabe] OS [
 			stack/set-last as cell! image/encode img where IMAGE_BMP
 		]
 		#if OS = 'Linux [#if modules contains 'View [
@@ -26,7 +26,7 @@ put system/codecs 'bmp context [
 	]
 
 	decode: routine [data [any-type!]][
-		#if not find [Android Linux FreeBSD Syllabe] OS [
+		#if not find [Android Linux FreeBSD NetBSD Syllabe] OS [
 			stack/set-last as cell! image/decode data
 		]
 		#if OS = 'Linux [#if modules contains 'View [

--- a/environment/codecs/GIF.red
+++ b/environment/codecs/GIF.red
@@ -17,13 +17,13 @@ put system/codecs 'gif context [
 	suffixes: [%.gif]
 	
 	encode: routine [img [image!] where [any-type!]][
-		#if not find [Android Linux FreeBSD Syllabe] OS [
+		#if not find [Android Linux FreeBSD NetBSD Syllabe] OS [
 			stack/set-last as cell! image/encode img where IMAGE_GIF
 		]
 	]
 
 	decode: routine [data [any-type!]][
-		#if not find [Android Linux FreeBSD Syllabe] OS [
+		#if not find [Android Linux FreeBSD NetBSD Syllabe] OS [
 			stack/set-last as cell! image/decode data
 		]
 		#if OS = 'Linux [#if modules contains 'View [

--- a/environment/codecs/JPEG.red
+++ b/environment/codecs/JPEG.red
@@ -17,7 +17,7 @@ put system/codecs 'jpeg context [
 	suffixes: [%.jpg %.jpeg %.jpe %.jfif]	
 	
 	encode: routine [img [image!] where [any-type!]][
-		#if not find [Android Linux FreeBSD Syllabe] OS [
+		#if not find [Android Linux FreeBSD NetBSD Syllabe] OS [
 			stack/set-last as cell! image/encode img where IMAGE_JPEG
 		]
 		#if OS = 'Linux [#if modules contains 'View [
@@ -26,7 +26,7 @@ put system/codecs 'jpeg context [
 	]
 
 	decode: routine [data [any-type!]][
-		#if not find [Android Linux FreeBSD Syllabe] OS [
+		#if not find [Android Linux FreeBSD NetBSD Syllabe] OS [
 			stack/set-last as cell! image/decode data
 		]
 		#if OS = 'Linux [#if modules contains 'View [

--- a/environment/codecs/PNG.red
+++ b/environment/codecs/PNG.red
@@ -17,7 +17,7 @@ put system/codecs 'png context [
 	suffixes: [%.png]
 	
 	encode: routine [img [image!] where [any-type!]][
-		#if not find [Android Linux FreeBSD Syllabe] OS [
+		#if not find [Android Linux FreeBSD NetBSD Syllabe] OS [
 			stack/set-last as cell! image/encode img where IMAGE_PNG
 		]
 		#if OS = 'Linux [#if modules contains 'View [
@@ -26,7 +26,7 @@ put system/codecs 'png context [
 	]
 
 	decode: routine [data [any-type!]][
-		#if not find [Android Linux FreeBSD Syllabe] OS [
+		#if not find [Android Linux FreeBSD NetBSD Syllabe] OS [
 			stack/set-last as cell! image/decode data
 		]
 		#if OS = 'Linux [#if modules contains 'View [

--- a/environment/console/CLI/POSIX.reds
+++ b/environment/console/CLI/POSIX.reds
@@ -17,7 +17,7 @@ Red/System [
 #define OS_POLLIN 		1
 
 #case [
-	any [OS = 'macOS OS = 'FreeBSD] [
+	any [OS = 'macOS OS = 'FreeBSD OS = 'NetBSD] [
 		#define TIOCGWINSZ		40087468h
 		#define TERM_TCSADRAIN	1
 		#define TERM_VTIME		18
@@ -474,7 +474,7 @@ init-console: func [
 			TERM_ECHO or TERM_ICANON or TERM_IEXTEN or TERM_ISIG
 		)
 		#case [
-			any [OS = 'macOS OS = 'FreeBSD] [
+			any [OS = 'macOS OS = 'FreeBSD OS = 'NetBSD] [
 				cc: (as byte-ptr! term) + (4 * size? integer!)
 			]
 			true [cc: (as byte-ptr! term) + (4 * size? integer!) + 1]

--- a/environment/console/GUI/old/terminal.reds
+++ b/environment/console/GUI/old/terminal.reds
@@ -1482,6 +1482,7 @@ terminal: context [
 			Android  []
 			macOS    []
 			FreeBSD  []
+			NetBSD   []
 			Syllable []
 			#default []									;-- Linux
 		]

--- a/runtime/crypto.reds
+++ b/runtime/crypto.reds
@@ -387,6 +387,14 @@ crypto: context [
 				]
 			]]
 		]
+		OS = 'NetBSD [
+			#import [
+			LIBC-file cdecl [
+				get-errno-ptr: "__errno" [
+					return: [int-ptr!]
+				]
+			]]
+		]
 		true [
 			#import [
 			LIBC-file cdecl [
@@ -679,6 +687,9 @@ crypto: context [
 			]
 			FreeBSD [
 				#define LIBCRYPTO-file "libcrypto.so.8"
+			]
+			NetBSD [
+				#define LIBCRYPTO-file "libcrypto.so"
 			]
 			#default [
 				#switch config-name [

--- a/runtime/datatypes/common.reds
+++ b/runtime/datatypes/common.reds
@@ -500,7 +500,8 @@ words: context [
 	syllable:		-1
 	macOS:			-1
 	linux:			-1
-	
+	netbsd:			-1
+ 
 	any*:			-1
 	break*:			-1
 	copy:			-1
@@ -599,7 +600,8 @@ words: context [
 	_syllable:		as red-word! 0
 	_macOS:			as red-word! 0
 	_linux:			as red-word! 0
-	
+	_netbsd:		as red-word! 0
+ 
 	_push:			as red-word! 0
 	_pop:			as red-word! 0
 	_fetch:			as red-word! 0
@@ -745,6 +747,7 @@ words: context [
 		syllable:		symbol/make "Syllable"
 		macOS:			symbol/make "macOS"
 		linux:			symbol/make "Linux"
+		netbsd:			symbol/make "NetBSD"
 		
 		repeat:			symbol/make "repeat"
 		foreach:		symbol/make "foreach"
@@ -852,6 +855,7 @@ words: context [
 		_syllable:		_context/add-global syllable
 		_macOS:			_context/add-global macOS
 		_linux:			_context/add-global linux
+		_netbsd:		_context/add-global netbsd
 		
 		_to:			_context/add-global to
 		_thru:			_context/add-global thru

--- a/runtime/definitions.reds
+++ b/runtime/definitions.reds
@@ -375,7 +375,7 @@ Red/System [
 	#define	DT_DIR		#"^(04)"
 	
 	#case [
-		any [OS = 'FreeBSD OS = 'macOS] [
+		any [OS = 'FreeBSD OS = 'macOS OS = 'NetBSD] [
 			#define O_CREAT		0200h
 			#define O_TRUNC		0400h
 			#define O_EXCL		0800h

--- a/runtime/platform/netbsd.reds
+++ b/runtime/platform/netbsd.reds
@@ -1,0 +1,99 @@
+Red/System [
+	Title:   "Red runtime NetBSD API imported functions definitions"
+	Author:  "Nenad Rakocevic, Vasyl Zubko"
+	File:	 %netbsd.reds
+	Tabs:	 4
+	Rights:  "Copyright (C) 2011-2020 Red Foundation. All rights reserved."
+	License: {
+		Distributed under the Boost Software License, Version 1.0.
+		See https://github.com/red/red/blob/master/red-system/runtime/BSL-License.txt
+	}
+]
+
+
+#define MMAP_PROT_RW		03h				;-- PROT_READ | PROT_WRITE
+#define MMAP_PROT_RWX		07h				;-- PROT_READ | PROT_WRITE | PROT_EXEC
+
+#define MMAP_MAP_PRIVATE    02h
+#define MMAP_MAP_ANONYMOUS  1000h
+
+#define SC_PAGE_SIZE		28
+
+#define SYSCALL_MMAP		197
+#define SYSCALL_MUNMAP		73
+
+
+platform: context [
+
+	#include %POSIX.reds
+
+	#import  [
+		LIBC-file cdecl [
+			sysconf: "sysconf" [
+				property	[integer!]
+				return:		[integer!]
+			]
+			environ: "environ" [integer!]
+		]
+	]
+
+	page-size: 0
+
+	#syscall [
+		mmap: SYSCALL_MMAP [
+			address		[byte-ptr!]
+			size		[integer!]
+			protection	[integer!]
+			flags		[integer!]
+			fd			[integer!]
+			offset_l	[integer!]
+			offset_h    [integer!]              ;-- off_t is 64 bit on FreeBSD, works for NetBSD as well
+			return:		[byte-ptr!]
+		]
+		munmap: SYSCALL_MUNMAP [
+			address		[byte-ptr!]
+			size		[integer!]
+			return:		[integer!]
+		]
+	]
+	;-------------------------------------------
+	;-- Allocate paged virtual memory region from OS
+	;-------------------------------------------
+	allocate-virtual: func [
+		size	[integer!]						;-- allocated size in bytes (page size multiple)
+		exec?	[logic!]						;-- TRUE => executable region
+		return: [int-ptr!]						;-- allocated memory region pointer
+		/local ptr prot
+	][
+		assert zero? (size and (page-size - 1))	;-- size is a multiple of page size
+		prot: either exec? [MMAP_PROT_RWX][MMAP_PROT_RW]
+
+		ptr: mmap
+			null
+			size
+			prot
+			MMAP_MAP_PRIVATE or MMAP_MAP_ANONYMOUS
+			-1									;-- portable value
+			0
+			0
+
+		if -1 = as-integer ptr [throw OS_ERROR_VMEM_OUT_OF_MEMORY]
+		as int-ptr! ptr
+	]
+
+	;-------------------------------------------
+	;-- Free paged virtual memory region from OS
+	;-------------------------------------------
+	free-virtual: func [
+		ptr [int-ptr!]							;-- address of memory region to release
+	][
+		if -1 = munmap as byte-ptr! ptr ptr/value [
+			throw OS_ERROR_VMEM_RELEASE_FAILED
+		]
+	]
+
+	init: does [
+		page-size: sysconf SC_PAGE_SIZE
+		setlocale __LC_ALL ""					;@@ check if "utf8" is present in returned string?
+	]
+]

--- a/runtime/red.reds
+++ b/runtime/red.reds
@@ -23,6 +23,7 @@ red: context [
 		Syllable [#include %platform/syllable.reds]
 		macOS	 [#include %platform/darwin.reds]
 		FreeBSD  [#include %platform/freebsd.reds]
+		NetBSD   [#include %platform/netbsd.reds]
 		#default [#include %platform/linux.reds]
 	]
 	
@@ -54,6 +55,7 @@ red: context [
 		macOS	 [#include %platform/image-quartz.reds]
 		Linux	 [#if modules contains 'View [#include %platform/image-gdk.reds]]
 		FreeBSD  []
+		NetBSD   []
 		#default []
 	]
 	

--- a/runtime/simple-io.reds
+++ b/runtime/simple-io.reds
@@ -247,7 +247,7 @@ simple-io: context [
 		]
 
 		#case [
-			OS = 'FreeBSD [
+			any [OS = 'FreeBSD OS = 'NetBSD][
 				;-- http://fxr.watson.org/fxr/source/sys/stat.h?v=FREEBSD10
 				stat!: alias struct! [
 					st_dev		[integer!]
@@ -485,7 +485,7 @@ simple-io: context [
 		]
 
 		#case [
-			any [OS = 'macOS OS = 'FreeBSD OS = 'Android] [
+			any [OS = 'macOS OS = 'FreeBSD OS = 'NetBSD OS = 'Android] [
 				#import [
 					LIBC-file cdecl [
 						;-- https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/10.6/man2/stat.2.html?useVersion=10.6
@@ -695,7 +695,7 @@ simple-io: context [
 			OS = 'Windows [
 				GetFileSize file null
 			]
-			any [OS = 'macOS OS = 'FreeBSD OS = 'Android] [
+			any [OS = 'macOS OS = 'FreeBSD OS = 'NetBSD OS = 'Android] [
 				_stat file s
 				s/st_size
 			]
@@ -1030,7 +1030,7 @@ simple-io: context [
 		][
 			fd: open-file file/to-OS-path filename RIO_READ yes
 			if fd < 0 [	return none/push ]
-			#either any [OS = 'macOS OS = 'FreeBSD OS = 'Android] [
+			#either any [OS = 'macOS OS = 'FreeBSD OS = 'NetBSD OS = 'Android] [
 				_stat   fd s
 			][	_stat 3 fd s]
 			tm: gmtime as int-ptr! s/st_mtime

--- a/runtime/threads.reds
+++ b/runtime/threads.reds
@@ -162,10 +162,19 @@ thread: context [
 		nsec   [integer!] ;Nanoseconds
 	]
 
-	#either OS = 'macOS [
-		#define LIBPTHREAD-file "libpthread.dylib"
-	][
-		#define LIBPTHREAD-file "libpthread.so.0"
+	#switch OS [
+		macOS [
+			#define LIBPTHREAD-file "libpthread.dylib"
+		]
+		NetBSD [
+			#define LIBPTHREAD-file "libpthread.so"
+		]
+		FreeBSD [
+			#define LIBPTHREAD-file "libpthread.so"
+		]
+		#default [
+			#define LIBPTHREAD-file "libpthread.so.0"
+		]
 	]
 
 	#import [

--- a/runtime/utils.reds
+++ b/runtime/utils.reds
@@ -304,6 +304,96 @@ check-arg-type: func [
 		_context/add-with ctx _context/add-global symbol/make "build" val
 		stack/pop 2
 	]]
+
+	NetBSD [
+	utsname!: alias struct! [
+		sysname		[c-string!]
+		nodename	[c-string!]
+		release		[c-string!]
+		version		[c-string!]
+		machine		[c-string!]
+	]
+
+	#import [
+		LIBC-file cdecl [
+			uname: "uname" [
+				buf		[utsname!]
+				return: [integer!]
+			]
+			strchr: "strchr" [
+				str			[c-string!]
+				c			[byte!]
+				return:		[c-string!]
+			]
+		]
+	]
+
+	__get-OS-info: func [
+		/local
+			obj		[red-object!]
+			ctx		[red-context!]
+			val		[red-value!]
+			int		[red-integer!]
+			pbuf	[byte-ptr!]
+			str		[c-string!]
+			p		[c-string!]
+			err		[integer!]
+			major	[integer!]
+			minor	[integer!]
+			bugfix	[integer!]
+			file	[integer!]
+			len		[integer!]
+			buf		[utsname!]
+	][
+		obj: object/make-at as red-object! stack/push* 8
+		val: stack/push*
+		ctx: GET_CTX(obj)
+
+		buf: as utsname! allocate size? utsname!
+		uname buf
+
+		str: (as c-string! buf) + 256
+		string/load-at str length? str val UTF-8
+		_context/add-with ctx _context/add-global symbol/make "name" val
+
+		str: as c-string! buf
+		word/make-at symbol/make str + (256 * 4) val
+		_context/add-with ctx _context/add-global symbol/make "arch" val
+
+		err: 0
+		str: str + (256 * 2)
+		p: strchr str #"."
+		major: tokenizer/scan-integer as byte-ptr! str as-integer p - str 1 :err
+
+		str: p + 1
+		p: strchr str #"."
+		minor: tokenizer/scan-integer as byte-ptr! str as-integer p - str 1 :err
+
+		either p <> null [
+			str: p + 1
+			p: strchr str #"_"
+			bugfix: tokenizer/scan-integer as byte-ptr! str as-integer p - str 1 :err
+		][
+			bugfix: 0
+		]
+
+		either bugfix <> 0 [
+			val/header: TYPE_TUPLE or (3 << 19)
+			val/data1: bugfix << 16 or (minor << 8) or major
+		][
+			val/header: TYPE_TUPLE or (2 << 19)
+			val/data1: minor << 8 or major
+		]
+		_context/add-with ctx _context/add-global symbol/make "version" val
+
+		str: (as c-string! buf) + (256 * 3)
+		string/load-at str length? str val UTF-8
+		_context/add-with ctx _context/add-global symbol/make "build" val
+
+		stack/pop 2
+		free as byte-ptr! buf
+	]]
+
 	#default [
 	utsname!: alias struct! [
 		_pad0	[float!]

--- a/system/compiler.r
+++ b/system/compiler.r
@@ -1765,7 +1765,7 @@ system-dialect: make-profilable context [
 		]
 		
 		process-export: has [defs cc ns entry spec list name sym][
-			if all [job/type = 'exe job/OS <> 'FreeBSD][
+			if all [job/type = 'exe job/OS <> 'FreeBSD job/OS <> 'NetBSD][
 				throw-error "#export directive requires a library compilation mode"
 			]
 			if word? pc/2 [
@@ -3229,7 +3229,7 @@ system-dialect: make-profilable context [
 				any [
 					all [1 < slots job/target = 'ARM]	 ;-- ARM requires it only for struct > 4 bytes
 					all [
-						not find [Windows macOS FreeBSD] job/OS	 ;-- fallback on Linux ABI
+						not find [Windows macOS FreeBSD NetBSD] job/OS	 ;-- fallback on Linux ABI
 						job/target <> 'ARM
 					]
 				]

--- a/system/config.r
+++ b/system/config.r
@@ -10,7 +10,9 @@ REBOL [
 ;;-------------------------------------------
 ;;     Compilation Target Options
 ;;-------------------------------------------
-;;	OS:				'Windows | 'Linux | 'macOS | 'Syllable	;-- operating system name
+;;	OS:				'Windows | 'Linux | 'macOS
+;;					| 'Syllable	| 'FreeBSD
+;;					| 'NetBSD | 'Android 		;-- operating system name
 ;;	format:			'PE  | 'ELF | 'Mach-o		;-- file format
 ;;	type:			'exe | 'dll | 'drv			;-- file type
 ;;	target:			'IA-32 | 'ARM				;-- CPU or VM target
@@ -195,6 +197,16 @@ FreeBSD [
 	dynamic-linker: "/usr/libexec/ld-elf.so.1"
 	syscall: 'BSD
 	target: 'IA-32
+]
+;-------------------------
+NetBSD [
+	OS:				'NetBSD
+	format: 		'ELF
+	type:			'exe
+	dynamic-linker: "/usr/libexec/ld.elf_so"
+	syscall: 		'BSD
+	target: 		'IA-32
+	PIC?:			 yes
 ]
 ;-------------------------
 Darwin [

--- a/system/runtime/POSIX-signals.reds
+++ b/system/runtime/POSIX-signals.reds
@@ -15,15 +15,15 @@ Red/System [
 ;;  http://fxr.watson.org/fxr/source/bsd/sys/signal.h?v=xnu-1456.1.26;im=excerpts
 
 #define SIGBUS [                            ;-- Bus access error
-	#switch OS [macOS [10] FreeBSD [10] #default [7]]
+	#switch OS [macOS [10] FreeBSD [10] NetBSD [10] #default [7]]
 ]
 #define SIGILL       4                      ;-- Illegal instruction
 #define SIGFPE       8                      ;-- Floating point error
 #define SIGSEGV     11                      ;-- Segmentation violation
 #define SIGWINCH	28						;-- Console window resizing
 
-#define SA_SIGINFO   [#switch OS [macOS [0040h] FreeBSD [0040h] #default [00000004h]]]
-#define SA_RESTART   [#switch OS [macOS [0002h] FreeBSD [0002h] #default [10000000h]]]
+#define SA_SIGINFO   [#switch OS [macOS [0040h] FreeBSD [0040h] NetBSD [0040h] #default [00000004h]]]
+#define SA_RESTART   [#switch OS [macOS [0002h] FreeBSD [0002h] NetBSD [0002h] #default [10000000h]]]
 
 #define ILL_ILLOPC   1
 #define ILL_ILLOPN   [#switch OS [macOS [4] #default [2]]]

--- a/system/runtime/common.reds
+++ b/system/runtime/common.reds
@@ -141,6 +141,7 @@ re-throw: func [/local id [integer!]][
 	macOS	 [#include %darwin.reds]
 	Android	 [#include %android.reds]
 	FreeBSD	 [#include %freebsd.reds]
+	NetBSD	 [#include %netbsd.reds]
 	#default [#include %linux.reds]
 ]
 

--- a/system/runtime/lib-names.reds
+++ b/system/runtime/lib-names.reds
@@ -31,6 +31,10 @@ Red/System [
 		#define LIBC-file	"libc.so.7"
 		#define LIBM-file	"libm.so.5"
 	]
+	NetBSD [
+		#define LIBC-file	"libc.so"
+		#define LIBM-file	"libm.so"
+	]
 	#default [											;-- Linux
 		#either dynamic-linker = "/lib/ld-musl-i386.so.1" [
 			#define LIBC-file	"ld-musl-i386.so.1"

--- a/system/runtime/netbsd.reds
+++ b/system/runtime/netbsd.reds
@@ -1,0 +1,109 @@
+Red/System [
+	Title:   "Red/System NetBSD runtime"
+	Author:  "Nenad Rakocevic, Vasyl Zubko"
+	File: 	 %netbsd.reds
+	Tabs:	 4
+	Rights:  "Copyright (C) 2011-2020 Red Foundation. All rights reserved."
+	License: {
+		Distributed under the Boost Software License, Version 1.0.
+		See https://github.com/red/red/blob/master/BSL-License.txt
+	}
+]
+
+#define OS_TYPE		8
+
+#syscall [
+	write: 4 [
+		fd		[integer!]
+		buffer	[c-string!]
+		count	[integer!]
+		return: [integer!]
+	]
+]
+
+#if use-natives? = yes [
+	#syscall [
+		quit: 1 [							;-- "exit" syscall
+			status	[integer!]
+		]
+	]
+]
+
+sigaction!: alias struct! [
+	sigaction	[integer!]					;-- Warning: compiled as union on most UNIX
+	flags		[integer!]
+	mask0		[integer!]					;-- array of 4 uint32
+	mask1		[integer!]
+	mask2		[integer!]
+	mask3		[integer!]
+]
+
+siginfo!: alias struct! [
+	signal		[integer!]
+	error		[integer!]
+	code		[integer!]
+	pid			[integer!]
+	uid			[integer!]
+	status		[integer!]
+	address		[integer!]					;-- this field is a C union, dependent on signal
+	;... remaining fields skipped
+]
+
+;; Copied from FreeBSD
+
+#define UCTX_DEFINITION [
+	_ucontext!: alias struct! [
+		sigmask0	[integer!]			;-- __sigset defined as an array of 4 uint32
+		sigmask1	[integer!]
+		sigmask2	[integer!]
+		sigmask3	[integer!]
+		onstack		[integer!]			;-- mcontext_t inlined
+		mc_gs		[integer!]
+		mc_fs		[integer!]
+		mc_es		[integer!]
+		mc_ds		[integer!]
+		mc_edi		[integer!]
+		mc_esi		[integer!]
+		mc_ebp		[integer!]
+		mc_isp		[integer!]
+		mc_ebx		[integer!]
+		mc_edx		[integer!]
+		mc_ecx		[integer!]
+		mc_eax		[integer!]
+		mc_trapno	[integer!]
+		mc_err		[integer!]
+		mc_eip		[integer!]
+		mc_cs		[integer!]
+		mc_eflags	[integer!]
+		mc_esp		[integer!]
+		mc_ss		[integer!]
+		mc_len		[integer!]
+		mc_fpformat	[integer!]
+		mc_ownedfp	[integer!]
+		mc_flags	[integer!]
+		;... remaining fields skipped
+	]
+]
+
+#define UCTX_INSTRUCTION(ctx)		[ctx/mc_eip]
+#define UCTX_GET_STACK_TOP(ctx)		[ctx/mc_esp]
+#define UCTX_GET_STACK_FRAME(ctx)	[ctx/mc_ebp]
+
+;-------------------------------------------
+;-- Retrieve command-line information from stack
+;-------------------------------------------
+#if type = 'exe [
+	#either use-natives? = yes [
+		system/args-count:	pop
+		system/args-list:	as str-array! system/stack/top
+		system/env-vars:	system/args-list + system/args-count + 1
+	][
+		;-- the current stack is pointing to main(int argc, void **argv, void **envp) C layout
+		;-- we avoid the double indirection by reusing our variables from %start.reds
+		system/args-count:	***__argc
+		system/args-list:	as str-array! ***__argv
+		system/env-vars:	system/args-list + system/args-count + 1
+	]
+]
+
+#include %POSIX.reds

--- a/system/runtime/start.reds
+++ b/system/runtime/start.reds
@@ -27,10 +27,10 @@ system: declare struct! [							;-- trimmed down temporary system definition
 ]
 
 
-#switch OS [
-	Windows []										;-- nothing to do, initialization occurs in DLL init entry point
-	macOS   []										;-- nothing to do @@
-	FreeBSD [
+#case [
+	OS = 'Windows []										;-- nothing to do, initialization occurs in DLL init entry point
+	OS = 'macOS   []										;-- nothing to do @@
+	any [OS = 'FreeBSD OS = 'NetBSD] [
 		#import [ LIBC-file cdecl [
 			***__atexit: "atexit" [fun [pointer! [byte!]]]
 			***__exit: "exit" [code [integer!]]]
@@ -67,7 +67,7 @@ system: declare struct! [							;-- trimmed down temporary system definition
 		#export [environ __progname]
 	]
 
-	Syllable [
+	OS = 'Syllable [
 		#import [LIBC-file cdecl [
 			libc-start: "__libc_start_main" [
 				main 			[function! []]
@@ -108,7 +108,7 @@ system: declare struct! [							;-- trimmed down temporary system definition
 		libc-start :***_start ***__argv ***__envp null null ***__stack_end		
 	]
 	
-	Android [
+	OS = 'Android [
 		#import [LIBC-file cdecl [
 			libc-init: "__libc_init" [
 				args 			[pointer! [integer!]]
@@ -140,7 +140,7 @@ system: declare struct! [							;-- trimmed down temporary system definition
 		libc-init ***__argv - 1 null :***_start ***__argv - 16
 	]
 	
-	#default [										;-- for SVR4 fully conforming UNIX platforms
+	true [										;-- for SVR4 fully conforming UNIX platforms
 		#import [LIBC-file cdecl [
 			libc-start: "__libc_start_main" [
 				main 			[function! []]

--- a/system/targets/IA-32.r
+++ b/system/targets/IA-32.r
@@ -2076,7 +2076,7 @@ make-profilable make target-class [
 			compiler/job/OS <> 'Windows
 			slots: emitter/struct-slots?/check spec/4
 			not all [
-				find [macOS FreeBSD] compiler/job/OS ;-- for those OS,
+				find [macOS FreeBSD NetBSD] compiler/job/OS ;-- for those OS,
 				slots <= 2							;-- <ptr> is used for slots > 2 only
 			]
 			size: size - stack-width				;-- hidden pointer is freed by callee

--- a/usage.txt
+++ b/usage.txt
@@ -85,5 +85,6 @@ Cross-compilation targets:
     macOS        : macOS Intel, GUI-only, applications bundles
     Syllable     : Syllable OS, x86
     FreeBSD      : FreeBSD, x86
+    NetBSD       : NetBSD, x86
     Android      : Android, ARMv5
     Android-x86  : Android, x86


### PR DESCRIPTION
Successfully ported Red to NetBSD (x86, non-GUI console), fixing some FreeBSD and ELF generation issues along.

Everything seems to work so far, but you need NetBSD/i386 to run it, as NetBSD/amd64 lacks 32-bit libcurl in binary packages. You could probably build 32-bit libcurl manually and place it properly for multiarch setup (NetBSD supports this in general), but this is distro-specific effort and not related to the porting part itself.

(Separate commits squashed to avoid merge issues)