### PR TITLE
An alternate way to create Red binary

### DIFF
--- a/build/build-red.r
+++ b/build/build-red.r
@@ -56,7 +56,7 @@ save-files red-repo src-files
 
 script: [Red [
 	Title: "Red Programming Language"
-	Version: 0.6.6
+	Version: 0.6.4
 	Rights:  "Copyright (C) 2014-2020 Red Foundation. All rights reserved."
 	Needs: view
 	]

--- a/build/build-red.r
+++ b/build/build-red.r
@@ -1,0 +1,44 @@
+Rebol [
+	Title:   "Red binary build script"
+	Author:  "Xie Qingtian"
+	File: 	 %build-red.r
+	Tabs:	 4
+	Rights:  "Copyright (C) 2011-2020 Red Foundation. All rights reserved."
+	License: "BSD-3 - https://github.com/red/red/blob/master/BSD-3-License.txt"
+]
+
+rebol-bin: read/binary to-rebol-file system/script/args
+src-files: pick load %includes.r 8
+
+;-- save source files
+red-repo: make block! 20
+save-files: func [out src-files /local f][
+	foreach f src-files [
+		either block? f [
+			change-dir last out
+			append/only out make block! 20
+			save-files last out f
+			change-dir %..
+		][
+			append out f
+			unless dir? f [append out read/binary f]
+		]
+	]
+]
+change-dir %..		;-- change to the root directory of red repo
+save-files red-repo src-files
+
+script: [Red [Needs: view]
+	red-toolchain: none
+	red-toolchain?: yes
+	#include %../environment/console/CLI/console.red
+]
+poke script 4 reduce [rebol-bin red-repo]
+
+change-dir %build/
+red-src: %red.red
+save red-src script
+
+print "Encapping..."
+system/options/args: none
+do/args %../red.r join "-r " red-src

--- a/build/build-red.r
+++ b/build/build-red.r
@@ -13,7 +13,7 @@ comment {
         >> change-dir %<path-to-Red>/build/
 
 2. Run the build script from the console:
-		; do/args %build-red.r "path-to-rebol" [target-OS] [noview]	;-- args order matters
+		; do/args %build-red.r "path-to-rebol" [target] [noview|GUI]	;-- args order matters
 		
         >> do/args %build-red.r "path-to-rebol"			;-- generate for the current OS
         >> do/args %build-red.r "path-to-rebol" Linux	;-- generate for Linux OS
@@ -24,8 +24,11 @@ comment {
 4. Enjoy!
 }
 
+git-file:		%git.r
+
 args: parse/all system/script/args " "
 noview?: args/3 = "noview"
+GUI?: args/3 = "GUI"
 target: args/2
 Windows?: any [
 	all [none? target system/version/4 = 3]
@@ -35,6 +38,9 @@ if all [Windows? none? target][target: "Windows"]
 
 rebol-bin: read/binary to-rebol-file args/1
 src-files: pick load %includes.r 8
+
+;-- Try to get version data from git repository
+save git-file do %git-version.r
 
 ;-- save source files
 red-repo: make block! 20
@@ -58,10 +64,10 @@ script: [Red [
 	Title: "Red Programming Language"
 	Version: 0.6.4
 	Rights:  "Copyright (C) 2014-2020 Red Foundation. All rights reserved."
+	Config: [gui-console?: no unicode?: yes red-help?: yes toolchain?: yes]
 	Needs: view
 	]
 	red-toolchain: none
-	red-toolchain?: yes
 	#include
 ]
 poke script 4 reduce [rebol-bin red-repo]
@@ -70,10 +76,8 @@ either noview? [
 	clear skip tail script/2 -2
 	append script %../environment/console/CLI/console.red
 ][
-	append script either Windows? [
-		append script/2 [
-			Config: [gui-console?: yes red-help?: yes]
-		]
+	append script either any [GUI? Windows?][
+		poke script/2/8 2 'yes
 		%../environment/console/GUI/gui-console.red	
 	][
 		%../environment/console/CLI/console.red

--- a/build/build-red.r
+++ b/build/build-red.r
@@ -7,6 +7,20 @@ Rebol [
 	License: "BSD-3 - https://github.com/red/red/blob/master/BSD-3-License.txt"
 ]
 
+comment {
+1. Open a Rebol console, and CD to the **%build/** folder.
+
+        >> change-dir %<path-to-Red>/build/
+
+2. Run the build script from the console:
+
+        >> do/args %build-red.r "path-to-rebol"
+        
+3. After a few seconds, a new **red** binary will be available in the **build/bin/** folder.
+
+4. Enjoy!
+}
+
 rebol-bin: read/binary to-rebol-file system/script/args
 src-files: pick load %includes.r 8
 
@@ -42,3 +56,7 @@ save red-src script
 print "Encapping..."
 system/options/args: none
 do/args %../red.r join "-r " red-src
+
+if system/version/4 <> 3 [	;-- Unix OSes
+	call/wait "chmod 755 ./red"
+]

--- a/build/build-red.r
+++ b/build/build-red.r
@@ -68,6 +68,7 @@ script: [Red [
 	Needs: view
 	]
 	red-toolchain: none
+	#include %toolchain.red
 	#include
 ]
 poke script 4 reduce [rebol-bin red-repo]

--- a/build/includes.r
+++ b/build/includes.r
@@ -11,6 +11,7 @@ change-dir %..
 do %system/utils/encap-fs.r
 
 write %build/bin/sources.r set-cache [
+	%red.r
 	%version.r
 	%usage.txt
 	%boot.red
@@ -321,6 +322,7 @@ write %build/bin/sources.r set-cache [
 			%target-class.r
 		]
 		%utils/ [
+			%encap-fs.r
 			%IEEE-754.r
 			%int-to-bin.r
 			%libRedRT.r

--- a/build/toolchain.red
+++ b/build/toolchain.red
@@ -1,0 +1,81 @@
+Red [
+	Title:   "Functions to run the Red toolchain"
+	Author:  "Xie Qingtian"
+	File: 	 %toolchain.red
+	Tabs:	 4
+	Rights:  "Copyright (C) 2011-2020 Red Foundation. All rights reserved."
+	License: "BSD-3 - https://github.com/red/red/blob/master/BSD-3-License.txt"
+]
+
+system/toolchain: context [
+	write-srcs: function [blk][
+		foreach [f b] blk [
+			either block? b [
+				make-dir f
+				change-dir f
+				write-srcs b
+				change-dir %..
+			][
+				write/binary f b
+			]
+		]
+	]
+
+	run: function [cmd][
+		args: split cmd #" "
+		switch?: all [1 = length? args #"-" = first args/1]
+		if all [	;-- file pathname
+			1 = length? args
+			#"-" <> first args/1
+		][return false]
+
+		extract?: no
+		tool-dir: append copy system/options/cache
+				#either config/OS = 'Windows [%RedToolChain/][%.RedToolChain/]
+
+		ts-file: tool-dir/timestamp.red
+		if all [	;-- delete the older version
+			exists? ts-file
+			system/build/date > load ts-file
+		][
+			delete-dir tool-dir
+		]
+		unless exists? tool-dir [
+			extract?: yes
+			make-dir/deep tool-dir
+		]
+
+		rebol: append copy tool-dir #either config/OS = 'Windows [%rebol.exe][%rebol]
+		cwd: what-dir
+		change-dir tool-dir
+		if all [extract? value? 'red-toolchain][	;-- extract toolchain
+			write/binary rebol red-toolchain/1
+			write-srcs red-toolchain/2
+			#if config/OS <> 'Windows [
+				call/wait append "chmod +x " rebol
+			]
+			write ts-file system/build/date
+			unset red-toolchain
+		]
+
+		change-dir cwd
+		unless switch? [
+			print "Compiling, please wait a while..."
+			#if config/gui-console? [
+				vt: gui-console-ctx/terminal
+				loop 50 [vt/do-ask-loop/no-wait]
+			]
+		]
+		out: make string! 1000
+		err: make string! 1000
+		call/output/error rejoin [
+			#"^"" to-local-file rebol #"^""
+			" -cqs "
+			to-local-file tool-dir/red.r " "
+			cmd
+		] out err
+		unless empty? out [print out]
+		unless empty? err [print err]
+		true
+	]
+]

--- a/environment/console/engine.red
+++ b/environment/console/engine.red
@@ -64,15 +64,19 @@ system/console: context [
 		unless exists? rebol [			;-- extract toolchain
 			write/binary rebol red-toolchain/1
 			write-srcs red-toolchain/2
+			#if config/OS <> 'Windows [
+				call/wait append "chmod +x " rebol
+			]
 		]
+
 		change-dir cwd
 		print "Compiling, please wait a while..."
 		out: make string! 1000
 		err: make string! 1000
 		call/output/error rejoin [
-			#"^"" to-string to-local-file rebol #"^""
+			#"^"" to-local-file rebol #"^""
 			" -cqs "
-			to-string to-local-file tool-dir/red.r " "
+			to-local-file tool-dir/red.r " "
 			system/script/args
 		] out err
 		unless empty? out [print out]

--- a/environment/console/engine.red
+++ b/environment/console/engine.red
@@ -53,7 +53,12 @@ system/console: context [
 	]
 
 	call-toolchain: function [][
-		if 1 = length? split system/script/args #" " [return false]
+		args: split system/script/args #" "
+		switch?: all [1 = length? args #"-" = first args/1]
+		if all [	;-- file pathname
+			1 = length? args
+			#"-" <> first args/1
+		][return false]
 
 		tool-dir: append copy system/options/cache
 				#either config/OS = 'Windows [%RedToolChain/][%.RedToolChain/]
@@ -70,7 +75,13 @@ system/console: context [
 		]
 
 		change-dir cwd
-		print "Compiling, please wait a while..."
+		unless switch? [
+			print "Compiling, please wait a while..."
+			#if config/gui-console? [
+				vt: gui-console-ctx/terminal
+				loop 50 [vt/do-ask-loop/no-wait]
+			]
+		]
 		out: make string! 1000
 		err: make string! 1000
 		call/output/error rejoin [
@@ -86,7 +97,7 @@ system/console: context [
 	
 	read-argument: function [/local value][
 		if red-toolchain? [
-			if call-toolchain [quit-return 0]
+			if call-toolchain [return "Red []"]
 			unset red-toolchain
 		]
 		if args: system/script/args [

--- a/environment/functions.red
+++ b/environment/functions.red
@@ -699,6 +699,21 @@ make-dir: function [
 	path
 ]
 
+delete-dir:	func [
+	"Deletes a directory including all files and subdirectories."
+	dir	[file! url!] 
+	/local files
+][
+	if all [
+		dir? dir 
+		dir: dirize	dir	
+		attempt	[files:	read dir]
+	] [
+		foreach	file files [delete-dir dir/:file]
+	] 
+	attempt	[delete	dir]
+]
+
 extract: function [
 	"Extracts a value from a series at regular intervals"
 	series	[series!]

--- a/environment/system.red
+++ b/environment/system.red
@@ -457,4 +457,5 @@ system: context [
 	console:	none
 	view:		none
 	reactivity: none
+	toolchain:	none
 ]

--- a/system/compiler.r
+++ b/system/compiler.r
@@ -76,6 +76,7 @@ system-dialect: make-profilable context [
 		show:				none
 		command-line:		none
 		show-func-map?:		no							;-- yes => output the functions address/name map
+		toolchain?:			no							;-- yes => toolchain mode
 	]
 	
 	compiler: make-profilable context [


### PR DESCRIPTION
This PR contains a script to create Red binary without using Rebol SDK. The created executable has the same features as the current one, plus some advantages:

1. Use red.exe from system path (fix issue #3562 #543, #1547)
2. Use red.exe immediately after downloaded, no precompiling needed.
3. More friendly to the OS's package manager (APT, YUM, etc.)
4. Maybe we can sign it to avoid warning of some Anti-virus software.

Here are the prebuilt binaries for testing:
[red-win.zip](https://github.com/red/red/files/5614742/red-win.zip)
[red-linux.zip](https://github.com/red/red/files/5614746/red-linux.zip)
[red-mac.zip](https://github.com/red/red/files/5614747/red-mac.zip)
