### PR TITLE
FIX: when change selected/data of text-list, shouldn't trigger on-changed

### DIFF
--- a/modules/view/backends/gtk3/gui.reds
+++ b/modules/view/backends/gtk3/gui.reds
@@ -1155,9 +1155,11 @@ change-data: func [
 			type = text-list
 			TYPE_OF(data) = TYPE_BLOCK
 		][
+			g_signal_handlers_block_by_func(widget :text-list-selected-rows-changed widget)
 			gtk_list_box_unselect_all widget
 			gtk_container_foreach widget as-integer :remove-entry widget
 			init-text-list widget as red-block! data selected
+			g_signal_handlers_unblock_by_func(widget :text-list-selected-rows-changed widget)
 		]
 		any [type = drop-list type = drop-down][
 			init-combo-box widget as red-block! data null type = drop-list
@@ -1226,7 +1228,9 @@ change-selection: func [
 			select-camera widget idx
 		]
 		type = text-list [
+			g_signal_handlers_block_by_func(widget :text-list-selected-rows-changed widget)
 			select-text-list widget idx
+			g_signal_handlers_unblock_by_func(widget :text-list-selected-rows-changed widget)
 		]
 		any [type = drop-list type = drop-down][
 			gtk_combo_box_set_active widget idx


### PR DESCRIPTION
example 1:
```
d: ["1" "2" "3" "4" "yikes!"]
view [tl: text-list 100x300 data d [print 1] button "xxx" [either tl/selected [tl/selected: tl/selected + 1][tl/selected: 1]]]
```
example 2:
```
d: ["1" "2" "3" "4" "yikes!"]
view [tl: text-list 100x300 data d [print 1] button "xxx" [append d "x"]]
```