### PR TITLE
FEAT: faster/simpler empty? function

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -64,11 +64,11 @@ quit: func [
 ]
 
 empty?: func [
-	"Returns true if a series is at its tail or a map! is empty"
-	series	[series! none! map!]
+	"Returns true if data is a series at its tail or an empty map"
+	data	[series! none! map!]
 	return:	[logic!]
 ][
-	either series [zero? length? series][true]
+	either data [zero? length? data][true]
 ]
 
 ??: func [

--- a/environment/functions.red
+++ b/environment/functions.red
@@ -68,11 +68,7 @@ empty?: func [
 	series	[series! none! map!]
 	return:	[logic!]
 ][
-	case [
-		series? series [tail? series]
-		map? series [series = #()]
-		none? series [true]
-	]
+	either series [zero? length? series][true]
 ]
 
 ??: func [


### PR DESCRIPTION
![](https://i.gyazo.com/4f6bcfbff02eb3ff6a09ece216ca617a.png)

benchmark source:
```
Red [] 

do %../common/clock.red

empty1: func [
    {Returns true if a series is at its tail or a map! is empty} 
    series [series! none! map!] 
    return: [logic!]
][
    case [
        series? series [tail? series] 
        map? series [series = #()] 
        none? series [true]
    ]
]

empty2: func [
    {Returns true if a series is at its tail or a map! is empty} 
    series [series! none! map!] 
    return: [logic!]
][
	either series [zero? length? series][true]
]

do [loop 5 [
clock/times [empty1 none   ] 1000000
clock/times [empty1 []     ] 1000000
clock/times [empty1 [a b]  ] 1000000
clock/times [empty1 #()    ] 1000000
clock/times [empty1 #(a: b)] 1000000
print ""
clock/times [empty2 none   ] 1000000
clock/times [empty2 []     ] 1000000
clock/times [empty2 [a b]  ] 1000000
clock/times [empty2 #()    ] 1000000
clock/times [empty2 #(a: b)] 1000000
print "---"
]] 
```