### PR TITLE
FIX: NetBSD compilation and rpath

### DIFF
--- a/runtime/red.reds
+++ b/runtime/red.reds
@@ -61,7 +61,7 @@ red: context [
 		macOS	 [#include %platform/image-quartz.reds]
 		Linux	 [#include %platform/image-gdk.reds]
 		FreeBSD  [#include %platform/image-gdk.reds]
-		NetBSD   []
+		NetBSD   [#include %platform/image-gdk.reds]
 		#default []
 	]
 	
@@ -119,6 +119,7 @@ red: context [
 	#if OS = 'macOS   [#include %datatypes/image.reds]	;-- temporary
 	#if OS = 'Linux   [#include %datatypes/image.reds]
 	#if OS = 'FreeBSD [#include %datatypes/image.reds]
+	#if OS = 'NetBSD [#include %datatypes/image.reds]
 
 	;-- Debugging helpers --
 	

--- a/system/formats/ELF.r
+++ b/system/formats/ELF.r
@@ -24,7 +24,7 @@ context [
 
 		base-address	(to-integer #{08048000})
 		page-size		4096
-		rpath			"$ORIGIN"
+		rpath			"$ORIGIN:/usr/pkg/lib"  ;; Additional path is for NetBSD. TODO: consider moving this rpath option to config, instead of hard-coding.
 
 		;; ELF Constants
 


### PR DESCRIPTION
Similarly to  #4984, this commit fixes broken NetBSD compilation, by adding relevant new dependency - gdk_pixbuf2.

Additionally, it also appends the hardcoded 'rpath' key in ELF format definition with NetBSD-specific library search path, that is /usr/pkg/lib. While any deeply hard-coded path is rather ugly by definition, and in future it would probably be preferable to refactor it to be used at least in build config instead, right now it serves the purpose fine and doesn't affect other ELF-based OSes.