### PR TITLE
FEAT: by operator

### DIFF
--- a/environment/operators.red
+++ b/environment/operators.red
@@ -10,7 +10,7 @@ Red [
 	}
 ]
 
-;-- #load temporary directive is used to workaround REBOL LOAD limitations on some words
+;-- #do keep directive is used to workaround REBOL LOAD limitations on some words
 
 #do keep [to-set-word "+"]		make op! :add
 #do keep [to-set-word "-"]		make op! :subtract
@@ -33,3 +33,4 @@ Red [
 and:							make op! :and~
 or:								make op! :or~
 xor:							make op! :xor~
+do [by:							make op! :as-pair]


### PR DESCRIPTION
Alias to `as-pair`, as in `2 by 4`, `w by h`, `cols by rows`. 
It's readable, concise and conveys 2D meaning, and hardly has a better use.
I can compare it to addition: we can use `add` and sometimes we prefer that, but most of the time stick with just `+`. Same here. I can find couple of dozens uses of `by` in Spaces vs only a couple of `as-pair`.