### PR TITLE
FIX: temporarily fix a GC issue in parse.

### DIFF
--- a/runtime/parse.reds
+++ b/runtime/parse.reds
@@ -1886,7 +1886,7 @@ parser: context [
 	]
 
 	init: does [
-		series: block/make-in root 8
+		series: block/make-in root 40
 		rules:  block/make-in root 100
 	]
 ]


### PR DESCRIPTION
In function parser/process, `input` points to the buffer of `series` block. When `series` block expanded, `input` still points to the old slot, which is OK. But if GC triggered later, the memory may be overwrote by the GC.