### PR TITLE
FEAT: String interpolation

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -1093,7 +1093,7 @@ transcode-trace: func [
 ]
 
 with: function [
-	"Bind code to a given context or list of contexts (in order from first to last)"
+	"Bind block to a given context or list of contexts (in order from first to last)"
 	ctx [any-object! function! any-word! block!]
 		"Block [x: ...] becomes a context, [x 'x ...] is reduced and passed sequentially to BIND native"
 	block [block!] "Is not evaluated"

--- a/tests/source/units/all-tests.txt
+++ b/tests/source/units/all-tests.txt
@@ -65,3 +65,4 @@ clipboard-test.red
 csv-test.red
 json-test.red
 redbin-codec-test.red
+rejoin-test.red

--- a/tests/source/units/preprocessor-test.red
+++ b/tests/source/units/preprocessor-test.red
@@ -92,11 +92,11 @@ Red [
 ===start-group=== "#rejoin"
 
 	--test-- "#rejoin-1"
-		--assert [rejoin [""]   ] == [#rejoin "()"]
-		--assert [rejoin ["" []]] == [#rejoin "([])"]	;-- result is string not block
+		--assert [ rejoin ["" ()] ] == [#rejoin "()"]
+		--assert [ rejoin ["" []] ] == [#rejoin "([])"]
 
-	--test-- "#rejoin-2" --assert [#rejoin "(\(\\\))"    ] == [rejoin ["((\\))"] ]		;-- escaping & string grouping
-	--test-- "#rejoin-3" --assert [#rejoin %"(\(\\\))"   ] == [rejoin [%"((\\))"]]		;-- 1st string is the return type
+	--test-- "#rejoin-2" --assert [#rejoin "(\(\\\))"    ] == ["((\\))"]				;-- escaping & string grouping
+	--test-- "#rejoin-3" --assert [#rejoin %"(\(\\\))"   ] == [%"((\\))"]				;-- 1st string is the return type
 	--test-- "#rejoin-4" --assert [#rejoin %"({(})(\\\))"] == [rejoin [%"" "((\\))"]]
 	--test-- "#rejoin-5" --assert [#rejoin "()"          ] == [rejoin ["" ()]    ]
 	--test-- "#rejoin-6" --assert [#rejoin "([])"        ] == [rejoin ["" []]    ]		;-- paren removal from obvious cases

--- a/tests/source/units/preprocessor-test.red
+++ b/tests/source/units/preprocessor-test.red
@@ -89,4 +89,59 @@ Red [
 
 ===end-group===
 
+===start-group=== "#rejoin"
+
+	--test-- "#rejoin-1"
+		--assert [rejoin [""]   ] == [#rejoin "()"]
+		--assert [rejoin ["" []]] == [#rejoin "([])"]	;-- result is string not block
+
+	--test-- "#rejoin-2" --assert [#rejoin "(\(\\\))"    ] == [rejoin ["((\\))"] ]		;-- escaping & string grouping
+	--test-- "#rejoin-3" --assert [#rejoin %"(\(\\\))"   ] == [rejoin [%"((\\))"]]		;-- 1st string is the return type
+	--test-- "#rejoin-4" --assert [#rejoin %"({(})(\\\))"] == [rejoin [%"" "((\\))"]]
+	--test-- "#rejoin-5" --assert [#rejoin "()"          ] == [rejoin ["" ()]    ]
+	--test-- "#rejoin-6" --assert [#rejoin "([])"        ] == [rejoin ["" []]    ]		;-- paren removal from obvious cases
+	--test-- "#rejoin-7" --assert [#rejoin "(1)"         ] == [rejoin ["" 1]     ]
+	--test-- "#rejoin-8" --assert [#rejoin "('x)"        ] == [rejoin ["" 'x]    ]
+	--test-- "#rejoin-9" --assert [#rejoin "(x)"         ] == [rejoin ["" (x)]   ]
+
+	--test-- "#rejoin-11-expansion-within-rejoin"
+		--assert [ #rejoin "(append {1} #rejoin {2(1 + 2)})" ]
+			== [ rejoin ["" (append "1" rejoin ["2" (1 + 2)])] ]
+	
+	--test-- "#rejoin-12"
+		--assert [ #rejoin "(1 + 2)(\text)" ]
+			== [ rejoin ["" (1 + 2) "(text)"] ]
+	
+	--test-- "#rejoin-13-line-comments"
+		--assert [rejoin ["" (1 + 2 * 3)]] == [#rejoin {(;-- comment
+			1 + 2 * 3									;-- another
+		)}]
+
+	--test-- "#rejoin-14"
+		--assert [#rejoin <tag flag=(mold 1 + 2)/>] == [
+			rejoin [
+				<tag flag=>								;-- result is a <tag>
+				(mold 1 + 2)
+				{/}										;-- other strings should be normal, or we'll have <<">> result
+			]
+		]
+		
+	--test-- "#rejoin-15"
+		--assert [#rejoin %"()() - (1 + 2)) - (\(<abc)))>) - (func)(1)()()"] == [
+			rejoin [
+				%""										;-- 1st string is of argument/result type, even empty
+				() ()									;-- () makes an unset, no empty strings inbetween
+				" - "									;-- subsequent fragments are of string! type
+				(1 + 2)									;-- 2+ tokens are parenthesized
+				") - ("									;-- literal parens
+				<abc)))>								;-- an explicit tag! - not a string!; without parens around
+				" - "
+				(func)									;-- words are parenthesized
+				1										;-- single token does not need parens
+				() ()									;-- no unnecessary empty strings
+			]
+		]
+  
+===end-group===
+
 ~~~end-file~~~

--- a/tests/source/units/rejoin-test.red
+++ b/tests/source/units/rejoin-test.red
@@ -1,0 +1,74 @@
+Red [
+	Title:   "REJOIN test script"
+	Author:  @hiiamboris
+	File: 	 %rejoin-test.red
+	Tabs:	 4
+	Rights:  "Copyright (C) 2022 Red Foundation. All rights reserved."
+	License: "BSD-3 - https://github.com/red/red/blob/origin/BSD-3-License.txt"
+]
+
+#include  %../../../quick-test/quick-test.red
+
+
+~~~start-file~~~ "rejoin"
+
+===start-group=== "Block joining"
+
+	--test-- "rejoin-block-1" --assert []        = rejoin []
+	--test-- "rejoin-block-2" --assert [1 2]     = rejoin b: [[] 1 2]
+	--test-- "rejoin-block-3" --assert [1 2]     = rejoin b
+	--test-- "rejoin-block-4" --assert [3 [3 4]] = rejoin [[] 1 + 2 [3 4]]
+	--test-- "rejoin-block-5" --assert (quote (1 2 [3 4])) == rejoin [quote () 1 2 [3 4]]
+	
+===end-group===
+
+===start-group=== "String joining"
+
+	--test-- "rejoin-string-1" --assert ""     == rejoin [""]
+	--test-- "rejoin-string-2" --assert "12"   == rejoin b: [1 2]
+	--test-- "rejoin-string-3" --assert <a127> == rejoin [<a> 1 2 3 + 4]
+	--test-- "rejoin-string-4" --assert %"127" == rejoin [%"" 1 2 3 + 4]
+	--test-- "rejoin-string-5" --assert %"a<b c>d e" == rejoin [%"a" <b c> [d e]]
+	
+===end-group===
+
+===start-group=== "String interpolation"
+
+	;; see also preprocessor test for more
+	--test-- "rejoin-interp-1" --assert ""       == rejoin "()"
+	--test-- "rejoin-interp-2" --assert ""       == rejoin "([])"
+	--test-- "rejoin-interp-3" --assert "((\\))" == rejoin "(\(\\\))"
+	--test-- "rejoin-interp-4"
+		--assert <tag flag="3"/> == rejoin <tag flag=(mold to string! 1 + 2)/>
+	--test-- "rejoin-interp-5"
+		--assert %" - 3 - <abc)))> - func1" == rejoin %"()() - (1 + 2) - (<abc)))>) - ('func)(1)()()"
+	--test-- "rejoin-interp-6"
+		--assert "*ERROR*" == rejoin/trap "(1 / 0)" "*ERROR*"
+	--test-- "rejoin-interp-7"
+		--assert "zero-divide expect-arg" == rejoin/trap "(1 / 0) ({a} + 1)" func [e][e/id]
+	--test-- "rejoin-interp-8"
+		--assert "print" == rejoin/trap "(1 / 0)" func [e]['print]	;-- no second error from double evaluation
+	--test-- "rejoin-interp-9"
+		"9" == rejoin {(;-- comment
+			1 + 2 * 3	;-- another
+		)}
+	--test-- "rejoin-interp-10"
+		--assert "123" == rejoin "(append {1} rejoin {2(1 + 2)})"
+	
+	--test-- "rejoin-interp-11"
+		c: context [x: 2 y: 3 z: 4]
+		--assert " 5 12 " == rejoin/with " (x + y) (y * z) " [c]
+	
+	--test-- "rejoin-interp-12"
+		c1: context [x: y: z: 2]
+		c2: context [y: 3 z: 4]
+		--assert " 5 12 " == rejoin/with " (x + y) (y * z) " [c1 c2]
+	
+	--test-- "rejoin-interp-13"
+		c1: context [x: y: z: 2]
+		c2: context [y: 3 z: 4]
+		--assert " 5 12 " == rejoin/with " (x + y) (y * z) " [in c1 'x in c2 'y]
+	
+===end-group===
+
+~~~end-file~~~

--- a/utils/preprocessor.r
+++ b/utils/preprocessor.r
@@ -324,6 +324,62 @@ preprocessor: context [
 		exec: make exec protos
 	]
 
+	expand-string: func [
+		template [any-string!]
+		/local block error string keep-expr expr val end pos keep-slice btail non-paren rule
+	][ 
+		block: clear []
+		;; display errors rather than cryptic "error in macro!"
+		;; load errors are reported at expand time by design
+		set/any 'error try [
+			;; uses "string" internally, because load %file/url:// does something else entirely, <tags> get appended with <>
+			string: to string! template					
+	
+			;; cleanup helpers to win some runtime performance:
+			keep-expr: [								;-- removes unnecesary parens in obvious cases
+				;; 2 or more tokens should remain parenthesized, so that only the last value is rejoin-ed
+				;;   e.g. (1 2 3) evaluates to 3 not 1
+				;; some single _loadable_ types should also remain parenthesized:
+				;;   - word/path (can be a function)
+				;;   - set-word/set-path (may eat strings otherwise)
+				;@@ TODO: list to be extended once we're able to load any-functions directly
+				expr: first set [val end]
+					either object? :Rebol [load/next pos][transcode/next pos]
+				expr: either all [								
+					1 = length? expr
+					not find [word! path! set-word! set-path!] type?/word first expr
+				] [first expr][to paren! expr]
+				append/only block :expr
+			]
+			keep-slice: [								;-- filters out empty strings
+				btail: tail block
+				append									;-- group strings when possible
+					either any [
+						string? btail/-1				;-- do not extend any-string (e.g. ["a" <b>] -> ["a" <bc>])
+						1 = length? block				;-- on 1st index any-string can be extended
+					] [btail/-1][block]
+					copy/part pos end
+			]
+			
+			non-paren: negate charset "(" 
+			rule: [
+				pos: any non-paren end: (do keep-slice)	;-- 1st string is mandatory and can be empty
+				any [
+					pos: some non-paren end: (do keep-slice)
+				|	"(\" (end: next pos  do keep-slice) 
+				|	"(" (do keep-expr) :end 
+				]
+			]
+			either object? :Rebol [do [parse/all string rule]][parse string rule]
+			change block to template first block		;-- preserve template type
+			
+			return copy block
+		]
+		
+		print ["*** ERROR in #REJOIN template:^/" :error]
+		do :error
+	]
+	
 	reset: func [job [object! none!]][
 		exec: do [context [config: job]]
 		clear protos
@@ -404,6 +460,15 @@ preprocessor: context [
 						if all [keep? trace?][print ["preproc: ==" mold expr]]
 						either keep? [s: change/part s :expr e][remove/part s e]
 					]
+				) :s
+				| s: #rejoin [any-string! | e: (syntax-error s e)] e: (
+					change/only change s 'rejoin expand-string s/2
+				) :s
+				| s: #print [any-string! | e: (syntax-error s e)] e: (
+					insert change s 'print reduce ['rejoin expand-string s/2]
+				) :s
+				| s: #error [any-string! | e: (syntax-error s e)] e: (
+					insert change s 'do reduce ['make 'error! 'rejoin expand-string s/2]
 				) :s
 				| s: #local [block! | (syntax-error s next s)] e: (
 					repend stack [negate length? macros tail protos]


### PR DESCRIPTION
This PR is technically a part of our [Format effort](https://github.com/hiiamboris/red-formatting/discussions), but:
- it's not tied to anything exported by Format module
- it's widely useful outside of Format scope and should not require one to include the latter

## Intro

[String interpolation is used in most languages](https://en.wikipedia.org/wiki/String_interpolation#Examples) as a readable way of inserting values into a string.

Though the first question everyone of us may have is *"what, another `rejoin`?"*, if `rejoin` was good enough for me or Gregg, this design would never have been born.

Here are just a few common examples written using `rejoin` function: 
```
avcmd: rejoin [{"} player {" "} vfile {" --audio-file "} afile {"}]
print rejoin ["Download OK: '" remote "' [" info/Content-Type ", " info/Content-Length " bytes]"]
do make error! rejoin [token1 " cannot follow " token2 " in the " name " part of " mold .mask]
```
Try to look at these expressions and visualize how the resulting string will look like, and if I've got all spaces and quotes right.
Not a human task, eh? Even telling the strings from code requires syntax highlighting or quote counting or guessing.

<details>
<summary>These are equivalent expressions written via string interpolation:</summary>

```
avcmd: #rejoin {"(player)" "(vfile)" --audio-file "(afile)"}
#print "Download OK: '(remote)' [(info/Content-Type), (info/Content-Length) bytes]"
#error "(token1) cannot follow (token2) in the (name) part of (mold .mask)"
```
Pretty clear, right?

</details>

Another, even more solid reason for this design is [**translation**](https://gitlab.com/hiiamboris/red-mezz-warehouse/-/blob/master/composite.md#localization). Whatever way we choose to translate our software, we have to give *whole* messages to the translator. 

For more **background info** you can read [related Format discussion](https://github.com/hiiamboris/red-formatting/discussions/20), [preliminary design document](https://gitlab.com/hiiamboris/red-mezz-warehouse/-/blob/master/composite.md) and the [original sad-emoji dialect design](https://github.com/greggirwin/red-formatting/blob/master/formatting-functions.adoc#composite), but I'll try to explain the main points here.

List of so far **registered use cases** can be [found here](https://github.com/hiiamboris/red-formatting/discussions/20#discussioncomment-2206751) but those are only mine. Maybe Gregg can find his own somewhere. [Below that](https://github.com/hiiamboris/red-formatting/discussions/20#discussioncomment-2210811) is a description of design implemented in this PR - a result of my experience with interpolation.

**Why a macro?**

Since input is a string, we don't get `word!`s from it. Without words, nothing is bound during context and function creation. Then the moment we extract words from the string, we can only bind them to the global scope, or to an explicitly provided list of contexts. [Gabriele expressed the concern very clearly](https://i.gyazo.com/ef113c3532289f0acf999c8fd5fe122a.png)

Macro helps us avoid this trap. It gets expanded and produces words before those words are bound, resulting in code that *just works*.

We also get the benefit of speed: if program is compiled, all macros are expanded at compile-time.

Function approach is still provided for advanced users as it has it's merit: macro cannot work on message that is generated at run time (it can, but it has no knowledge of contexts where to bind words).

**Syntax**

Every paren inside the string becomes code:
`#rejoin "(x) + (y) = (x + y)"` -> `rejoin ["" (x) " + " (y) " = " (x + y)]`
Why parenthesis? Because as everywhere else in Red, it visually hints at evaluation.

To treat a paren literally, it is escaped *inside* by a backslash:
`#rejoin "total (n) hits (\ratio: (100% * n / total))"` -> `rejoin ["total " (n) " hits (ratio: " (100% * n / total) ")"]`
This relies on backslash being invalid in Red, so if there's a plan to leverage `\` then another escape sigil must be found.

Original string type is preserved (leading `""` also serves this purpose):
`#rejoin %"file-(n).(ext)"` -> `rejoin [%"file-" (n) "." (ext)]`
`#rejoin <x (y)=(z)>` -> `rejoin [<x > (y) "=" (z)]`

**Extensions**

1. Format module will also include a `#format` macro, backward-compatible with `#rejoin` but with two more features:
   - it will convert `(expression as mask)` into `(format (expression) mask)`
   - it will support per-message locale specification:
     `#format/in "you've spent (spent as {$0.00}) of (spent + left as {$0.00})" locale`
     will be preprocessed into
     `#rejoin "you've spent (format/in (spent) {$0.00} locale) of (format/in (spent + left) {$0.00} locale)"`
     This will require #5009 to be solved.
  
2. It is expected that users will write their own macros for common cases based on `#rejoin`, e.g.:
   ```
   #macro [#log any-string!] func [[manual] s e] [insert remove s [log #rejoin] s]

   #log "(now) test message: (1) + (2) = (1 + 2)"		;) `#log` now is synonymous with `log #rejoin`
   #log "(now) test message: (2) * (3) = (2 * 3)"
   ```
3. Another extension idea concerns `#error` macro. Right now the only fully custom error we have is the User Error. I propose adding another fully custom error into every error category, so we could produce Script, Math, other errors with custom messages. `#error` should then default to Script error, with `#error/math`, `#error/syntax`, `#error/user` etc forms changing the error type.
4. For cases when template is only known at runtime (e.g. report generation with user-defined template), `rejoin` function is extended to accept `any-string!` argument of exactly the same syntax as the macro:
   - `rejoin <img src=(url) size=(as-pair sizex sizey)>` -> `<img src=http://../image.png size=100x100>`
   - to overcome the binding issue, `rejoin/with` accepts one or more contexts to bind produced expressions before reducing them
   - as a feature, `rejoin/trap` allows one to replace evaluation errors with some text (per original Gregg's design)
   - `/with` and `/trap` only apply to string case and have no effect on block argument

5. https://github.com/red/REP/issues/112 should be considered to bring URL support to this design.

P.S. I need some help reducing the docstrings :)