### PR TITLE
FIX: missing /same

### DIFF
--- a/modules/view/view.red
+++ b/modules/view/view.red
@@ -885,7 +885,7 @@ unview: function [
 	if empty? pane: svs/pane [exit]
 	
 	case [
-		only  [remove find head pane face]
+		only  [remove find/same head pane face]
 		all?  [while [not tail? pane][remove back tail pane]]
 		'else [remove back tail pane]
 	]


### PR DESCRIPTION
Console terminates on:
```
w1: view/no-wait [base data system]
w2: view/no-wait [base data system]
unview/only w1
```