### PR TITLE
FIX: issue #5644 ([CSV] Abruptly stops decoding at an arbitrary point)

### DIFF
--- a/environment/codecs/CSV.red
+++ b/environment/codecs/CSV.red
@@ -223,7 +223,7 @@ context [
 		]
 		foreach refs disallowed [
 			if all refs [
-				return make error! rejoin [
+				do make error! rejoin [
 					"Cannot use /" refs/1 " and /" refs/2 " refinements together"
 				]
 			]
@@ -239,6 +239,7 @@ context [
 		line: make block! 20
 		value: make string! 200
 		record: none
+		line-no: 1
 
 		; -- parse rules
 		newline: [crlf | lf | cr]
@@ -284,7 +285,7 @@ context [
 				length: length? line
 				if zero? longest [longest: length]		; first line
 				if all [strict? longest <> length][
-					return make error! non-aligned
+					do make error! non-aligned
 				]
 				if longest < length [longest: length]
 				either as-records [
@@ -308,6 +309,7 @@ context [
 					]
 				]
 			)
+			(line-no: line-no + 1)
 			init
 		]
 		line-rule: [end | values [newline | end] add-line]
@@ -319,6 +321,7 @@ context [
 				if (header) 
 				values newline
 				(header: copy line)
+				(line-no: line-no + 1)
 				init
 			]
 			mark: (
@@ -337,6 +340,10 @@ context [
 			|	init values add-line
 			]
 			any newline
+		]
+
+		unless parsed? [
+			do make error! rejoin ["Invalid CSV data near line " line-no]
 		]
 
 		; -- adjust output when needed

--- a/tests/source/units/csv-test.red
+++ b/tests/source/units/csv-test.red
@@ -62,6 +62,10 @@ Red [
 		--assert [["a" "b,b" "c"]] = load-csv {a,"b,b",c}
 	--test-- "load-csv-6-newline"
 		--assert [["a" "b^/b" "c"]] = load-csv {a,"b^/b",c}
+	--test-- "load-csv-7-invalid-syntax-5644"
+		--assert none? attempt [load-csv {1,2^/"a"x,b^/3,4}]
+	--test-- "load-csv-8-non-aligned-throws"
+		--assert none? attempt [load-csv {1,2^/3}]
 ===end-group===
 
 ===start-group=== "load-csv-with"


### PR DESCRIPTION
Changed environment/codecs/CSV.red:242:

- Tracks line-no while parsing.
- Checks parsed? after the top-level parse.
- Throws Invalid CSV data near line N instead of returning partial rows.
- Converts the strict non-aligned row path to throw with do make error!.

Added regressions in tests/source/units/csv-test.red:65:

- malformed quoted field must throw
- non-aligned rows must throw, not return an error! value