### PR TITLE
FIX: issue #4803 (Redbin a little too tight?)

### DIFF
--- a/runtime/redbin.reds
+++ b/runtime/redbin.reds
@@ -147,16 +147,16 @@ redbin: context [
 	
 	;-- Reference sub-system --
 	
-	reset: does [path/reset reference/reset]
+	reset: does [path/reset reference/reset]			;-- should be called before & after `encode`
 	
 	path: context [
-		stack: as int-ptr! 0
+		stack: as int-ptr! 0							;-- initialized by 'reset'
 		top:   stack
 		end:   stack
 		
 		push: func [/local newsz [integer!] new [int-ptr!]] [
 			if top + 1 > end [
-				newsz: (as-integer end - stack) * 3 / 2				;-- +50% of current size
+				newsz: (as-integer end - stack) * 3 / 2					;-- +50% of current size
 				new: as int-ptr! realloc as byte-ptr! stack newsz
 				if null? new [reset fire [TO_ERROR(internal no-memory)]]
 				top: new + (top - stack)
@@ -180,7 +180,7 @@ redbin: context [
 				free as byte-ptr! stack
 				stack: as int-ptr! 0
 			]
-			if null? stack [
+			if null? stack [											;-- start with the min. size
 				stack: as int-ptr! allocate min-size * size? integer!
 				end: stack + min-size
 			]
@@ -189,7 +189,9 @@ redbin: context [
 	]
 	
 	reference: context [
-		list: as int-ptr! 0
+		;-- a map of integer! -> red-integer!
+		map:  as node! 0								;-- initialized in 'reset'
+		list: as int-ptr! 0								;-- as well
 		top:  list
 		end:  list
 		
@@ -198,14 +200,11 @@ redbin: context [
 			return: [int-ptr!]
 			/local
 				here [int-ptr!]
+				slot [red-integer!]
 		][
-			here: list
-			while [here <> top][
-				if node = as node! here/value [return here + 1]
-				here: here + here/2 + 2
-			]
-			
-			null
+			slot: as red-integer! _hashtable/get-value map as-integer node
+			if null? slot [return null]
+			list + slot/value
 		]
 		
 		store: func [
@@ -215,10 +214,11 @@ redbin: context [
 				newsz [integer!]
 				reqsz [integer!]
 				new   [int-ptr!]
+				slot  [red-integer!]
 		][
 			size: (as integer! path/top - path/stack) >> log-b size? integer!
-			if top + size + 2 > end [
-				reqsz: (as-integer (top + size + 2) - list) + 8'192		;-- min. required + reserve for later
+			if top + size + 1 > end [									;-- (node=1) + size
+				reqsz: (as-integer (top + size + 1) - list) + 8'192		;-- min. required + reserve for later
 				newsz: (as-integer end - list) * 3 / 2					;-- +50% of current size
 				if newsz < reqsz [newsz: reqsz]
 				new: as int-ptr! realloc as byte-ptr! list newsz
@@ -227,11 +227,13 @@ redbin: context [
 				end: new + (newsz / size? integer!)
 				list: new
 			]
-			top/1: as integer! node
-			top/2: size
-			top: top + 2
-			copy-memory as byte-ptr! top as byte-ptr! path/stack size * size? integer!
-			top: top + size
+			assert not null? map
+			slot: as red-integer! _hashtable/put-key map as-integer node
+			assert not null? slot
+			integer/make-at as cell! slot (as-integer top - list) / size? integer!
+			top/1: size
+			copy-memory as byte-ptr! top + 1 as byte-ptr! path/stack size * size? integer!
+			top: top + size + 1
 		]
 		
 		reset: func [/local min-size] [
@@ -240,11 +242,17 @@ redbin: context [
 				free as byte-ptr! list
 				list: as int-ptr! 0
 			]
-			if null? list [
+			if null? list [												;-- start with the min. size
 				list: as int-ptr! allocate min-size * size? integer!
 				end: list + min-size
 			]
 			top: list
+			either null? map [
+				map: _hashtable/init 1024 null HASH_TABLE_INTEGER 1
+				_hashtable/mark map
+			][
+				_hashtable/clear-map map
+			]
 		]
 	]
 	
@@ -381,7 +389,7 @@ redbin: context [
 		symbols: binary/make-at stack/push* 4
 		table:   binary/make-at stack/push* 4
 		strings: binary/make-at stack/push* 4
-		
+
 		encode-value data payload symbols table strings
 		size: binary/rs-length? payload
 		
@@ -408,6 +416,7 @@ redbin: context [
 		
 		stack/pop 4
 		
+		reset
 		payload
 	]
 	
@@ -439,7 +448,6 @@ redbin: context [
 			p/4 = #"B" p/5 = #"I" p/6 = #"N"
 		][
 			either codec? [
-				reset
 				fire [TO_ERROR(script invalid-data) stack/arguments]
 			][
 				print-line "Error: Not a Redbin file!"
@@ -531,7 +539,7 @@ redbin: context [
 			TYPE_MONEY [(money/get-sign as red-money! data) << 20]
 			default    [0]
 		]
-		
+
 		switch type [
 			TYPE_UNSET
 			TYPE_NONE		[store payload header]
@@ -593,7 +601,7 @@ redbin: context [
 				unless global? [either null? ref [path/pop][encode-reference ref payload]]
 			]
 		]
-		
+
 		offset: offset + 1
 	]
 	

--- a/runtime/redbin.reds
+++ b/runtime/redbin.reds
@@ -235,6 +235,8 @@ redbin: context [
 			copy-memory as byte-ptr! top + 1 as byte-ptr! path/stack size * size? integer!
 			top: top + size + 1
 		]
+
+		on-gc-mark: does [_hashtable/mark map]
 		
 		reset: func [/local min-size] [
 			min-size: 16'384
@@ -249,13 +251,13 @@ redbin: context [
 			top: list
 			either null? map [
 				map: _hashtable/init 1024 null HASH_TABLE_INTEGER 1
-				_hashtable/mark map
+				collector/register as int-ptr! :on-gc-mark
 			][
 				_hashtable/clear-map map
 			]
 		]
 	]
-	
+
 	encode-reference: func [
 		reference [int-ptr!]
 		payload   [red-binary!]

--- a/runtime/redbin.reds
+++ b/runtime/redbin.reds
@@ -189,7 +189,7 @@ redbin: context [
 	]
 	
 	reference: context [
-		;-- a map of integer! -> red-integer!
+		;-- a map of node! -> offset in 'list'
 		map:  as node! 0								;-- initialized in 'reset'
 		list: as int-ptr! 0								;-- as well
 		top:  list

--- a/tests/source/units/redbin-codec-test.red
+++ b/tests/source/units/redbin-codec-test.red
@@ -817,4 +817,30 @@ Red [
 			
 	===end-group===
 
+	===start-group=== "Stress tests"
+
+		--test-- "stress-1"
+			s1b: make [] 100000
+			s1bin: #{}
+			loop 10 [
+				repeat s1i 5000 [append s1b form s1i]
+				s1t: dt [save/as clear s1bin s1b 'redbin]
+				s1b2: load/as s1bin 'redbin
+				recycle
+				--assert s1b == s1b2
+				--assert s1t < 0:0:1					;-- should be ~40ms
+			]
+			unset [s1b s1b2 s1bin]
+
+		--test-- "stress-2"
+			s2m: make #() 100'000
+			repeat s2i 100'000 [put s2m s2i form s2i]
+			s2t: dt [save/as s2bin: #{} s2m 'redbin]
+			s2m2: load/as s2bin 'redbin
+			--assert s2m == s2m2
+			--assert s2t < 0:0:5						;-- should be ~300ms
+			recycle
+
+	===end-group===
+
 ~~~end-file~~~

--- a/tests/source/units/redbin-codec-test.red
+++ b/tests/source/units/redbin-codec-test.red
@@ -834,8 +834,9 @@ Red [
 
 		--test-- "stress-2"
 			s2m: make #() 100'000
+			s2bin: #{}
 			repeat s2i 100'000 [put s2m s2i form s2i]
-			s2t: dt [save/as s2bin: #{} s2m 'redbin]
+			s2t: dt [save/as s2bin s2m 'redbin]
 			s2m2: load/as s2bin 'redbin
 			--assert s2m == s2m2
 			--assert s2t < 0:0:5						;-- should be ~300ms


### PR DESCRIPTION
Waiting for @9214 review ;)

Summary:
- Fixes #4803 by dynamically adjusting buffers size
- Reduces load time from O(n^2) to O(n) by using hashtable

Before the PR:
```
testing with 5000 strings..
*** Internal Error: internal limit reached: 20000
*** Where: encode
*** Stack: clock save
```
Dynamic but without hashtable:
```
testing with 5000 strings..
60.0 ms	[save/as clear bin b 'redbin]
2.00 ms	[c: load/as bin 'redbin]
loaded data valid? =  true
testing with 10000 strings..
219 ms	[save/as clear bin b 'redbin]
0.0 μs	[c: load/as bin 'redbin]
loaded data valid? =  true
testing with 15000 strings..
475 ms	[save/as clear bin b 'redbin]
3.00 ms	[c: load/as bin 'redbin]
loaded data valid? =  true
testing with 20000 strings..
829 ms	[save/as clear bin b 'redbin]
985 μs	[c: load/as bin 'redbin]
loaded data valid? =  true
testing with 25000 strings..
1533 ms	[save/as clear bin b 'redbin]
3.00 ms	[c: load/as bin 'redbin]
loaded data valid? =  true
testing with 30000 strings..
2022 ms	[save/as clear bin b 'redbin]
9.99 ms	[c: load/as bin 'redbin]
loaded data valid? =  true
testing with 35000 strings..
2910 ms	[save/as clear bin b 'redbin]
6.96 ms	[c: load/as bin 'redbin]
loaded data valid? =  true
testing with 40000 strings..
3775 ms	[save/as clear bin b 'redbin]
5.00 ms	[c: load/as bin 'redbin]
loaded data valid? =  true
testing with 45000 strings..
4826 ms	[save/as clear bin b 'redbin]
6.99 ms	[c: load/as bin 'redbin]
loaded data valid? =  true
testing with 50000 strings..
6127 ms	[save/as clear bin b 'redbin]
9.99 ms	[c: load/as bin 'redbin]
loaded data valid? =  true
```
With hashtable:
```
testing with 5000 strings..
998 μs	[save/as clear bin b 'redbin]
1.00 ms	[c: load/as bin 'redbin]
loaded data valid? =  true
testing with 10000 strings..
2.96 ms	[save/as clear bin b 'redbin]
999 μs	[c: load/as bin 'redbin]
loaded data valid? =  true
testing with 15000 strings..
5.00 ms	[save/as clear bin b 'redbin]
983 μs	[c: load/as bin 'redbin]
loaded data valid? =  true
testing with 20000 strings..
6.00 ms	[save/as clear bin b 'redbin]
1.97 ms	[c: load/as bin 'redbin]
loaded data valid? =  true
testing with 25000 strings..
12.0 ms	[save/as clear bin b 'redbin]
1.99 ms	[c: load/as bin 'redbin]
loaded data valid? =  true
testing with 30000 strings..
13.6 ms	[save/as clear bin b 'redbin]
2.51 ms	[c: load/as bin 'redbin]
loaded data valid? =  true
testing with 35000 strings..
9.96 ms	[save/as clear bin b 'redbin]
2.98 ms	[c: load/as bin 'redbin]
loaded data valid? =  true
testing with 40000 strings..
13.0 ms	[save/as clear bin b 'redbin]
3.00 ms	[c: load/as bin 'redbin]
loaded data valid? =  true
testing with 45000 strings..
23.0 ms	[save/as clear bin b 'redbin]
4.00 ms	[c: load/as bin 'redbin]
loaded data valid? =  true
testing with 50000 strings..
43.8 ms	[save/as clear bin b 'redbin]
4.02 ms	[c: load/as bin 'redbin]
loaded data valid? =  true
```
150 times faster on 50000 strings

Test code:
```
do https://gitlab.com/hiiamboris/red-mezz-warehouse/-/raw/master/clock.red
b: [] bin: #{}
recycle/off
loop 10 [
	repeat i 5000 [append b form i]
	print ["testing with" length? b "strings.."]
	clock [save/as clear bin b 'redbin]
	clock [c: load/as bin 'redbin]
	print ["loaded data valid? = " b = c]
	; recycle
]
```