### PR TITLE
FIX: Point3D! always returns false from `zero?`

### DIFF
--- a/runtime/datatypes/function.reds
+++ b/runtime/datatypes/function.reds
@@ -340,7 +340,7 @@ _function: context [
 				]
 				TYPE_SET_WORD [								 ;-- only return: is allowed as a set-word!
 					w: as red-word! value
-					if any [words/return* <> symbol/resolve w/symbol local?][do-error]
+					if any [ret? words/return* <> symbol/resolve w/symbol local?][do-error]
 					next: value + 1
 					next2: next + 1
 					unless all [

--- a/runtime/datatypes/pair.reds
+++ b/runtime/datatypes/pair.reds
@@ -106,7 +106,10 @@ pair: context [
 		left/x: x'
 		
 		y': integer/do-math-op left/y y op slot
-		if TYPE_OF(slot) <> TYPE_UNSET [promo]
+		if TYPE_OF(slot) <> TYPE_UNSET [
+			left/x: x									;-- reset left/x in case math op was already done (#5586)
+			promo
+		]
 		left/y: y'
 		left
 	]

--- a/runtime/interpreter.reds
+++ b/runtime/interpreter.reds
@@ -938,6 +938,7 @@ interpreter: context [
 					if any [
 						index < 0
 						all [value < tail TYPE_OF(value) <> TYPE_REFINEMENT]
+						value >= tail					;-- when invoking a local word as refinement (#5584)
 					][fire [TO_ERROR(script no-refine) fname ref]]
 					value: value + 1
 					sym-cnt: index + 1

--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -1922,7 +1922,7 @@ natives: context [
 				all [p/x = 0 p/y = 0]
 			]
 			TYPE_POINT2D [
-				pt: as red-point3D! i
+				pt: as red-point2D! i
 				all [pt/x = as-float32 0 pt/y = as-float32 0]
 			]
 			TYPE_POINT3D [

--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -1925,7 +1925,7 @@ natives: context [
 				pt: as red-point3D! i
 				all [pt/x = as-float32 0 pt/y = as-float32 0]
 			]
-			TYPE_POINT2D [
+			TYPE_POINT3D [
 				pt: as red-point3D! i
 				all [pt/x = as-float32 0 pt/y = as-float32 0 pt/z = as-float32 0]
 			]

--- a/tests/source/units/regression-test-red.red
+++ b/tests/source/units/regression-test-red.red
@@ -3722,6 +3722,9 @@ comment {
 	--test-- "#5579"
 		h5579: make hash! [1 2]
 		--assert h5579 = copy/part make hash! [1 2 3 4 5 6 7 8] 2
+
+	--test-- "#5586"
+		100x100 / 100x99 = (1, 1.010101)
 		
 	--test-- "#5587"
 		--assert '+ = first quote +/1/5

--- a/tests/source/units/regression-test-red.red
+++ b/tests/source/units/regression-test-red.red
@@ -3729,6 +3729,19 @@ comment {
 			--assert error? try [f5584/y]
 		]
 
+	--test-- "#5585"
+		do [											;-- compiler would catch that error
+			--assert error? try [
+				func [
+				  return: [integer!] "abcd" 
+				  return: [integer!]
+				  /local xx
+				][
+					123456
+				]
+			]
+		]
+
 	--test-- "#5586"
 		100x100 / 100x99 = (1, 1.010101)
 		

--- a/tests/source/units/regression-test-red.red
+++ b/tests/source/units/regression-test-red.red
@@ -3723,6 +3723,12 @@ comment {
 		h5579: make hash! [1 2]
 		--assert h5579 = copy/part make hash! [1 2 3 4 5 6 7 8] 2
 
+	--test-- "#5584"
+		do [											;-- compiler would catch that error
+			f5584: func [/local y][probe 22]
+			--assert error? try [f5584/y]
+		]
+
 	--test-- "#5586"
 		100x100 / 100x99 = (1, 1.010101)
 		


### PR DESCRIPTION
Due to incomplete copy/paste change and dupe Point2D! case.