### PR TITLE
FIX: edit Red/System header, File: %wcwidth.reds

### DIFF
--- a/environment/console/CLI/wcwidth.reds
+++ b/environment/console/CLI/wcwidth.reds
@@ -1,7 +1,7 @@
 Red/System [
 	Title:	"Implementation of wcwidth() and wcswidth() for Unicode."
 	Author: "Xie Qingtian"
-	File: 	%win32.reds
+	File: 	%wcwidth.reds
 	Tabs: 	4
 	Rights: "Copyright (C) 2014-2015 Xie Qingtian. All rights reserved."
 	License: {


### PR DESCRIPTION
In Red/System header, File: has wrong name: %win32.reds