### PR TITLE
FIX: preprocessor/fetch-next updates

### DIFF
--- a/tests/source/compiler/preprocessor-test.r
+++ b/tests/source/compiler/preprocessor-test.r
@@ -113,7 +113,7 @@ REBOL [
 			prin "*test9* " probe preprocessor/fetch-next [a: 1 + b/o/f/x f f 4 5 6]
 			prin "*test10* " probe preprocessor/fetch-next [a: 1 + b/o/f/x + * 4 5 6]
 			o: make op! func [x 'y][]
-			prin "*test11* " probe preprocessor/fetch-next [a: o b: 1]
+			prin "*test11* " probe preprocessor/fetch-next ['a o b: 1]
 			prin "*test12* " probe preprocessor/fetch-next [f o f 1]
 			prin "*test13* " probe preprocessor/fetch-next [b/o/f o b/o/f/x 1 2 3]
 			p: 10x20 s: "abcd"

--- a/utils/preprocessor.r
+++ b/utils/preprocessor.r
@@ -169,7 +169,7 @@ preprocessor: context [
 		reduce [path get/any 'value]
 	]
 
-	fetch-next: func [code [block! paren!] /local i left item item2 value fn-spec path f-arity at-op? op-mode arg][
+	fetch-next: func [code [block! paren!] /local i left item item2 value fn-spec path f-arity at-op? op-mode][
 		left: reduce [yes]
 		
 		while [all [not tail? left not tail? code]][
@@ -197,10 +197,9 @@ preprocessor: context [
 					word? item2: second code
 					op? get/any :item2
 				][
-					op-mode: arg-mode? spec-of get/any :item2 1
-					if all [f-arity  op-mode = word!][		;-- check if function's lit/get-arg takes priority
-						if any [arg: arg-mode? fn-spec 1 not empty? f-arity][at-op?: word! = arg]
-					]
+					if all [f-arity 1 < length? f-arity] [		;-- check if function's lit/get-arg takes priority
+						at-op?: word! = arg-mode? fn-spec 1
+					] 
 				]
 				case [
 					at-op? [							;-- a * b


### PR DESCRIPTION
Fixed the tests, but I'm lazy to add preprocessor support for this new feature:
```
>> quote 2 * 3
== 6
```
Hopefully we'll get rid of R2 dependency sooner or later.