### PR TITLE
FIX: Issue 4911 (FIND type! vs FIND typeset! inconsistency)

### DIFF
--- a/environment/actions.red
+++ b/environment/actions.red
@@ -291,10 +291,10 @@ copy: make action! [[
 find: make action! [[
 		"Returns the series where a value is found, or NONE"
 		series	 [series! bitset! typeset! port! map! none!]
-		value 	 [any-type!]
+		value 	 [any-type!] "Typesets and datatypes can be used to search by datatype"
 		/part "Limit the length of the search"
 			length [number! series!]
-		/only "Treat a series search value as a single value"
+		/only "Treat series and typeset value arguments as single values"
 		/case "Perform a case-sensitive search"
 		/same {Use "same?" as comparator}
 		/any  "TBD: Use * and ? wildcards in string searches"

--- a/runtime/datatypes/block.reds
+++ b/runtime/datatypes/block.reds
@@ -858,6 +858,7 @@ block: context [
 			op		[integer!]
 			type	[integer!]
 			stype	[integer!]
+			dt?		[logic!]
 			ts?		[logic!]
 			found?	[logic!]
 			hash?	[logic!]
@@ -917,9 +918,11 @@ block: context [
 		]
 
 		type: TYPE_OF(value)
+		dt?: all [not only? type = TYPE_DATATYPE]		;-- /only disables special treatment
+		ts?: all [not only? type = TYPE_TYPESET]
 		if any [
-			type = TYPE_DATATYPE
-			type = TYPE_TYPESET
+			dt?
+			ts?
 			all [not same? type = TYPE_OBJECT]
 		][hash?: no]									;-- use block search
 		any-blk?: ANY_BLOCK?(type)
@@ -964,26 +967,16 @@ block: context [
 
 			reverse?: any [reverse? last?]					;-- reduce both flags to one
 			
-			type: either all [not only? type = TYPE_DATATYPE][
+			type: either dt? [
 				dt: as red-datatype! value
 				dt/value
 			][-1]											;-- disable "type searching" mode
-			ts?: TYPE_OF(value) = TYPE_TYPESET
 
 			until [
 				either zero? values [
 					stype: TYPE_OF(slot)
 					found?: case [
-						positive? type [
-							dt: as red-datatype! slot
-							any [
-								stype = type				;-- simple type comparison
-								all [
-									stype = TYPE_DATATYPE
-									dt/value = type			;-- attempt matching a datatype! value
-								]
-							]
-						]
+						dt?  [stype = type]					;-- simple type comparison
 						ts?  [BS_TEST_BIT_ALT(value stype)]	;-- attempt matching a typeset! value
 						true [actions/compare slot value op];-- atomic comparison
 					]

--- a/tests/source/units/find-test.red
+++ b/tests/source/units/find-test.red
@@ -482,4 +482,41 @@ Red [
 
 ===end-group===
 
+===start-group=== "FIND issue #4911"
+
+	tss: reduce [1 integer! 2.0 number! 3]
+	hss: make hash! tss
+
+	--test-- "issue-4911-1"
+		--assert 1 = index? find      tss 1
+	--test-- "issue-4911-2"
+		--assert 1 = index? find      tss integer!
+	--test-- "issue-4911-3"
+		--assert 1 = index? find      tss number!
+	--test-- "issue-4911-4"
+		--assert 1 = index? find/same tss integer!
+	--test-- "issue-4911-5"
+		--assert 1 = index? find/same tss number!
+	--test-- "issue-4911-6"
+		--assert 2 = index? find/only tss integer!
+	--test-- "issue-4911-7"
+		--assert 4 = index? find/only tss number!
+
+	--test-- "issue-4911-8"
+		--assert 1 = index? find      hss 1
+	--test-- "issue-4911-9"
+		--assert 1 = index? find      hss integer!
+	--test-- "issue-4911-10"
+		--assert 1 = index? find      hss number!
+	--test-- "issue-4911-11"
+		--assert 1 = index? find/same hss integer!
+	--test-- "issue-4911-12"
+		--assert 1 = index? find/same hss number!
+	--test-- "issue-4911-13"
+		--assert 2 = index? find/only hss integer!
+	--test-- "issue-4911-14"
+		--assert 4 = index? find/only hss number!
+
+===end-group===
+
 ~~~end-file~~~

--- a/tests/source/units/switch-test.red
+++ b/tests/source/units/switch-test.red
@@ -139,6 +139,39 @@ Red [
 		]
         --assert sb14-j = "Red"
 	
+	--test-- "switch-basic-15"
+		sb15-i: integer!
+		sb15-j: "REBOL"
+		switch sb15-i [
+			1 			[sb15-j: "Earl"]
+			integer!	[sb15-j: "Peter"]
+			#[integer!]	[sb15-j: "Red"]
+			#[char!]	[sb15-j: "Blue"]
+		]
+        --assert sb15-j = "Red"
+
+	--test-- "switch-basic-16"
+		sb16-i: number!
+		sb16-j: "REBOL"
+		do [switch sb16-i reduce [
+			1 			[sb16-j: "Earl"]
+			'number!	[sb16-j: "Peter"]
+			number!		[sb16-j: "Red"]					;@@ no idea how to encode a typeset literally, have to evaluate
+			char!		[sb16-j: "Blue"]
+		]]
+        --assert sb16-j = "Red"
+
+	--test-- "switch-basic-17"
+		sb17-j: "REBOL"
+		do [switch () reduce [
+			unset! 		[sb17-j: "Earl"]
+			100			[sb17-j: "Peter"]
+			()			[sb17-j: "Red"]					;@@ no idea how to encode `unset` literally, have to evaluate
+			char!		[sb17-j: "Blue"]
+		]]
+        --assert sb17-j = "Red"
+
+
 ===end-group===
 
 ===start-group=== "switch basics local"    ;; one "direct" type & one "indirect"


### PR DESCRIPTION
Fixes #4911
Adds tests for #2125
Removes some `switch` kludges made obsolete by commit https://github.com/red/red/commit/32d353efea0fcb53660db88a702a92b315a5168b
`find [#[integer!] 1] integer!` now matches `1` only, not the datatype (for less surprises and consistency with typesets)
`find/only` also enables the use of hash lookups for datatypes and typesets