### PR TITLE
FIX: workaround for #5110

### DIFF
--- a/modules/view/backends/windows/events.reds
+++ b/modules/view/backends/windows/events.reds
@@ -347,6 +347,8 @@ get-event-picked: func [
 		]
 		EVT_WHEEL [
 			idx: WIN32_HIWORD(msg/wParam)
+			if idx < -24000 [idx: idx + 30720]			;-- workaround for #5110 bug in drivers
+			if idx >  24000 [idx: idx - 30720]			;-- 256*120 = 30720
 			float/push (as float! idx) / 120.0	;-- WHEEL_DELTA: 120
 		]
 		EVT_LEFT_DOWN


### PR DESCRIPTION
Most wheel offset values seem to be not exceeding 1500, so 24000 seems like a reasonable limit that should not cause problems.