### PR TITLE
FIX: Point3D! always returns false from `zero?`

### DIFF
--- a/runtime/natives.reds
+++ b/runtime/natives.reds
@@ -1925,7 +1925,7 @@ natives: context [
 				pt: as red-point3D! i
 				all [pt/x = as-float32 0 pt/y = as-float32 0]
 			]
-			TYPE_POINT2D [
+			TYPE_POINT3D [
 				pt: as red-point3D! i
 				all [pt/x = as-float32 0 pt/y = as-float32 0 pt/z = as-float32 0]
 			]


### PR DESCRIPTION
Bug was due to incomplete copy/paste change and dupe Point2D! case. Point3D! type is _intentionally_ used for both cases, reusing `pt` var.