### PR TITLE
FEAT: transparent round/to x 0

### DIFF
--- a/runtime/datatypes/bitset.reds
+++ b/runtime/datatypes/bitset.reds
@@ -721,6 +721,7 @@ bitset: context [
 		#if debug? = yes [if verbose > 0 [print-line "bitset/compare"]]
 
 		if TYPE_OF(bs2) <> TYPE_BITSET [RETURN_COMPARE_OTHER]
+		if op = COMP_SAME [return as-integer bs1/node <> bs2/node]
 		
 		s: 	  GET_BUFFER(bs1)
 		head: as byte-ptr! s/offset

--- a/runtime/datatypes/date.reds
+++ b/runtime/datatypes/date.reds
@@ -1083,6 +1083,8 @@ date: context [
 			t1	 [float!]
 			t2	 [float!]
 			eq?	 [logic!]
+			ip1  [int-ptr!]
+			ip2  [int-ptr!]
 	][
 		#if debug? = yes [if verbose > 0 [print-line "date/compare"]]
 
@@ -1098,9 +1100,13 @@ date: context [
 		switch op [
 			COMP_EQUAL
 			COMP_FIND
-			COMP_SAME
 			COMP_NOT_EQUAL
 			COMP_STRICT_EQUAL [res: as-integer not eq?]
+			COMP_SAME [
+				ip1: as int-ptr! :t1
+				ip2: as int-ptr! :t2
+				res: as-integer any [d1 <> d2  ip1/1 <> ip2/1  ip1/2 <> ip2/2]
+			]
 			default [
 				either eq? [res: 0][
 					res: SIGN_COMPARE_RESULT(d1 d2)

--- a/runtime/datatypes/float.reds
+++ b/runtime/datatypes/float.reds
@@ -921,7 +921,6 @@ float: context [
 				sc: abs scale/value
 			]
 			if TYPE_OF(f) = TYPE_PERCENT [sc: sc / 100.0]
-			if sc = 0.0 [fire [TO_ERROR(math overflow)]]
 		]
 		if sc < ldexp abs dec -53 [return value]		;-- is scale negligible?
 

--- a/runtime/datatypes/float.reds
+++ b/runtime/datatypes/float.reds
@@ -746,6 +746,8 @@ float: context [
 			left  [float!]
 			right [float!] 
 			res	  [integer!]
+			ip1   [int-ptr!]
+			ip2   [int-ptr!]
 	][
 		#if debug? = yes [if verbose > 0 [print-line "float/compare"]]
 
@@ -774,6 +776,11 @@ float: context [
 		switch op [
 			COMP_EQUAL
 			COMP_NOT_EQUAL 	[res: as-integer not almost-equal left right]
+			COMP_SAME [
+				ip1: as int-ptr! :left
+				ip2: as int-ptr! :right
+				res: as-integer any [ip1/1 <> ip2/1  ip1/2 <> ip2/2]
+			]
 			default [
 				res: SIGN_COMPARE_RESULT(left right)
 			]

--- a/runtime/datatypes/integer.reds
+++ b/runtime/datatypes/integer.reds
@@ -759,7 +759,7 @@ integer: context [
 			]
 			sc: abs scale/value
 		]
-		if zero? sc [fire [TO_ERROR(math overflow)]]
+		if zero? sc [return value]
 
 		n: abs num
 		r: n % sc

--- a/runtime/datatypes/money.reds
+++ b/runtime/datatypes/money.reds
@@ -1710,7 +1710,7 @@ money: context [
 			]
 		]
 		
-		if zero-money? scale [fire [TO_ERROR(math overflow)]]
+		if zero-money? scale [return value]
 		value: absolute-money value
 		
 		lower: divide-money as red-money! stack/push as red-value! value scale yes no

--- a/runtime/datatypes/word.reds
+++ b/runtime/datatypes/word.reds
@@ -477,11 +477,17 @@ word: context [
 			COMP_FIND [
 				res: as-integer not EQUAL_WORDS?(arg1 arg2)
 			]
-			COMP_SAME
 			COMP_STRICT_EQUAL [
 				res: as-integer any [
 					type <> TYPE_OF(arg1)
 					arg1/symbol <> arg2/symbol
+				]
+			]
+			COMP_SAME [
+				res: as-integer any [
+					arg1/symbol <> arg2/symbol
+					arg1/ctx    <> arg2/ctx
+					type <> TYPE_OF(arg1)
 				]
 			]
 			COMP_STRICT_EQUAL_WORD [

--- a/tests/source/units/find-test.red
+++ b/tests/source/units/find-test.red
@@ -408,18 +408,77 @@ Red [
 
 ===end-group===
 
-===start-group=== "FIND issue #4165"
+===start-group=== "FIND issue #4165 (words)"
 
 	a: object [x: 1]
 	b: object [x: 2]
 	xs: reduce ['x in a 'x in b 'x]
 
-	--test-- "issue-4165-1"
+	--test-- "issue-4165-w1"
 		--assert 2 = index? find/same xs in a 'x
-	--test-- "issue-4165-2"
+	--test-- "issue-4165-w2"
 		--assert 3 = index? find/same xs in b 'x
-	--test-- "issue-4165-3"
+	--test-- "issue-4165-w3"
 		--assert 2 = index? find/same xs next xs
+	--test-- "issue-4165-w4"
+		--assert to logic! find/match/same xs reduce ['x in a 'x]
+	--test-- "issue-4165-w5"
+		--assert same? xs/1 to word! to refinement! xs/2	;-- loses binding during conversion
+	--test-- "issue-4165-w6"
+		--assert same? xs/1 to word! to issue! xs/2			;-- loses binding during conversion
+
+===end-group===
+
+===start-group=== "FIND issue #4165 (floats)"
+
+	nan1: 0.0 / 0.0
+	nan2: 1.0 * 1.#inf
+	b: reduce [1 1.0 nan1 nan2 to percent! nan1 to time! nan2]
+
+	--test-- "issue-4165-f1"
+		--assert 3 = index? find/same b nan1
+	--test-- "issue-4165-f2"
+		--assert 4 = index? find/same b nan2
+	--test-- "issue-4165-f3"
+		--assert 3 = index? find/same b reduce [nan1 nan2]
+	--test-- "issue-4165-f4"
+		--assert to logic! find/match/same next b reduce [1.0 nan1 nan2]
+	--test-- "issue-4165-f5"
+		--assert 5 = index? find/same b to percent! nan1
+	--test-- "issue-4165-f6"
+		--assert 6 = index? find/same b to time! nan2
+
+	dt1: 2000-1-1 + to time! nan1
+	dt2: 2000-1-1 + to time! nan2
+	dts: reduce [dt1 dt2]
+
+	--test-- "issue-4165-f7"
+		--assert not same?  dt1 dt2
+	; --test-- "issue-4165-f8"				;@@ FIXME: needs #4717 merged to work
+	; 	--assert not equal? dt1 dt1
+	; --test-- "issue-4165-f9"				;@@ FIXME: needs #4717 merged to work
+	; 	--assert not strict-equal? dt1 dt1
+	--test-- "issue-4165-f10"
+		--assert 1 = index? find/same dts dt1
+	--test-- "issue-4165-f11"
+		--assert 2 = index? find/same dts dt2
+
+===end-group===
+
+===start-group=== "FIND issue #4165 (bitsets)"
+
+	bs1: make bitset! [1 - 10]
+	bs2: make bitset! [1 - 10]
+	bss: reduce [bs1 bs2]
+
+	--test-- "issue-4165-bs1"
+		--assert equal? bs1 bs2
+	--test-- "issue-4165-bs2"
+		--assert not same? bs1 bs2
+	--test-- "issue-4165-bs3"
+		--assert 1 = index? find/same bss bs1
+	--test-- "issue-4165-bs4"
+		--assert 2 = index? find/same bss bs2
 
 ===end-group===
 

--- a/tests/source/units/find-test.red
+++ b/tests/source/units/find-test.red
@@ -408,4 +408,19 @@ Red [
 
 ===end-group===
 
+===start-group=== "FIND issue #4165"
+
+	a: object [x: 1]
+	b: object [x: 2]
+	xs: reduce ['x in a 'x in b 'x]
+
+	--test-- "issue-4165-1"
+		--assert 2 = index? find/same xs in a 'x
+	--test-- "issue-4165-2"
+		--assert 3 = index? find/same xs in b 'x
+	--test-- "issue-4165-3"
+		--assert 2 = index? find/same xs next xs
+
+===end-group===
+
 ~~~end-file~~~

--- a/tests/source/units/float-test.red
+++ b/tests/source/units/float-test.red
@@ -395,6 +395,12 @@ Red [
 		--assert 0:00:16 = round/to 15.0 0:0:2
 		--assert 12.9 = round/to 13.0 30%
 
+	--test-- "round22"
+		--assert 23.0 == round/to         23.0 0.0
+		--assert 23%  == round/to         23%  0%
+		--assert 23.0 == round/to/ceiling 23.0 0.0
+		--assert 23.0 == round/to/floor   23.0 0.0
+
 ===end-group===
 
 ===start-group=== "various regression tests from bugtracker"

--- a/tests/source/units/integer-test.red
+++ b/tests/source/units/integer-test.red
@@ -146,6 +146,11 @@ Red [
 		--assert  23.1 = round/to 23 30%
 		--assert  0:00:16 = round/to 15 0:0:2
 
+	--test-- "round16"
+		--assert 23 = round/to         23 0
+		--assert 23 = round/to/ceiling 23 0
+		--assert 23 = round/to/floor   23 0
+
 ===end-group===
 
 ===start-group=== "with other datatypes"

--- a/tests/source/units/money-test.red
+++ b/tests/source/units/money-test.red
@@ -451,7 +451,8 @@ system/options/money-digits: 5						;-- enforce molding of the whole fractional 
 		--assert -$4.0  == round/to/floor -$2.4 2.0
 		--assert -$1.0  == round/to -$0.50 1
 		--assert $0.0   == round/to -$0.49 1
-		--assert error? try [round/to $123 0]
+		--assert $123.4 == round/to  $123.4 0
+		--assert error? try [round/to $123 1e-10]	;-- out of money's representation range
 		--assert error? try [round/to $123 100%]
 		--assert error? try [round/to $123 1:2:3]
 

--- a/tests/source/units/pair-test.red
+++ b/tests/source/units/pair-test.red
@@ -264,6 +264,14 @@ Red [
 
 ===end-group===
 
+===start-group=== "pair - round"
+
+	--test-- "pround-1"		--assert 15x10 = round/to 17x8  5
+	--test-- "pround-3"		--assert 15x10 = round/to 15x10 1
+	--test-- "pround-3"		--assert 15x10 = round/to 15x10 0
+
+===end-group===
+
 
 ===start-group=== "pair - issues"
 

--- a/tests/source/units/select-test.red
+++ b/tests/source/units/select-test.red
@@ -176,5 +176,16 @@ Red [
   --assert none = select/skip "12345166661234557890" "6" 5
 ===end-group===
 
+===start-group=== "SELECT issue #4165"
+
+	--test-- "select-issue-4165"
+		a: object [x: 1]
+		b: object [x: 2]
+		xs: reduce ['x in a 'x in b 'x]
+		--assert none? select/same xs in b 'x
+		--assert (in b 'x) =? select/same xs in a 'x
+
+===end-group===
+
 ~~~end-file~~~
 

--- a/tests/source/units/time-test.red
+++ b/tests/source/units/time-test.red
@@ -380,6 +380,9 @@ Red [
 		--assert 12:34:56.1 = round/to 12:34:56 0.3
 		--assert 12:34:56.1 = round/to 12:34:56 30%
 
+	--test-- "round 5"
+		--assert 12:34:56.7 = round/to 12:34:56.7 0
+
 ===end-group===
 
 ===start-group=== "Rudolf Meijer's Test Cases"


### PR DESCRIPTION
Following the discussion :point_up: [April 22, 2021 9:27 PM](https://gitter.im/red/help?at=6081c02db6a4714a29ded202) and TG chat.

**Summary**

Rationale: to not create special cases where they aren't required

Example:
```
>> round/to pi 1
== 3
>> round/to pi 1e-10
== 3.1415926536
>> round/to pi 1e-100
== 3.141592653589793
>> round/to pi 1e-500
*** Math Error: math or number overflow
>> round/to pi 0
*** Math Error: math or number overflow
```
As `scale` approaches zero we should expect the result to come closer and closer to the original value.
With the `lim (round/to value scale) = value` when `scale -> 0`.
The zero can be reached in practice as mentioned in the above discussion, so it makes sense to handle it automatically, leaving programmer with less headaches.

This PR implements `x = round/to x 0` invariant, even for special floats:
```
>> round/to pi 0
== 3.141592653589793
>> round/to now/time 0
== 21:10:46
>> round/to 1.#inf 0
== 1.#INF
>> round/to -1.#inf 0
== -1.#INF
>> round/to 1.#nan 0
== 1.#NaN
```