### PR TITLE
Make a tiny change to SPLIT's parse rule for ~40x speedup on large inputs, with identical results.

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -790,7 +790,7 @@ split: function [
 	series [any-string!] dlm [string! char! bitset!] /local s
 ][
 	num: either string? dlm [length? dlm][1]
-	parse series [collect any [end keep (make string! 0) | copy s [to [dlm | end]] keep (s) num skip]]
+	parse series [collect any [end keep (make string! 0) | copy s [to dlm | to end] keep (s) num skip]]
 ]
 
 dirize: func [


### PR DESCRIPTION
What a difference one word makes.