### PR TITLE
FIX: workaround for libc atan2 bug

### DIFF
--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -1737,7 +1737,18 @@ natives: context [
 		][
 			x: f/value
 		]
-		f/value: atan2 y x
+		#either OS = 'Windows [
+			f/value: atan2 y x
+		][
+			either all [								;-- bugfix for libc (all Linux versions)
+				x - x <> 0.0							;-- if both x and y are infinite (or NaN)
+				y - y <> 0.0
+			][
+				f/value: x - x							;-- then the result should be NaN
+			][
+				f/value: atan2 y x
+			]
+		]
 		if radians < 0 [f/value: 180.0 / PI * f/value]			;-- to degrees
 		stack/set-last as red-value! f
 	]


### PR DESCRIPTION
In Ubuntu Linux and RPi `atan2 inf inf` returns `pi / 4`, whereas in msvcrt it returns `nan`. I consider `nan` to be a valid result here, same as `inf / inf` is `nan`, not `1.0`.

This PR patches `arctangent2` native to return `1.#nan` and be consistent for this special case.
Failing `float-arctangent2-5` test should start passing.