### PR TITLE
FEAT: transparent round/to x 0

### DIFF
--- a/environment/actions.red
+++ b/environment/actions.red
@@ -148,7 +148,7 @@ round: make action! [[
 		"Returns the nearest integer. Halves round up (away from zero) by default"
 		n		[number! money! time! pair!]
 		/to		"Return the nearest multiple of the scale parameter"
-		scale	[number! money! time!] "Must be a non-zero value"
+		scale	[number! money! time!] "If zero, returns N unchanged"
 		/even		"Halves round toward even results"
 		/down		"Round toward zero, ignoring discarded digits. (truncate)"
 		/half-down	"Halves round toward zero"

--- a/runtime/datatypes/float.reds
+++ b/runtime/datatypes/float.reds
@@ -914,7 +914,6 @@ float: context [
 				sc: abs scale/value
 			]
 			if TYPE_OF(f) = TYPE_PERCENT [sc: sc / 100.0]
-			if sc = 0.0 [fire [TO_ERROR(math overflow)]]
 		]
 		if sc < ldexp abs dec -53 [return value]		;-- is scale negligible?
 

--- a/runtime/datatypes/integer.reds
+++ b/runtime/datatypes/integer.reds
@@ -759,7 +759,7 @@ integer: context [
 			]
 			sc: abs scale/value
 		]
-		if zero? sc [fire [TO_ERROR(math overflow)]]
+		if zero? sc [return value]
 
 		n: abs num
 		r: n % sc

--- a/runtime/datatypes/money.reds
+++ b/runtime/datatypes/money.reds
@@ -1710,7 +1710,7 @@ money: context [
 			]
 		]
 		
-		if zero-money? scale [fire [TO_ERROR(math overflow)]]
+		if zero-money? scale [return value]
 		value: absolute-money value
 		
 		lower: divide-money as red-money! stack/push as red-value! value scale yes no

--- a/tests/source/units/float-test.red
+++ b/tests/source/units/float-test.red
@@ -395,6 +395,12 @@ Red [
 		--assert 0:00:16 = round/to 15.0 0:0:2
 		--assert 12.9 = round/to 13.0 30%
 
+	--test-- "round22"
+		--assert 23.0 == round/to         23.0 0.0
+		--assert 23%  == round/to         23%  0%
+		--assert 23.0 == round/to/ceiling 23.0 0.0
+		--assert 23.0 == round/to/floor   23.0 0.0
+
 ===end-group===
 
 ===start-group=== "various regression tests from bugtracker"

--- a/tests/source/units/integer-test.red
+++ b/tests/source/units/integer-test.red
@@ -146,6 +146,11 @@ Red [
 		--assert  23.1 = round/to 23 30%
 		--assert  0:00:16 = round/to 15 0:0:2
 
+	--test-- "round16"
+		--assert 23 = round/to         23 0
+		--assert 23 = round/to/ceiling 23 0
+		--assert 23 = round/to/floor   23 0
+
 ===end-group===
 
 ===start-group=== "with other datatypes"

--- a/tests/source/units/money-test.red
+++ b/tests/source/units/money-test.red
@@ -451,7 +451,8 @@ system/options/money-digits: 5						;-- enforce molding of the whole fractional 
 		--assert -$4.0  == round/to/floor -$2.4 2.0
 		--assert -$1.0  == round/to -$0.50 1
 		--assert $0.0   == round/to -$0.49 1
-		--assert error? try [round/to $123 0]
+		--assert $123.4 == round/to  $123.4 0
+		--assert error? try [round/to $123 1e-10]	;-- out of money's representation range
 		--assert error? try [round/to $123 100%]
 		--assert error? try [round/to $123 1:2:3]
 

--- a/tests/source/units/pair-test.red
+++ b/tests/source/units/pair-test.red
@@ -264,6 +264,14 @@ Red [
 
 ===end-group===
 
+===start-group=== "pair - round"
+
+	--test-- "pround-1"		--assert 15x10 = round/to 17x8  5
+	--test-- "pround-3"		--assert 15x10 = round/to 15x10 1
+	--test-- "pround-3"		--assert 15x10 = round/to 15x10 0
+
+===end-group===
+
 
 ===start-group=== "pair - issues"
 

--- a/tests/source/units/time-test.red
+++ b/tests/source/units/time-test.red
@@ -380,6 +380,9 @@ Red [
 		--assert 12:34:56.1 = round/to 12:34:56 0.3
 		--assert 12:34:56.1 = round/to 12:34:56 30%
 
+	--test-- "round 5"
+		--assert 12:34:56.7 = round/to 12:34:56.7 0
+
 ===end-group===
 
 ===start-group=== "Rudolf Meijer's Test Cases"


### PR DESCRIPTION
Following the discussion :point_up: [April 22, 2021 9:27 PM](https://gitter.im/red/help?at=6081c02db6a4714a29ded202) and TG chat.

**Summary**

Rationale: to not create special cases where they aren't required

Example:
```
>> round/to pi 1
== 3
>> round/to pi 1e-10
== 3.1415926536
>> round/to pi 1e-100
== 3.141592653589793
>> round/to pi 1e-500
*** Math Error: math or number overflow
>> round/to pi 0
*** Math Error: math or number overflow
```
As `scale` approaches zero we should expect the result to come closer and closer to the original value.
With the `lim (round/to value scale) = value` when `scale -> 0`.
The zero can be reached in practice as mentioned in the above discussion, so it makes sense to handle it automatically, leaving programmer with less headaches.

This PR implements `x = round/to x 0` invariant, even for special floats:
```
>> round/to pi 0
== 3.141592653589793
>> round/to now/time 0
== 21:10:46
>> round/to 1.#inf 0
== 1.#INF
>> round/to -1.#inf 0
== -1.#INF
>> round/to 1.#nan 0
== 1.#NaN
```