### PR TITLE
FIX: Compile and run on FreeBSD 13

### DIFF
--- a/runtime/crypto.reds
+++ b/runtime/crypto.reds
@@ -686,7 +686,7 @@ crypto: context [
 				#define LIBCRYPTO-file "libcrypto.dylib"
 			]
 			FreeBSD [
-				#define LIBCRYPTO-file "libcrypto.so.8"
+				#define LIBCRYPTO-file "libcrypto.so.111"
 			]
 			NetBSD [
 				#define LIBCRYPTO-file "libcrypto.so"

--- a/runtime/red.reds
+++ b/runtime/red.reds
@@ -60,7 +60,7 @@ red: context [
 		Syllable []
 		macOS	 [#include %platform/image-quartz.reds]
 		Linux	 [#include %platform/image-gdk.reds]
-		FreeBSD  []
+		FreeBSD  [#include %platform/image-gdk.reds]
 		NetBSD   []
 		#default []
 	]
@@ -118,6 +118,7 @@ red: context [
 	#if OS = 'Windows [#include %datatypes/image.reds]	;-- temporary
 	#if OS = 'macOS   [#include %datatypes/image.reds]	;-- temporary
 	#if OS = 'Linux   [#include %datatypes/image.reds]
+	#if OS = 'FreeBSD [#include %datatypes/image.reds]
 
 	;-- Debugging helpers --
 	


### PR DESCRIPTION
Looks like FreeBSD compilation was broken for quite a while, due to  GDK dependencies introduced some time ago. This minor patch fixes the problem, although it also introduces additional runtime lib dependency: gdk_pixbuf2.

Second fix updates the hardcoded libcrypto version, so that the compiled program can run on latest FreeBSD without issues.