### PR TITLE
FIX: issue #5000 (CRASH when molding UTF8 string loaded from binary)

### DIFF
--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -2825,6 +2825,7 @@ natives: context [
 			dt	  [red-datatype!]
 			fun	  [red-function!]
 			s	  [series!]
+			cs    [c-string!]
 	][
 		#typecheck [transcode next one prescan scan part into trace]
 
@@ -2870,7 +2871,18 @@ natives: context [
 		one?: any [next? not all? not load?]
 		either type = TYPE_BINARY [
 			if len < 0 [len: binary/rs-length? bin]
-			type: lexer/scan slot binary/rs-head bin len one? scan? load? no :offset fun as red-series! bin out
+			cs: as c-string! binary/rs-head bin
+			if all [									;-- skip the BOM, don't load it as word
+				len >= 3
+				cs/1 = #"^(EF)"
+				cs/2 = #"^(BB)"
+				cs/3 = #"^(BF)"
+			][
+				len: len - 3
+				cs: cs + 3
+				bin/head: bin/head + 3
+			]
+			type: lexer/scan slot as byte-ptr! cs len one? scan? load? no :offset fun as red-series! bin out
 		][
 			str: as red-string! bin
 			if len < 0 [len: string/rs-length? str]

--- a/runtime/unicode.reds
+++ b/runtime/unicode.reds
@@ -204,6 +204,7 @@ unicode: context [
 			unit [integer!]
 			cp	 [integer!]
 			part [integer!]
+			char [integer!]
 	][
 		s:	  GET_BUFFER(str)
 		unit: GET_UNIT(s)
@@ -212,7 +213,8 @@ unicode: context [
 		unless len/value = -1 [
 			if len/value < part [part: len/value]
 		]
-		buf: as byte-ptr! get-cache str unit << 1 * (1 + part)
+		char: either unit < 4 [unit + 1][unit]
+		buf: as byte-ptr! get-cache str char * (1 + part)
 		beg: buf
 
 		p:	  string/rs-head str

--- a/tests/source/units/lexer-test.red
+++ b/tests/source/units/lexer-test.red
@@ -1504,6 +1504,9 @@ Red [
 	--test-- "#4781"
 		--assert 3:3:3.3000000001 = transcode/one "3:3:3,3"
 
+	--test-- "#5000"
+		--assert ["s"] == transcode #{EFBBBF227322}
+
 ===end-group===
 	
 ~~~end-file~~~


### PR DESCRIPTION
Fixes #5000 by skipping BOM in `transcode*` native.
Also noticed extra sized cache allocation, reduced following the logic of https://github.com/red/red/pull/4995