### PR TITLE
FEAT: Unboring `attempt`

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -26,8 +26,11 @@ attempt: func [
 	"Tries to evaluate a block and returns result or NONE on error"
 	value [block!]
 	/safer "Capture all possible errors and exceptions"
+	/local all
 ][
-	unless error? set/any 'value (apply 'try/:all [:value safer]) [get/any 'value]
+	set 'all safer										;-- `all:` refuses to compile
+	try/:all [return do code]
+	none
 ]
 
 comment: func ["Consume but don't evaluate the next value" 'value][]


### PR DESCRIPTION
Tried a few variants, but paths win over apply:
```
attempt1: func [
	"Tries to evaluate a block and returns result or NONE on error"
	code [block!]
	/safer "Capture all possible errors and exceptions"
][
	; apply 'try/:all [[return do code] safer]     ;-- same
	apply/all :try [[return do code] safer]
	none
]

attempt2: func [
	"Tries to evaluate a block and returns result or NONE on error"
	code [block!]
	/safer "Capture all possible errors and exceptions"
	/local all
][
	set 'all safer										;-- `all:` refuses to compile
	try/:all [return do code]
	none
]

clock/times [attempt []] 1e6
clock/times [attempt1 []] 1e6
clock/times [attempt2 []] 1e6
```

```
0.92 μs [attempt []]
0.89 μs [attempt1 []]
0.41 μs [attempt2 []]
```
Unfortunately on failure it's still slow and presses GC a lot by spawning errors and then discarding them.
