### PR TITLE
FIX: issue #4733 ([VID] Late switching of layout direction)

### DIFF
--- a/modules/view/VID.red
+++ b/modules/view/VID.red
@@ -633,7 +633,12 @@ system/view/VID: context [
 					bound: max bound cursor
 				]
 				space	[spacing: fetch-argument pair! spec]
-				origin	[origin: cursor: pad + top-left: fetch-argument pair! spec  last-size: none]
+				origin	[
+					origin: cursor: pad + top-left: fetch-argument pair! spec
+					do re-align
+					limit: tail list
+					last-size: none
+				]
 				at		[at-offset: fetch-expr 'spec spec: back spec]
 				pad		[cursor: cursor + fetch-argument pair! spec]
 				do		[do-safe bind fetch-argument block! spec panel]
@@ -750,6 +755,7 @@ system/view/VID: context [
 			]
 			spec: next spec
 		]
+		if last-size [cursor/:anti: cursor/:anti - last-size/:anti]
 		do re-align
 		process-reactors reactors						;-- Needs to be after [set name face]
 		

--- a/modules/view/VID.red
+++ b/modules/view/VID.red
@@ -529,7 +529,6 @@ system/view/VID: context [
 		begin:		  tail list
 		size:		  none								;-- user-set panel's size
 		max-sz:		  0									;-- maximum width/height of current column/row
-		current:	  0									;-- layout's cursor position
 		global?: 	  yes								;-- TRUE: panel options expected
 		below?: 	  no
 		

--- a/modules/view/VID.red
+++ b/modules/view/VID.red
@@ -549,7 +549,6 @@ system/view/VID: context [
 			]
 			align-faces begin direction align max-sz
 			begin: tail list
-		probe length? limit
 			unless empty? limit [begin: back begin]		;-- allow to realign the last face (e.g. below -> across -> across bottom)
 			
 			words: pick [[left center right][top middle bottom]] below?
@@ -626,7 +625,7 @@ system/view/VID: context [
 					do re-align
 					max-sz: 0
 					if begin/1 [						;-- last face is still subject to alignment?
-						cursor: cursor - (probe saved) + probe begin/1/offset		;-- re-align may have moved the last face
+						cursor: cursor - saved + begin/1/offset		;-- re-align may have moved the last face
 						max-sz: begin/1/size/(pick [x y] below?)
 						if divides [throw-error spec]	;-- forbid change of direction in grid mode
 					]

--- a/modules/view/VID.red
+++ b/modules/view/VID.red
@@ -520,7 +520,7 @@ system/view/VID: context [
 		/local axis anti								;-- defined in a SET block
 	][
 		background!:  make typeset! [image! file! url! tuple! word! issue!]
-		list:		  make block! 4						;-- panel's pane block
+		limit: list:  make block! 4						;-- panel's pane block
 		reactors:     make block! 10					;-- reactors of this particular layout
 		local-styles: any [css make block! 2]			;-- panel-local styles definitions
 		pane-size:	  0x0								;-- panel's content dynamic size
@@ -549,6 +549,8 @@ system/view/VID: context [
 			]
 			align-faces begin direction align max-sz
 			begin: tail list
+		probe length? limit
+			unless empty? limit [begin: back begin]		;-- allow to realign the last face (e.g. below -> across -> across bottom)
 			
 			words: pick [[left center right][top middle bottom]] below?
 			align: any [								;-- set new alignment
@@ -566,6 +568,7 @@ system/view/VID: context [
 				max-sz: spacing/:anti
 				cursor/:anti: cursor/:anti + max-sz
 			]
+			limit: tail list							;-- exclude placed items from further alignment
 			do re-align
 			cursor: as-pair origin/:axis spacing/:anti + max bound/:anti cursor/:anti + max-sz 
 			if direction = 'below [cursor: reverse cursor]
@@ -622,13 +625,10 @@ system/view/VID: context [
 					saved: attempt [select last list 'offset]
 					do re-align
 					max-sz: 0
-					if direction <> value [				;-- row & column intersect at this face
-						begin: back begin				;-- so it has to be aligned along both axes
-						if begin/1 [
-							cursor: cursor - saved + begin/1/offset		;-- re-align may have moved the last face
-							max-sz: begin/1/size/(pick [x y] below?)
-							if divides [throw-error spec]	;-- forbid change of direction in grid mode
-						]
+					if begin/1 [						;-- last face is still subject to alignment?
+						cursor: cursor - (probe saved) + probe begin/1/offset		;-- re-align may have moved the last face
+						max-sz: begin/1/size/(pick [x y] below?)
+						if divides [throw-error spec]	;-- forbid change of direction in grid mode
 					]
 					direction: value
 					bound: max bound cursor

--- a/tests/clip-test.red
+++ b/tests/clip-test.red
@@ -61,8 +61,6 @@ board: layout [
 	below
 	label: text "" 200x30 font [size: 14]
 	canvas: base 200x200 255.0.0.128
-	below
-	across
 	btn-prev: button "previous" [ 
 		unless btn-next/enabled? [ btn-next/enabled?: true ]
 		either index > 2 [
@@ -72,6 +70,7 @@ board: layout [
 			show canvas
 		][ btn-prev/enabled?: false ]
 	]
+	across
 	btn-next: button "next" [
 		unless btn-prev/enabled? [ btn-prev/enabled?: true ]
 		either index < length? drawings [

--- a/tests/complexpen-test.red
+++ b/tests/complexpen-test.red
@@ -681,8 +681,6 @@ board: layout [
     below
     label: text "" 400 font [size: 16]
     canvas: base 700x400
-    below
-    across
     btn-prev: button "previous" [ 
         unless btn-next/enabled? [ btn-next/enabled?: true ]
         either index > 2 [
@@ -692,6 +690,7 @@ board: layout [
             show canvas
         ][ btn-prev/enabled?: false ]
     ]
+    across
     btn-next: button "next" [
         unless btn-prev/enabled? [ btn-prev/enabled?: true ]
         either index < length? drawings [

--- a/tests/matrix-test.red
+++ b/tests/matrix-test.red
@@ -87,8 +87,6 @@ board: layout [
 	below
 	label: text "" 200x30 font [size: 14]
 	canvas: base 600x400
-	below
-	across
 	btn-prev: button "previous" [ 
 		unless btn-next/enabled? [ btn-next/enabled?: true ]
 		either index > 2 [
@@ -98,6 +96,7 @@ board: layout [
 			show canvas
 		][ btn-prev/enabled?: false ]
 	]
+	across
 	btn-next: button "next" [
 		unless btn-prev/enabled? [ btn-prev/enabled?: true ]
 		either index < length? drawings [

--- a/tests/select-text.red
+++ b/tests/select-text.red
@@ -21,8 +21,7 @@ view [
 			f/parent/selected: f
 			f/selected: 1x5
 		]
-		across
-		text "Field:" 30 text "" left react [face/data: f/selected] return
+		text "Field:" 30 across text "" left react [face/data: f/selected] return
 		text "Area:"  30 text "" left react [face/data: a/selected]
 	]
 ]

--- a/tests/shape-test.red
+++ b/tests/shape-test.red
@@ -231,8 +231,6 @@ board: layout [
     below
     label: text "" 200 font [size: 16]
     canvas: base 700x400
-    below
-    across
     btn-prev: button "previous" [ 
         unless btn-next/enabled? [ btn-next/enabled?: true ]
         either index > 2 [
@@ -242,6 +240,7 @@ board: layout [
             show canvas
         ][ btn-prev/enabled?: false ]
     ]
+    across
     btn-next: button "next" [
         unless btn-prev/enabled? [ btn-prev/enabled?: true ]
         either index < length? drawings [

--- a/tests/vid.red
+++ b/tests/vid.red
@@ -31,13 +31,14 @@ view [
 		"tab2" [at 80x10 text "two"]
 	]
 	
-	below
 	slider 5%
+	below
 	pad 10x0 bar: progress 50% 130
 	base 255.0.0.138 50x50 draw [fill-pen blue circle 25x25 15]
 	across
 	return middle
 	
+	pad 0x20
 	check "option 1" font-size 14
 	check "option 2" font-color orange
 	radio "option 3" font-name "Times New Roman"

--- a/tests/vid2.red
+++ b/tests/vid2.red
@@ -16,13 +16,12 @@ view [
 
    	below left
    	button "ok" base green text "4" 
+   	button "ok"
+    across base yellow 350x250 text "5"
 
-   	across 
-   	button "ok" base yellow 350x250 text "5"
+   	button "ok"
+    below center base green text "6" return
 
-    below center
-   	button "ok" base green text "6" return
-
-   	below right
-   	button "ok" base green text "7" return
+   	button "ok"
+    below right base green text "7" return
 ]

--- a/tests/vid5.red
+++ b/tests/vid5.red
@@ -8,6 +8,7 @@ Red [
 system/view/VID/debug?: yes
 view [
 	at 1x110 base 1100x1 black
+	origin 10x10
     across top	  base 1x60 button 50x50 button "OK" text "text" cyan field drop-down drop-list check yellow radio yellow progress slider return
     across middle base 1x60 button 50x50 button "OK" text "text" cyan field drop-down drop-list check yellow radio yellow progress slider return
     across bottom base 1x60 button 50x50 button "OK" text "text" cyan field drop-down drop-list check yellow radio yellow progress slider 

--- a/tests/vid6.red
+++ b/tests/vid6.red
@@ -8,6 +8,7 @@ Red [
 system/view/VID/debug?: yes
 view [
 	at 320x1 base 1x400 black
+	origin 10x10
     below left	 base 200x1 button 50x50 button "OK" text "text" cyan field drop-down check yellow radio yellow drop-list progress slider return
     below center base 200x1 button 50x50 button "OK" text "text" cyan field drop-down check yellow radio yellow drop-list progress slider return
     below right  base 200x1 button 50x50 button "OK" text "text" cyan field drop-down check yellow radio yellow drop-list progress slider


### PR DESCRIPTION
**I. Implements alternative reading semantics of across/below keywords:**

In doing so, fixes #4733 

Was:
| Code | Meaning |
| --- | --- |
| `across` | "across this.." |
| `base` | "..BASE, place the next face.." |
| `below` | "below this.." |
| `field` | "..FIELD, place the next.." |
| `field` | "..FIELD" |

New:
| Code | Meaning |
| --- | --- |
| `across` | (no effect, overridden further) |
| `base` | "place this BASE.." |
| `below` | "below it.." |
| `field` | "place a FIELD.." |
| `field` | "then another FIELD" |

Which arguably is more predictable and human-friendly, esp. in stair layouts. (And if you insert `return` between faces in the layout below, you'll totally lose track of things :p)
E.g.: 
```
view layout [
    space 8x2 pad 5x20
    across bottom   base field base 80x70
    below right     field 60x25 base 70x70
    across          pad 5x0 base base 40x40
    below           base
    across          base
]
```
| Old | New |
| ---| ---|
| ![](https://i.gyazo.com/26a525d82d5341b4d171daa5376d49fa.png) | ![](https://i.gyazo.com/234229f3803fd951f7e14ac28c871b28.png) |

And simpler: `view [base base below base across base below base across base]`
| Old | New |
| --- | --- |
| ![](https://i.gyazo.com/c82acc6064c2fadf66999e6532641d84.png) | ![](https://i.gyazo.com/403083d14a552879a7546e48f1900204.png) |

---
**II. Also throws an error when one attempts to change flow direction in GRID mode:** `view [panel 2 [below base across base base]]`, as results of it are (and were) unpredictable. 

If someone has an idea of how we can *usefully* combine grid mode with flow diversion, I can implement it.
