### PR TITLE
FEAT: define distance? for pairs

### DIFF
--- a/modules/view/utils.red
+++ b/modules/view/utils.red
@@ -45,7 +45,7 @@ overlap?: function [
 	"Return TRUE if the two faces bounding boxes are overlapping"
 	A		[object!] "First face"
 	B		[object!] "Second face"
-	return: [logic!]  "TRUE if overlapping"
+	; return: [logic!]  "TRUE if overlapping"
 ][
 	A1: A/offset
 	B1: B/offset
@@ -55,12 +55,13 @@ overlap?: function [
 ]
 
 distance?: function [
-	"Returns the distance between the center of two faces"
-	A		[object!] "First face"
-	B		[object!] "Second face"
+	"Returns the distance between 2 points or face centers"
+	A		[object! pair!] "First face or point"
+	B		[object! pair!] "Second face or point"
 	return: [float!]  "Distance between them"
 ][
-	square-root
-		((A/offset/x - B/offset/x + (A/size/x - B/size/x / 2)) ** 2)
-		+ ((A/offset/y - B/offset/y + (A/size/y - B/size/y / 2)) ** 2)
+	A: either object? A [A/offset * 2 + A/size][A * 2]	;-- doubling for odd-sized faces
+	B: either object? B [B/offset * 2 + B/size][B * 2]	;-- to compensate for integer pair (im)precision
+	d: B - A
+	d/x ** 2 + (d/y ** 2) ** 0.5 / 2
 ]

--- a/modules/view/utils.red
+++ b/modules/view/utils.red
@@ -45,7 +45,7 @@ overlap?: function [
 	"Return TRUE if the two faces bounding boxes are overlapping"
 	A		[object!] "First face"
 	B		[object!] "Second face"
-	; return: [logic!]  "TRUE if overlapping"
+	return: [logic!]  "TRUE if overlapping"
 ][
 	A1: A/offset
 	B1: B/offset


### PR DESCRIPTION
Why not? I haven't found a single use of `distance?` in Red codebase. But found myself reinventing the pair distance a few times already.
```
>> distance? object [offset: 0x0 size: 0x0] object [offset: 0x0 size: 1x1]
== 0.7071067811865476
>> distance? 0x0 1x1
== 1.414213562373095
```

An alternative would be to define `(length? A - B) -> float!`.