### PR TITLE
FIX: 4 typos in system and docs

### DIFF
--- a/docs/red-system/red-system-specs.txt
+++ b/docs/red-system/red-system-specs.txt
@@ -4203,7 +4203,7 @@ Both -** (internal representation for >>>) and /// (internal representation for 
  								;-- c-strings, pointers and structs.
 
  struct [
-	[align <n> <little|big>]	;-- change members alignment and endianess
+	[align <n> <little|big>]	;-- change members alignment and endianness
 	<members>
  ]
 

--- a/system/emitter.r
+++ b/system/emitter.r
@@ -26,7 +26,7 @@ emitter: make-profilable context [
 
 		
 	pointer: make-struct [
-		value [integer!]				;-- 32/64-bit, watch out for endianess!!
+		value [integer!]				;-- 32/64-bit, watch out for endianness!!
 	] none
 	
 	types-model: [

--- a/system/formats/Mach-O.r
+++ b/system/formats/Mach-O.r
@@ -262,7 +262,7 @@ context [
 	] none
 	
 	pointer: make-struct [
-		value [integer!]			;-- 32/64-bit, watch out for endianess!!
+		value [integer!]			;-- 32/64-bit, watch out for endianness!!
 	] none
 
 	;-- Globals --

--- a/system/formats/PE.r
+++ b/system/formats/PE.r
@@ -416,7 +416,7 @@ context [
 	] none
 
 	pointer: make-struct [
-		value [integer!]					;-- 32/64-bit, watch out for endianess!!
+		value [integer!]					;-- 32/64-bit, watch out for endianness!!
 	] none
 
 	base-address:		none


### PR DESCRIPTION
Fix typos in the comment section of system and docs