### PR TITLE
FIX: removed uncalled-for series expansion

### DIFF
--- a/runtime/datatypes/string.reds
+++ b/runtime/datatypes/string.reds
@@ -674,12 +674,16 @@ string: context [
 			UCS-4 [0]
 		]
 		unit: GET_UNIT(s)
-		
-		if ((as byte-ptr! s/tail) + unit) > ((as byte-ptr! s + 1) + s/size) [
-			s: expand-series s 0
+
+		loop 2 [
+			p: (as byte-ptr! s/offset) + (offset << (log-b unit))
+			either (p + unit) > ((as byte-ptr! s/offset) + s/size) [
+				s: expand-series s 0
+			][
+				break
+			]
 		]
 
-		p: (as byte-ptr! s/offset) + (offset << (log-b unit))
 		poke-char s p cp
 		if p >= as byte-ptr! s/tail [s/tail: as cell! p + unit]
 		s

--- a/tests/source/units/json-test.red
+++ b/tests/source/units/json-test.red
@@ -193,6 +193,14 @@ Red [
         str: {{"tag":"value","<tag":"value",">tag":"value","tag<":"value","<tag<":"value",">tag<":"value","tag>":"value","<tag>":"value",">tag>":"value","a<tag>b":"value"}}
         --assert res = load-json str
 
+    --test-- "load-json-23"         ;-- crash test for strings divisable by 16
+        s: "1234567812345678"
+        --assert s = load/as mold s 'json
+
+    --test-- "load-json-24"         ;-- crash test
+        o: load/as {{"location": "関西    ↓詳しいプロ↓"}} 'json
+        --assert o/location = "関西    ↓詳しいプロ↓"
+
 ===end-group===
 
 ===start-group=== "json-codec"


### PR DESCRIPTION
See crash reports from [January 20, 2021 1:10 AM](https://gitter.im/red/codecs?at=600758c9d8bdab473947fe66)

Cause: `string/overwrite-char` extended the series where it wasn't needed or expected.
