### PR TITLE
FIX: regression in PR 4144

### DIFF
--- a/runtime/interpreter.reds
+++ b/runtime/interpreter.reds
@@ -685,6 +685,7 @@ interpreter: context [
 				if set? [fire [TO_ERROR(script invalid-path-set) path]]
 				if get? [fire [TO_ERROR(script invalid-path-get) path]]
 				pc: eval-code parent pc end yes path item - 1 parent
+				unless sub? [stack/set-last stack/top]
 				return pc
 			]
 			TYPE_UNSET [fire [TO_ERROR(script no-value)	head]]

--- a/tests/source/units/evaluation-test.red
+++ b/tests/source/units/evaluation-test.red
@@ -101,6 +101,53 @@ Red [
 
 ===end-group===
 
+===start-group=== "do path"
+
+	--test-- "do-path-1"
+		t: 0
+		f: func [/x] [t: 1 2]
+		--assert 2 == do 'f/x
+		--assert 1 == t
+
+	--test-- "do-path-2"
+		t: 0
+		f: func [/x] [t: 1 2]
+		--assert 2 == do as path! [f x]
+		--assert 1 == t
+
+	--test-- "do-path-3"
+		t: 0
+		f: func [/x] [t: 1 2]
+		g: does ['f/x]
+		--assert 2 == do g
+		--assert 1 == t
+
+
+	--test-- "do-path-4"								;-- path to func inside object
+		t: 0
+		o: make object! [
+			f: func [/x] [t: 1 2]
+		]
+		g: does ['o/f/x]
+		--assert 2 == do g
+		--assert 1 == t
+
+	--test-- "do-path-5"								;-- forbid variadic use: should not take args
+		t: 0
+		f: func [/x y] [t: 1 2]
+		g: does ['f/x]
+		--assert error? try [do g 'arg]
+
+	--test-- "do-path-6"								;-- forbid variadic use: should not take args
+		t: 0
+		o: make object! [
+			f: func [/x y] [t: 1 2]
+		]
+		g: does ['o/f/x]
+		--assert error? try [do g 'arg]
+
+===end-group===
+
 ===start-group=== "reduce"
 
 	--test-- "reduce-1"

--- a/tests/source/units/regression-test-red.red
+++ b/tests/source/units/regression-test-red.red
@@ -2810,7 +2810,7 @@ b}
 		forall refs3385 [
 			foreach ref3385 next refs3385 [
 				path3385: as path! reduce ['now refs3385/1 ref3385]
-				--assert types3385/:i3385 = attempt [type? do reduce [path3385]]
+				--assert types3385/:i3385 = attempt [type? do path3385]
 				i3385: i3385 + 1
 			]
 		]


### PR DESCRIPTION
also provides tests to ensure `do` cannot be used to make variadic calls