### PR TITLE
FIX: access violation on mouse events in GTK backend

### DIFF
--- a/modules/view/backends/gtk3/handlers.reds
+++ b/modules/view/backends/gtk3/handlers.reds
@@ -1247,7 +1247,7 @@ mouse-button-release-event: func [
 	if buf <> null [
 		w: cairo_image_surface_get_width buf
 		pixels: as int-ptr! cairo_image_surface_get_data buf
-		pixels: pixels + (y - 1 * w) + x
+		pixels: pixels + (y * w) + x
 		if pixels/1 and FF000000h = 0 [		;-- transparent pixel
 			return EVT_DISPATCH
 		]
@@ -1334,7 +1334,7 @@ mouse-button-press-event: func [
 	if buf <> null [
 		w: cairo_image_surface_get_width buf
 		pixels: as int-ptr! cairo_image_surface_get_data buf
-		pixels: pixels + (y - 1 * w) + x
+		pixels: pixels + (y * w) + x
 		if pixels/1 and FF000000h = 0 [		;-- transparent pixel
 			return EVT_DISPATCH
 		]
@@ -1397,7 +1397,7 @@ mouse-motion-notify-event: func [
 	if buf <> null [
 		w: cairo_image_surface_get_width buf
 		pixels: as int-ptr! cairo_image_surface_get_data buf
-		pixels: pixels + (y - 1 * w) + x
+		pixels: pixels + (y * w) + x
 		enter: GET-BASE-ENTER(widget)
 		either pixels/1 and FF000000h = 0 [		;-- transparent pixel
 			if enter <> null  [


### PR DESCRIPTION
While using base component with transparency, the GTK backend checks for transparent pixel and triggers events when necessary. This fix is related to the calculation of the position of these pixels, avoiding negative values when mouse Y is 0.

This fix is related to a previous one: [4743](https://github.com/red/red/issues/4743)
@qtxie maybe you had some specific use case in mind. Could you check this one, please?
Thanks in advance.