### PR TITLE
FIX: issue #4365 (`mold/flat` has no effect on binary values).

### DIFF
--- a/runtime/datatypes/binary.reds
+++ b/runtime/datatypes/binary.reds
@@ -854,7 +854,8 @@ binary: context [
 			size   [integer!]
 	][
 		#if debug? = yes [if verbose > 0 [print-line "binary/serialize"]]
-
+		
+		if part < 0 [part: 0]
 		s: GET_BUFFER(bin)
 		head: (as byte-ptr! s/offset) + bin/head
 		tail: as byte-ptr! s/tail
@@ -862,7 +863,7 @@ binary: context [
 
 		string/concatenate-literal buffer "#{"
 		bytes: 0
-		if size > 30 [
+		if all [size > 30 not flat?][
 			string/append-char GET_BUFFER(buffer) as-integer lf
 			part: part - 1
 		]
@@ -870,7 +871,7 @@ binary: context [
 		while [head < tail][
 			string/concatenate-literal buffer string/byte-to-hex as-integer head/value
 			bytes: bytes + 1
-			if bytes % 32 = 0 [
+			if all [bytes % 32 = 0 not flat?][
 				string/append-char GET_BUFFER(buffer) as-integer lf
 				part: part - 1
 			]
@@ -878,7 +879,7 @@ binary: context [
 			if all [OPTION?(arg) part <= 0][return part]
 			head: head + 1
 		]
-		if all [size > 30 bytes % 32 <> 0] [
+		if all [size > 30 bytes % 32 <> 0 not flat?][
 			string/append-char GET_BUFFER(buffer) as-integer lf
 			part: part - 1
 		]

--- a/tests/source/units/serialization-test.red
+++ b/tests/source/units/serialization-test.red
@@ -91,6 +91,31 @@ ser-formed: {1 none true false c red Red a/b 'a/b :a/b a/b: 1 + 2 a  a c d b e f
  
 ===end-group===
 
+===start-group=== "binary"
+	--test-- "binary-1"  --assert "#{}" = mold #{}
+	--test-- "binary-2"  --assert "#{}" = form #{}
+	--test-- "binary-3"  --assert "#{ABCD}" = mold #{abcd}
+	--test-- "binary-4"  --assert "#{ABCD}" = form #{abcd}
+	--test-- "binary-5"  --assert "" = mold/part #{deadbeef} -1
+	--test-- "binary-6"  --assert "" = mold/part #{deadbeef} 0
+	--test-- "binary-7"  --assert "#" = mold/part #{deadbeef} 1
+	--test-- "binary-8"  --assert "#{DEADBEEF}" = mold/part #{deadbeef} 11
+	--test-- "binary-9"  --assert "#{DEADBEEF}" = mold/part #{deadbeef} 100
+	--test-- "binary-10" --assert "" = form/part #{deadbeef} -1
+	--test-- "binary-11" --assert "" = form/part #{deadbeef} 0
+	--test-- "binary-12" --assert "#" = form/part #{deadbeef} 1
+	--test-- "binary-13" --assert "#{DEADBEEF}" = form/part #{deadbeef} 11
+	--test-- "binary-14" --assert "#{DEADBEEF}" = form/part #{deadbeef} 100
+	--test-- "binary-15"
+		--assert equal?
+			rejoin ["#{" newline append/dup "" "DEADBEEF" 8 newline "DEADBEEF" newline "}"]
+			mold append/dup #{} #{deadbeef} 9
+	--test-- "binary-16"
+		--assert equal?
+			rejoin ["#{" append/dup "" "DEADBEEF" 10 "}"]
+			mold/flat append/dup #{} #{deadbeef} 10
+===end-group===
+
 ===start-group=== "logic"
 	
 	--test-- "mold-logic1"


### PR DESCRIPTION
Fixes #4365 and provides serialization tests for `binary!` that cover `mold/flat` case.