### PR TITLE
FIX: 4900 (fmod platform discrepancy leads to modulo ambiguity)

### DIFF
--- a/runtime/datatypes/float.reds
+++ b/runtime/datatypes/float.reds
@@ -241,12 +241,11 @@ float: context [
 				]
 			]
 			OP_REM [
-				if any [left = -INF left = +INF right = 0.0][return QNaN]	;-- issue #4574
-				either all [0.0 = right not NaN? right][
-					fire [TO_ERROR(math zero-divide)]
-					0.0									;-- pass the compiler's type-checking
-				][
-					fmod left right
+				case [
+					0.0 * right = 0.0 [fmod left right]	;-- finite right part - no special case
+					NaN? right [QNaN]
+					0.0 * left = 0.0 [left]				;-- finite % +-infinity - special case for #4900
+					true [QNaN]							;-- +-infinity % +-infinity = NaN
 				]
 			]
 			default [

--- a/runtime/datatypes/float.reds
+++ b/runtime/datatypes/float.reds
@@ -245,7 +245,7 @@ float: context [
 					0.0 * right = 0.0 [fmod left right]	;-- finite right part - no special case
 					NaN? right [QNaN]
 					0.0 * left = 0.0 [left]				;-- finite % +-infinity - special case for #4900
-					true [QNaN]							;-- +-infinity % +-infinity = NaN
+					true [QNaN]							;-- (+-infinity or NaN) % +-infinity = NaN
 				]
 			]
 			default [

--- a/tests/source/units/regression-test-red.red
+++ b/tests/source/units/regression-test-red.red
@@ -3009,6 +3009,11 @@ comment {
 		--assert not all-equal?4205
 		unset [anded4205 last-random4205 all-equal?4205]
 	
+	--test-- "#4260"
+		catch [throw 1]
+		err4260: try [add none none]
+		--assert to-logic find form err4260 "add does not"
+
 	--test-- "#4451"
 		path: quote :foo/bar
 		--assert ":foo/bar" = mold path
@@ -3133,10 +3138,23 @@ comment {
 		--assert not strict-equal? "foo" #{666F6F}
 		--assert not strict-equal? #{666F6F} "foo"
 
-	--test-- "#4260"
-		catch [throw 1]
-		err4260: try [add none none]
-		--assert to-logic find form err4260 "add does not"
+	--test-- "#4900"
+		--assert 1.0 = (    1.0 %  1.#inf)
+		--assert 1.0 = (    1.0 % -1.#inf)
+		--assert nan?  (    1.0 %  1.#nan)
+		--assert nan?  ( 1.#inf %  1.#inf)
+		--assert nan?  ( 1.#inf % -1.#inf)
+		--assert nan?  ( 1.#inf %  1.#nan)
+		--assert nan?  (-1.#inf %  1.#inf)
+		--assert nan?  (-1.#inf % -1.#inf)
+		--assert nan?  (-1.#inf %  1.#nan)
+		--assert nan?  ( 1.#nan %     1.0)
+		--assert nan?  ( 1.#nan %  1.#inf)
+		--assert nan?  ( 1.#nan % -1.#inf)
+		--assert nan?  ( 1.#nan % -1.#nan)
+		; --assert 2x3   = (2x3   % 1.#inf)				;@@ FIXME: throws an error, unlike tuple
+		--assert 1.2.3 = (1.2.3 % 1.#inf)
+		--assert (make vector! [1.0 2.0]) = ((make vector! [1.0 2.0]) % 1.#inf)
 
 ===end-group===
 


### PR DESCRIPTION
Fixes #4900 by following GCC semantics for x % infinity.

Also removes dead code.