### PR TITLE
FEAT: clip function

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -1104,6 +1104,14 @@ average: func [
 	divide sum block to float! length? block
 ]
 
+clip: func [
+	"Return A if it's within [B,C] range, otherwise nearest to it range boundary"
+	a [scalar!] b [scalar!] c [scalar!]
+	return: [scalar!]
+][
+	min max a b max min a b c
+]
+
 last?: func [
 	"Returns TRUE if the series length is 1"
 	series [series!]

--- a/environment/functions.red
+++ b/environment/functions.red
@@ -1105,7 +1105,7 @@ average: func [
 ]
 
 clip: func [
-	"Return A if it's within [B,C] range, otherwise nearest to it range boundary"
+	"Return A if it's within [B,C] range, otherwise the range boundary nearest to A"
 	a [scalar!] b [scalar!] c [scalar!]
 	return: [scalar!]
 ][


### PR DESCRIPTION
What would you think if you saw in someone's code: `v: max min a b min max a b v`?
Probably that poor fellow has gone bananas.
However `v: clip v a b` is easy to understand: "clip value V between A and B".

Thought I'd PR this function which I find very useful in many projects, and this particular design is the result of it's long usage, and doesn't interfere with any other planned features that I'm aware of.

```
>> ? clip
USAGE:
     CLIP a b c

DESCRIPTION:
     Return A if it's within [B,C] range, otherwise nearest to it range boundary.
     CLIP is a function! value.

ARGUMENTS:
     a            [scalar!]
     b            [scalar!]
     c            [scalar!]

RETURNS:
     [scalar!]
```
For the ease of understanding of it's meaning and use, as well as docstring formulation, docstring implies that `A` is the point, and `[B,C]` is the segment. 

Yet the function has a nice property: one doesn't have to remember the order of arguments, because it doesn't matter! If A,B,C are scalars, it chooses one of A,B,C that is between the other two. If A,B,C are pairs, it applies the same logic to both X and Y axes. If types are mixed, result is at the mercy of `min`/`max` functions, most likely type promotion first, then the same logic follows.

An illustration:
![](https://i.gyazo.com/9531ac84d339daa3aef7a461df6a5a01.gif)
```
view [
	base coal cyan 200x200 "Click me^/and drag around"
	all-over on-over [
		if event/down? [
			a: event/offset
			b: 0x0
			c: face/size 
			face/draw: compose [
				pen red   circle (clip a b c) 10
				pen green circle (clip b c a) 15
				pen blue  circle (clip c b a) 20
			]
		]
	]
]
```