### PR TITLE
FIX: bulk SET changes are ignored by CHANGED reflector.

### DIFF
--- a/runtime/datatypes/object.reds
+++ b/runtime/datatypes/object.reds
@@ -149,6 +149,7 @@ object: context [
 			values2	[red-value!]
 			tail	[red-value!]
 			tail2   [red-value!]
+			end		[red-value!]
 			new		[red-value!]
 			old		[red-value!]
 			int		[red-integer!]
@@ -161,15 +162,16 @@ object: context [
 	][
 		smudge: [word/header: word/header or flag-word-dirty]
 	
-		ctx:	GET_CTX(obj)
-		s:		as series! ctx/values/value
-		values: s/offset
-		tail:	s/tail
-		type:	TYPE_OF(value)
+		ctx:	 GET_CTX(obj)
+		s:		 as series! ctx/values/value				;-- object values
+		values:  s/offset
+		tail:	 s/tail
+		type:	 TYPE_OF(value)
 		on-set?: obj/on-set <> null
-		s: _hashtable/get-ctx-words ctx
-		word: as red-word! s/offset
-		tail2: s/tail
+		
+		s:       _hashtable/get-ctx-words ctx				;-- object symbols
+		word:    as red-word! s/offset
+		tail2:   s/tail
 		
 		if on-set? [
 			s: as series! obj/on-set/value
@@ -180,15 +182,21 @@ object: context [
 		]
 
 		either all [not only? any [type = TYPE_BLOCK type = TYPE_OBJECT]][
-			values2: either type = TYPE_BLOCK [				;-- first value slot
-				block/rs-head as red-block! value
+			either type = TYPE_BLOCK [				;-- first value slot
+				end:     block/rs-tail as red-block! value
+				values2: block/rs-head as red-block! value
 			][
-				get-values as red-object! value
+				obj2:    as red-object! value
+				ctx:     GET_CTX(obj2)
+				s:       as series! ctx/values/value 
+				end:     s/tail
+				values2: s/offset
 			]
-
+			
 			i: 0
 			if all [not only? not some?][					;-- pre-check of unset values
 				while [word < tail2][
+					if values2 = end [break]				;-- reached the end of the rightmost argument
 					if all [not any? TYPE_OF(values2) = TYPE_UNSET][
 						fire [TO_ERROR(script need-value) word]
 					]

--- a/runtime/datatypes/object.reds
+++ b/runtime/datatypes/object.reds
@@ -140,6 +140,7 @@ object: context [
 		only? [logic!]
 		some? [logic!]
 		/local
+			smudge  [subroutine!]
 			ctx		[red-context!]
 			ctx2	[red-context!]
 			obj2	[red-object!]
@@ -158,6 +159,8 @@ object: context [
 			type	[integer!]
 			on-set?	[logic!]
 	][
+		smudge: [word/header: word/header or flag-word-dirty]
+	
 		ctx:	GET_CTX(obj)
 		s:		as series! ctx/values/value
 		values: s/offset
@@ -212,6 +215,7 @@ object: context [
 						][
 							copy-cell new values
 						]
+						smudge
 					]
 					i: i + 1
 					word: word + 1
@@ -234,6 +238,7 @@ object: context [
 							][
 								copy-cell new values
 							]
+							smudge
 						]
 					]
 					word: word + 1
@@ -252,6 +257,7 @@ object: context [
 				][
 					copy-cell value values
 				]
+				smudge
 				i: i + 1
 				word: word + 1
 				values: values + 1

--- a/tests/source/units/object-test.red
+++ b/tests/source/units/object-test.red
@@ -2146,6 +2146,58 @@ Red [
 
 ===end-group===
 
+===start-group=== "changed fields"
+	
+	reset: func [foo [object!]][modify foo 'changed none]
+	ebbs?: func [foo [object!]][reflect foo 'changed]
+	
+	foo: reset object [x: y: 0]						;@@ RESET is required to trick the compiler
+
+	--test-- "changed-1"		
+		--assert [] = ebbs? foo
+		foo/x: 1
+		--assert [x] = ebbs? foo
+		
+	--test-- "changed-2"
+		put foo 'y 2
+		--assert [x y] = ebbs? foo
+		--assert [] = ebbs? reset foo
+	
+	--test-- "changed-3"
+		do bind [x: y: 0] foo
+		--assert [x y] = ebbs? foo
+		
+	--test-- "changed-4"
+		set in reset foo 'y 1
+		--assert [y] = ebbs? foo
+		
+	--test-- "changed-5"
+		set 'foo/x 2
+		--assert [x y] = ebbs? foo
+		--assert [] = ebbs? reset foo
+	
+	--test-- "changed-6"
+		set foo [bar]
+		--assert [x y] = ebbs? foo					;-- Y was set to NONE
+	
+	--test-- "changed-7"
+		set/some reset foo [bar]
+		--assert [x] = ebbs? foo					;-- Y was ignored
+	
+	--test-- "changed-8"
+		set reset foo object []
+		--assert [] = ebbs? foo
+	
+	--test-- "changed-9"
+		set reset foo object [y: 2]
+		--assert [y] = ebbs? foo
+	
+	--test-- "changed-10"
+		set reset foo object [x: 1 y: 2]
+		--assert [x y] = ebbs? foo
+	
+===end-group===
+
 ===start-group=== "set"
 
 	--test-- "os1"


### PR DESCRIPTION
`changed` property was added to objects in 05f99635 and is briefly described [here](https://github.com/red/red/wiki/%5BNOTE%5D-Undocumented-features#changed-reflector-in-objects). It works as intended with an exception of bulk `set` changes (i.e. `set <object> ...`) — this PR fixes that ommission, along with some minor out-of-range bug within `object/set-many`.

Relevant tests are also provided.