### PR TITLE
TESTS: regression test for issue #4613 (compiled script crashes on MONEY! literal with user-defined currency code).

### DIFF
--- a/compiler.r
+++ b/compiler.r
@@ -4834,7 +4834,7 @@ red: context [
 				append boot-extras compose [
 					block/rs-append 
 						as red-block! #get system/locale/currencies/list
-						as red-value! word/load (mold c)
+						as red-value! word/load (uppercase mold c)
 				]
 			]
 			currencies: copy spec

--- a/tests/source/compiler/regression-test-redc-5.r
+++ b/tests/source/compiler/regression-test-redc-5.r
@@ -227,14 +227,6 @@ test
 	--test-- "#3891"
 		--compile-and-run-this-red {probe load "a<=>"}
 		--assert not crashed?
-	
-	--test-- "#4526"
-		--compile-and-run-this {
-			Red []
-			do bind [probe 1 ** 2] context [**: make op! func [x y][x + y]]
-		}
-		--assert compiled?
-		--assert 3 = load qt/output
 		
 ===end-group===
 
@@ -250,6 +242,18 @@ test
 		}
 		--assert not crashed?
 		--assert true? find qt/output "boom"
+		
+===end-group===
+
+===start-group=== "Red regressions #4501 - #5000"
+
+	--test-- "#4526"
+		--compile-and-run-this {
+			Red []
+			do bind [probe 1 ** 2] context [**: make op! func [x y][x + y]]
+		}
+		--assert compiled?
+		--assert 3 = load qt/output
 
 ===end-group===
 

--- a/tests/source/compiler/regression-test-redc-5.r
+++ b/tests/source/compiler/regression-test-redc-5.r
@@ -254,7 +254,23 @@ test
 		}
 		--assert compiled?
 		--assert 3 = load qt/output
-
+	
+	--test-- "#4613"
+		--compile-and-run-this "Red [] probe bug$0"
+		--assert compilation-error?
+		
+		--compile-and-run-this "Red [Currencies: [bug]] probe bug$0"
+		--assert compiled?
+		--assert "BUG$0.00" = qt/output
+		
+		--compile-and-run-this {
+			Red [Currencies: [bug]]
+			append system/locale/currencies/list 'bug
+			probe bug$0
+		}
+		--assert compiled?
+		--assert script-error?
+		
 ===end-group===
 
 ~~~end-file~~~ 


### PR DESCRIPTION
Provides compiler regression test for #4613, also fixes a minor omission: currency symbols from the header are now uppercased and processed in "normalized" form.