### PR TITLE
20x faster JSON string decoder

### DIFF
--- a/environment/codecs/JSON.red
+++ b/environment/codecs/JSON.red
@@ -31,34 +31,6 @@ context [
 	;-----------------------------------------------------------
 	;-- Generic support funcs
 
-	BOM: [
-		UTF-8		#{EFBBBF}
-		UTF-16-BE	#{FEFF}
-		UTF-16-LE	#{FFFE}
-		UTF-32-BE	#{0000FEFF}
-		UTF-32-LE	#{FFFE0000}
-	]
-
-	BOM-UTF-16?: func [data [string! binary!]][
-		any [find/match data BOM/UTF-16-BE  find/match data BOM/UTF-16-LE]
-	]
-
-	BOM-UTF-32?: func [data [string! binary!]][
-		any [find/match data BOM/UTF-32-BE  find/match data BOM/UTF-32-LE]
-	]
-
-
-	; MOLD adds quotes string!, but not all any-string! values.
-	enquote: func [str [string!] "(modified)"][append insert str {"} {"}]
-
-	high-surrogate?: func [codepoint [integer!]][
-        all [codepoint >= D800h  codepoint <= DBFFh]
-    ]
-    
-	low-surrogate?: func [codepoint [integer!]][
-        all [codepoint >= DC00h  codepoint <= DFFFh]
-    ]
-    
 	translit: func [
 		"Transliterate sub-strings in a string"
 		string [string!] "Input (modified)"
@@ -91,21 +63,14 @@ context [
 		{\r} "^M"
 		{\t} "^-"
 	]
-	red-to-json-escape-table: reverse copy json-to-red-escape-table
-	
+
 	json-esc-ch: charset {"t\/nrbf}             ; Backslash escaped JSON chars
 	json-escaped: [#"\" json-esc-ch]			; Backslash escape rule
-	red-esc-ch: charset {^"^-\/^/^M^H^L}        ; Red chars requiring JSON backslash escapes
 
 	decode-backslash-escapes: func [string [string!] "(modified)"][
 		translit string json-escaped json-to-red-escape-table
 	]
 
-	encode-backslash-escapes: func [string [string!] "(modified)"][
-		translit string red-esc-ch red-to-json-escape-table
-	]
-
-	ctrl-char: charset [#"^@" - #"^_"]			; Control chars 0-31
 	;-----------------------------------------------------------
 	;-- JSON decoder
 	;-----------------------------------------------------------
@@ -178,9 +143,6 @@ context [
 		]
 		s
 	]
-	;str: {\/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%&*()_+-=[]{}|;:',./<>?}
-	;mod-str: decode-backslash-escapes json-ctx/replace-unicode-escapes copy str
-	;mod-str: json-ctx/replace-unicode-escapes decode-backslash-escapes copy str
 
 	;-----------------------------------------------------------
 	;-- Object		

--- a/environment/codecs/JSON.red
+++ b/environment/codecs/JSON.red
@@ -107,12 +107,12 @@ context [
 				src: src + unit
 				c2: switch c2 [
 					#"^"" #"\" #"/" [c2]
-					#"b" #"B" [as-integer #"^H"]   ; #"^(back)"
-					#"f" #"F" [as-integer #"^L"]   ; #"^(page)"
-					#"n" #"N" [as-integer #"^/"]
-					#"r" #"R" [as-integer #"^M"]
-					#"t" #"T" [as-integer #"^-"]
-					#"u" #"U" [
+					#"b" [as-integer #"^H"]   ; #"^(back)"
+					#"f" [as-integer #"^L"]   ; #"^(page)"
+					#"n" [as-integer #"^/"]
+					#"r" [as-integer #"^M"]
+					#"t" [as-integer #"^-"]
+					#"u" [
 						c2: 0
 						loop 4 [
 							c1: string/get-char src unit

--- a/tests/source/units/json-test.red
+++ b/tests/source/units/json-test.red
@@ -214,6 +214,15 @@ Red [
     --test-- "json-codec-3"
         --assert {{"a":{"b":{"c":3,"d":4}}}} = save/as none #("a" #("b" #("c" 3 "d" 4))) 'json
 
+    --test-- "json-codec-4"
+        str: copy ""
+        random/seed 1337
+        loop 1'000'000 [append str random #"^(110)"]
+        save/as bin: #{} str 'json
+        str2: load/as bin 'json
+        --assert str == str2
+        unset [str str2 bin]
+
 ===end-group===
 
 ~~~end-file~~~


### PR DESCRIPTION
before/after
```
length: 1000000
698 ms  [save/as bin: #{} s1 'json]
5297 ms [s2: load/as bin 'json]
s2 == s1 : false
```
```
length: 1000000
548 ms  [save/as bin: #{} s1 'json]
267 ms  [s2: load/as bin 'json]
s2 == s1 : true
```