### PR TITLE
FIX: reset system/thrown before capturing call stack in error!.

### DIFF
--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -1943,8 +1943,8 @@ natives: context [
 		][												;-- TRY/ALL case, catch everything
 			stack/adjust-post-try
 		]
-		if keep <> -1 [error/capture as red-object! stack/arguments]
 		system/thrown: 0
+		if keep <> -1 [error/capture as red-object! stack/arguments]
 		result
 	]
 


### PR DESCRIPTION
error/capture may trigger GC. free-virtual will check system/thrown.
In this case, `system/thrown` is RED_THROWN_ERROR when free-virtual is called.