### PR TITLE
FEAT: output mode details in transcode-trace

### DIFF
--- a/environment/system.red
+++ b/environment/system.red
@@ -459,15 +459,16 @@ system: context [
 		]
 		
 		tracer: lex: func [
-		  event  [word!]                  				;-- event name
-		  input  [string! binary!]            			;-- input series at current loading position
-		  type   [datatype! word! none!]       		 	;-- type of token or value currently processed.
-		  line   [integer!]               				;-- current input line number
-		  token                      					;-- current token as an input slice (pair!) or a loaded value.
-		  return: [logic!]                				;-- YES: continue to next lexing stage, NO: cancel current token lexing
+			event  [word!]                  			;-- event name
+			input  [string! binary!]            		;-- input series at current loading position
+			type   [datatype! word! none!]       		;-- type of token or value currently processed.
+			line   [integer!]               			;-- current input line number
+			token                      					;-- current token as an input slice (pair!) or a loaded value.
+			return: [logic!]                			;-- YES: continue to next lexing stage, NO: cancel current token lexing
 		][
-		  print [event type token line mold/part input 16]
-		  either event = 'error [input: next input no][yes]
+			type: rejoin [mold type "(" type? type ")"]
+			print [event type token line mold/part input 16]
+			either event = 'error [input: next input no][yes]
 		]
 	]
 	

--- a/environment/system.red
+++ b/environment/system.red
@@ -466,8 +466,13 @@ system: context [
 			token                      					;-- current token as an input slice (pair!) or a loaded value.
 			return: [logic!]                			;-- YES: continue to next lexing stage, NO: cancel current token lexing
 		][
-			type: rejoin [mold type "(" type? type ")"]
-			print [event type token line mold/part input 16]
+			print [										;-- total: 64
+				uppercase pad event 8
+				pad rejoin [mold type "(" type? type ")"] 20
+				pad mold/part token 12 12				;-- limit in case it's a huge string/binary
+				pad line 4
+				mold/part input 16
+			]
 			either event = 'error [input: next input no][yes]
 		]
 	]


### PR DESCRIPTION
didn't do any polishing, just added the type of `type`:
```
>> transcode-trace "1 + 2;"
prescan integer!(datatype) 1x2 1 " + 2;"
scan integer!(datatype) 1x2 1 " + 2;"
load integer!(datatype) 1 1 " + 2;"
prescan word!(datatype) 3x4 1 " 2;"
scan word!(datatype) 3x4 1 " 2;"
load word!(datatype) + 1 " 2;"
prescan integer!(datatype) 5x6 1 ";"
scan integer!(datatype) 5x6 1 ";"
load integer!(datatype) 2 1 ";"
prescan comment(word) 6x7 1 ";"
scan comment(word) 6x7 1 ""
== [1 + 2]
```