### PR TITLE
 FIX: issue #4196 (crash on execution of malformed routine). 

### DIFF
--- a/environment/system.red
+++ b/environment/system.red
@@ -119,6 +119,7 @@ system: context [
 				bad-func-def:		["invalid function definition:" :arg1]
 				bad-func-arg:		["function argument" :arg1 "is not valid"]
 				bad-func-extern:	["invalid /extern value:" :arg1]
+				bad-routine-def:	["invalid routine definition:" :arg1]
 				no-refine:			[:arg1 "has no refinement called" :arg2]
 				bad-refines:		"incompatible or invalid refinements"
 				bad-refine:			["incompatible refinement:" :arg1]

--- a/runtime/interpreter.reds
+++ b/runtime/interpreter.reds
@@ -262,6 +262,10 @@ interpreter: context [
 			value: s/offset
 			tail:  s/tail
 			
+			if all [value = tail args <> 0][			;-- issue #4196
+				fire [TO_ERROR(script bad-routine-def) block/push-only* 0]
+			]
+			
 			until [										;-- scan forward for end of arguments
 				switch TYPE_OF(value) [
 					TYPE_SET_WORD

--- a/tests/source/units/regression-test-red.red
+++ b/tests/source/units/regression-test-red.red
@@ -2986,7 +2986,13 @@ comment {
 		--assert not tail? i4056
 		--assert tail? next next next next i4056
 		--assert tail? next back next tail i4056
-
+	
+	--test-- "#4196"
+		clear body-of :as-ipv4
+		--assert 1.3.3.7 == as-ipv4 1 3 3 7
+		clear spec-of :as-ipv4
+		--assert error? do [try [as-ipv4 1 3 3 7]]
+	
 	--test-- "#4205 - seed random with precise time!"
 		anded4205: to integer! #{FFFFFFFF}
 		loop 10 [


### PR DESCRIPTION
Fixes #4196 by adding an extra error check in the interpreter, which uses the content of routine's spec block for argument type checking. Crash occured when there was a mismatch between routine's arity (stored in cell's header) and the actual number of arguments in the spec block.

Regression test is provided, although it's quite devious: by malforming `as-ipv4` (and by extension `as-rgba`) it prevents these routines from being used in the rest of the tests.