### PR TITLE
No need "to float!" in average

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -1090,7 +1090,7 @@ average: func [
 	block [block! vector! paren! hash!]
 ][
 	if empty? block [return none]
-	divide sum block to float! length? block
+	divide sum block length? block
 ]
 
 last?: func [


### PR DESCRIPTION
In current `average` function there is `to float!` conversion which is not necessary anymore because `divide` returns float now.

```red
average: func [
    "Returns the average of all values in a block"
    block [block! vector! paren! hash!]
][
    if empty? block [return none]
    divide sum block to float! length? block
]
```

Note that this change also makes `average` returns integer in some cases, but this could be a good change:

```red
>> average [0]
== 0
>> average [1 2 3]
== 2
```