### PR TITLE
FIX: para breaks `toggle` alignment

### DIFF
--- a/modules/view/backends/windows/events.reds
+++ b/modules/view/backends/windows/events.reds
@@ -926,7 +926,10 @@ process-custom-draw: func [
 					SetTextColor DC color/array1 and 00FFFFFFh
 				]
 				rc: as RECT_STRUCT (as int-ptr! item) + 5
-				unless sym = button [
+				unless any [
+					sym = button
+					sym = toggle
+				][
 					rc/left: rc/left + dpi-scale 16			;-- compensate for invisible check box
 				]
 				if TYPE_OF(txt) = TYPE_STRING [


### PR DESCRIPTION
The text alignment for `toggle` objects is ignored/reset when its `para` is configured.

Short example:
```red
view [ button 25 bold "A" toggle 25 bold "B" ]
```
Output:
![image](https://user-images.githubusercontent.com/16247881/173933184-f1ace139-e2f4-4955-91bc-d595e57de5b0.png)
