### PR TITLE
FIX: issue #4537 (/LOCAL refinement injected by function constructors is malformed).

### DIFF
--- a/runtime/datatypes/word.reds
+++ b/runtime/datatypes/word.reds
@@ -390,21 +390,23 @@ word: context [
 			dt		[red-datatype!]
 			bool	[red-logic!]
 			str		[red-string!]
+			word	[red-word!]
 			name	[names!]
 			cstr	[c-string!]
 			len		[integer!]
+			index	[integer!]
 			val		[red-value!]
 	][
 		#if debug? = yes [if verbose > 0 [print-line "word/to"]]
 
 		switch TYPE_OF(spec) [
-			TYPE_WORD
-			TYPE_SET_WORD
-			TYPE_GET_WORD
-			TYPE_LIT_WORD
-			TYPE_REFINEMENT [proto: spec]
+			TYPE_ANY_WORD [proto: spec]
+			TYPE_REFINEMENT
 			TYPE_ISSUE [
-				check-1st-char as red-word! spec
+				word: as red-word! spec
+				if TYPE_OF(spec) = TYPE_ISSUE [check-1st-char word]
+				index: _context/bind-word TO_CTX(global-ctx) word	;-- issue #4537
+				assert index >= 0
 				proto: spec
 			]
 			TYPE_STRING [

--- a/tests/source/units/evaluation-test.red
+++ b/tests/source/units/evaluation-test.red
@@ -578,7 +578,7 @@ Red [
 		set quote obj/a: 4
 		--assert 4 == get quote obj/a:
 	
-	--test-- "set-13"								;-- extra tests to see how compiler handles GET-PATH!s
+	--test-- "set-30"								;-- extra tests to see how compiler handles GET-PATH!s
 		obj: object [a: 0]
 		
 		set to get-path! 'obj/a 1
@@ -589,7 +589,7 @@ Red [
 		
 		set load ":obj/a" 3
 		--assert 3 == get load ":obj/a"
-
+	
 ===end-group===
 
 ~~~end-file~~~

--- a/tests/source/units/regression-test-red.red
+++ b/tests/source/units/regression-test-red.red
@@ -3051,7 +3051,21 @@ comment {
 	
 	--test-- "#4522"
 		--assert error? try [find/skip [1] [1] ()]
-
+	
+	--test-- "#4537"
+		local: "global"
+		--assert "global" == get to word! first spec-of has [foo][]
+		--assert "global" == get to word! first spec-of function [][[foo:]]
+		unset 'local
+		
+		--assert equal?
+			system/words
+			context? to word! to issue! in context [foo: 'bar] 'foo
+		
+		--assert equal?
+			system/words
+			context? to word! to refinement! in context [foo: 'bar] 'foo
+	
 	--test-- "#4563" do [							;@@ #4526
 		--assert error? try [make op! :>>]
 		--assert error? try [make op! make op! func [x y][]]


### PR DESCRIPTION
Fixes #4537 with an alternative solution (see the previous one in https://github.com/red/red/pull/4594): `issue!` and `refinement!` values, being strictly symbolic, cannot be acessed by `get` or `set`, but nethertheless can hold a binding to some context internally. This binding can be "revealed" only by convertion of these values to `any-word!`.

But what `to` does in such cases, from now on, is re-binding of a newly created word to global context during conversion. That implicitly resolves the original issue described in #4537.