### PR TITLE
FIX: issue #5297 (Drop-down data being corrupted after 'selected set)

### DIFF
--- a/modules/view/view.red
+++ b/modules/view/view.red
@@ -494,7 +494,7 @@ face!: object [				;-- keep in sync with facet! enum
 				selected
 				block? data
 				find [drop-list drop-down text-list field area] type
-				set-quiet 'text pick data selected
+				set-quiet 'text copy pick data selected 
 			]
 
 			system/reactivity/check/only self any [saved word]


### PR DESCRIPTION
EVT_SELECT changes the /text facet in place in get-text function. https://github.com/red/red/blob/master/modules/view/backends/windows/events.reds#L568